### PR TITLE
Fixed toValue not properly converting type aliases

### DIFF
--- a/value.go
+++ b/value.go
@@ -352,17 +352,18 @@ func toValue(value interface{}) Value {
 		case reflect.String:
 			return Value{valueString, string(value.String())}
 		default:
+			if !value.IsValid() || value.IsNil() {
+				return UndefinedValue()
+			}
+
 			toValue_reflectValuePanic(value.Interface(), value.Kind())
 		}
 	default:
 		{
 			value := reflect.ValueOf(value)
-			if value.IsNil() {
-				return UndefinedValue()
-			}
 
 			value = reflect.Indirect(value)
-			toValue_reflectValuePanic(value.Interface(), value.Kind())
+			return toValue(value)
 		}
 	}
 	panic(newTypeError("Invalid value: Unsupported: %v (%T)", value, value))

--- a/value_test.go
+++ b/value_test.go
@@ -31,6 +31,8 @@ func TestObject(t *testing.T) {
 	//Is(newStringObject("Hello, World.").Value(), "Hello, World.")
 }
 
+type IntAlias int
+
 func TestToValue(t *testing.T) {
 	Terst(t)
 
@@ -43,6 +45,9 @@ func TestToValue(t *testing.T) {
 
 	value, _ = otto.ToValue((*byte)(nil))
 	Is(value, "undefined")
+
+	value, _ = otto.ToValue(IntAlias(5))
+	Is(value, "5")
 }
 
 func TestToBoolean(t *testing.T) {


### PR DESCRIPTION
If a Go type was aliased (Example: `type IntAlias int64`) then Otto would return an InvalidType error. This PR fixes that issue and adds a new test.
