### PR TITLE
Simple limitation of evaluation speed.

### DIFF
--- a/limits_test.go
+++ b/limits_test.go
@@ -1,0 +1,88 @@
+package otto
+
+import (
+	"fmt"
+	"testing"
+	"time"
+	. "./terst"
+)
+
+func limitedLoop(otto *Otto, d time.Duration) (iterations int64) {
+	toRun := fmt.Sprintf(`
+	  var d = new Date();
+		var iters = 0;
+		var deadline = d.getTime() + %d;
+		while (new Date().getTime() < deadline) {
+			iters++;
+		}
+		iters;
+	`, d/time.Millisecond)
+
+	result, err := otto.Run(toRun)
+
+	Is(err, nil)
+
+	iterations, err = result.ToInteger()
+
+	Is(err, nil)
+
+	return
+}
+
+func TestLimitedBurstEvaluation(t *testing.T) {
+	Terst(t)
+
+	otto := New()
+
+	otto.Limits.Evaluation.Burst = 10
+
+	otto.Limits.Evaluation.PerSecond = 1000
+
+	firstResult := limitedLoop(otto, time.Millisecond*100)
+
+	otto.Limits.Evaluation.PerSecond = 10000
+
+	secondResult := limitedLoop(otto, time.Millisecond*100)
+
+	// Check that the second result is about 10 times bigger than the first, since it can evaluate 10 times faster and the burst is quite small.
+	Compare(secondResult, ">", firstResult*8)
+	Compare(secondResult, "<", firstResult*12)
+}
+
+func TestBurstEvaluation(t *testing.T) {
+	Terst(t)
+
+	otto := New()
+
+	otto.Limits.Evaluation.Burst = 10000000
+
+	otto.Limits.Evaluation.PerSecond = 1000
+
+	firstResult := limitedLoop(otto, time.Millisecond*100)
+
+	otto.Limits.Evaluation.PerSecond = 10000
+
+	secondResult := limitedLoop(otto, time.Millisecond*100)
+
+	// Check that the two results are about the same, since both should have fit within the generous burst we set.
+	Compare(secondResult*10, ">", firstResult*8)
+	Compare(secondResult*10, "<", firstResult*12)
+}
+
+func TestEvaluationsPerSecond(t *testing.T) {
+	Terst(t)
+
+	otto := New()
+
+	otto.Limits.Evaluation.PerSecond = 1000
+
+	firstResult := limitedLoop(otto, time.Millisecond*100)
+
+	otto.Limits.Evaluation.PerSecond = 10000
+
+	secondResult := limitedLoop(otto, time.Millisecond*100)
+
+	// Check that the second result is about 10 times bigger than the first, since it can evaluate 10 times faster.
+	Compare(secondResult, ">", firstResult*8)
+	Compare(secondResult, "<", firstResult*12)
+}

--- a/otto.go
+++ b/otto.go
@@ -171,15 +171,31 @@ package otto
 
 import (
 	"fmt"
-	"github.com/robertkrimen/otto/registry"
 	"strings"
+
+	"github.com/robertkrimen/otto/registry"
 )
+
+// EvaluationLimits define the limits for how fast an Otto instance can evaluate.
+type EvaluationLimits struct {
+	// Burst is the number of evaluations that can occur before the limitations set in.
+	Burst uint
+	// PerSecond is the maximum average evaluations per second for an Otto instnace. Zero is equivalent to no limitation.
+	PerSecond uint
+}
+
+// Limits define the resource limits for an Otto instance.
+type Limits struct {
+	// Evaluation is the limits for how fast an Otto instance can evaluate nodes.
+	Evaluation EvaluationLimits
+}
 
 // Otto is the representation of the JavaScript runtime. Each instance of Otto has a self-contained namespace.
 type Otto struct {
 	// Interrupt is a channel for interrupting the runtime. You can use this to halt a long running execution, for example.
 	// See "Halting Problem" for more information.
 	Interrupt chan func()
+	Limits    Limits
 	runtime   *_runtime
 }
 

--- a/runtime.go
+++ b/runtime.go
@@ -3,6 +3,7 @@ package otto
 import (
 	"reflect"
 	"strconv"
+	"time"
 )
 
 type _global struct {
@@ -52,6 +53,9 @@ type _runtime struct {
 	eval *_object // The builtin eval, for determine indirect versus direct invocation
 
 	Otto *Otto
+
+	burstCounter uint
+	lastEval     time.Time
 }
 
 func (self *_runtime) EnterGlobalExecutionContext() {

--- a/runtime.go
+++ b/runtime.go
@@ -54,6 +54,7 @@ type _runtime struct {
 
 	Otto *Otto
 
+	// Used to limit the speed with which this runtime evaluates nodes
 	burstCounter uint
 	lastEval     time.Time
 }


### PR DESCRIPTION
A `Limits` struct in the `Otto` struct contains `Burst` and `PerSecond` fields used by `evaluate.go` (if `PerSecond` > 0) to limit the speed with which the runtime can evaluate nodes.
