### PR TITLE
Implement strings without value16 (fixes #68)

### DIFF
--- a/builtin_string.go
+++ b/builtin_string.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"unicode/utf16"
 )
 
 // String
@@ -42,24 +41,24 @@ func builtinString_fromCharCode(call FunctionCall) Value {
 
 func builtinString_charAt(call FunctionCall) Value {
 	checkObjectCoercible(call.This)
-	value := toString(call.This)
-	value16 := utf16.Encode([]rune(value))
-	index := toInteger(call.Argument(0)).value
-	if 0 > index || index >= int64(len(value16)) {
+	_, so := call.This._object().stringValue()
+	idx := int(toInteger(call.Argument(0)).value)
+	if 0 > idx || idx >= so.RuneCount() {
 		return toValue_string("")
 	}
-	return toValue_string(string(value16[index]))
+	r := so.At(idx)
+	return toValue_string(string(r))
 }
 
 func builtinString_charCodeAt(call FunctionCall) Value {
 	checkObjectCoercible(call.This)
-	value := toString(call.This)
-	value16 := utf16.Encode([]rune(value))
-	index := toInteger(call.Argument(0)).value
-	if 0 > index || index >= int64(len(value16)) {
+	_, so := call.This._object().stringValue()
+	idx := int(toInteger(call.Argument(0)).value)
+	if 0 > idx || idx >= so.RuneCount() {
 		return NaNValue()
 	}
-	return toValue_uint16(value16[index])
+	r := so.At(idx)
+	return toValue_uint16(uint16(r))
 }
 
 func builtinString_concat(call FunctionCall) Value {

--- a/global.go
+++ b/global.go
@@ -17,7 +17,6 @@ var (
 			_valueType: valueString,
 			value:      "",
 		},
-		value16: []uint16(nil),
 	}
 	prototypeValueBoolean = Value{
 		_valueType: valueBoolean,


### PR DESCRIPTION
Hello everyone! As promised, here's my take on the "value16 problem."

This PR fixes `newStringObject` generating a lot of garbage in case of intense string manipulation as well as `charCodeAt` and `charAt` not reusing `_stringObject`s value16. In my tests using utf8string.String outperformed any other methods solely by not allocating value16 whatsoever. (As in many use cases string's life expectancy in very low.)

For a simple React widget generating 256 `p`s, new implementation performs 15x faster. (500ms vs 7.5s)

``` bash
echo "var global = {};" | cat - react.js test.js | otto
```

``` javascript
var R;
if (global) R = global.React;

var App = R.createClass({
    render: function() {
        var r = [];
        for(var i = 0; i < 256; i++) {
            r.push(R.DOM.p({key: i}, this.props.text));
        }
        return R.DOM.div({}, r);
    }
});

var d1 = Date.now();
console.log(R.renderComponentToString(App({text: "foobar"})));
console.log(Date.now() - d1);
```

I think strings implementation might need some more love on that front, but I've tried to keep PR as concise as possible.

/cc: @tux21b
