### PR TITLE
Updated toValue to properly handle nil pointers

### DIFF
--- a/value.go
+++ b/value.go
@@ -356,7 +356,12 @@ func toValue(value interface{}) Value {
 		}
 	default:
 		{
-			value := reflect.Indirect(reflect.ValueOf(value))
+			value := reflect.ValueOf(value)
+			if value.IsNil() {
+				return UndefinedValue()
+			}
+
+			value = reflect.Indirect(value)
 			toValue_reflectValuePanic(value.Interface(), value.Kind())
 		}
 	}


### PR DESCRIPTION
I encountered errors when calling `toValue` on a nil pointer (panic: reflect: call of reflect.Value.Interface on zero Value)

When debugging this error I found that the value being passed to `toValue` was `(*html.Node)(<nil>)`. This code fixes this panic however there might be a better place to put the check.
