### PR TITLE
Fix panic: in.value.(Value) != true

### DIFF
--- a/bug_test.go
+++ b/bug_test.go
@@ -573,3 +573,23 @@ func Test_issue80(t *testing.T) {
         `, "[1401868959,14018689591,140186895901,1401868959001,14018689590001,140186895900001,1401868959000001,1.4018689590000015e+15,14018689590000001,140186895900000001,1401868959000000001,1.401868959e+19,1.401868959e+20,1.401868959e+20]")
 	})
 }
+
+func Test_issue86(t *testing.T) {
+	tt(t, func() {
+		test, tester := test()
+
+		test(`
+			var obj = Object.create({}, {
+				abc: {
+					get: function(){
+						return 1;
+					}
+				}
+			});
+			obj.abc;
+		`, 1)
+
+		v, err := tester.vm.Copy().Run(`obj.abc;`)
+		is(is(v, 1), is(nil, err))
+	})
+}

--- a/clone.go
+++ b/clone.go
@@ -140,9 +140,13 @@ func (clone *_clone) stash(in _stash) _stash {
 
 func (clone *_clone) property(in _property) _property {
 	out := in
-	if value, valid := in.value.(Value); valid {
-		out.value = clone.value(value)
-	} else {
+
+	switch v := in.value.(type) {
+	case _propertyGetSet:
+		out.value = _propertyGetSet{v[0], v[1]}
+	case Value:
+		out.value = clone.value(v)
+	default:
 		panic(fmt.Errorf("in.value.(Value) != true"))
 	}
 	return out


### PR DESCRIPTION
When copying a runtime which contains objects with property accessors ({g,s}etters)

```
$ go test -v -run=Test_issue86
=== RUN Test_issue86
~~~ FAIL: (Terst)
--- FAIL: Test_issue86 (0.00 seconds)
panic: in.value.(Value) != true [recovered]
	panic: in.value.(Value) != true [recovered]
	panic: in.value.(Value) != true

goroutine 20 [running]:
runtime.panic(0x2f5400, 0x2086ed7e0)
	/usr/local/go/src/pkg/runtime/panic.c:279 +0xf5
testing.func·006()
	/usr/local/go/src/pkg/testing/testing.go:416 +0x176
runtime.panic(0x2f5400, 0x2086ed7e0)
	/usr/local/go/src/pkg/runtime/panic.c:248 +0x18d
_/Users/tim/repositories/github.com/sdgoij/otto/terst.func·001()
	/Users/tim/repositories/github.com/sdgoij/otto/terst/terst.go:475 +0xf5
runtime.panic(0x2f5400, 0x2086ed7e0)
	/usr/local/go/src/pkg/runtime/panic.c:248 +0x18d
_/Users/tim/repositories/github.com/sdgoij/otto.(*_clone).property(0x2087a6030, 0x2a0360, 0x2086ed5d0, 0x92, 0x0, 0x0, 0x0)
	/Users/tim/repositories/github.com/sdgoij/otto/clone.go:146 +0x186
_/Users/tim/repositories/github.com/sdgoij/otto.objectClone(0x208779b60, 0x2087a8ba0, 0x2087a6030, 0x20878f4a0)
	/Users/tim/repositories/github.com/sdgoij/otto/object_class.go:471 +0x279
_/Users/tim/repositories/github.com/sdgoij/otto.(*_clone).object(0x2087a6030, 0x208779b60, 0x208779b60)
	/Users/tim/repositories/github.com/sdgoij/otto/clone.go:87 +0xf1
_/Users/tim/repositories/github.com/sdgoij/otto.(*_clone).value(0x2087a6030, 0x5, 0x336680, 0x208779b60, 0x0, 0x0, 0x0)
	/Users/tim/repositories/github.com/sdgoij/otto/clone.go:121 +0xb6
_/Users/tim/repositories/github.com/sdgoij/otto.(*_clone).property(0x2087a6030, 0x341ea0, 0x2087a40a0, 0x48, 0x0, 0x0, 0x0)
	/Users/tim/repositories/github.com/sdgoij/otto/clone.go:144 +0xbc
_/Users/tim/repositories/github.com/sdgoij/otto.objectClone(0x2086f0c00, 0x208779c80, 0x2087a6030, 0x20878f8e0)
	/Users/tim/repositories/github.com/sdgoij/otto/object_class.go:471 +0x279
_/Users/tim/repositories/github.com/sdgoij/otto.(*_clone).object(0x2087a6030, 0x2086f0c00, 0x2087a60f0)
	/Users/tim/repositories/github.com/sdgoij/otto/clone.go:87 +0xf1
_/Users/tim/repositories/github.com/sdgoij/otto.(*_runtime).clone(0x20873c000, 0x0)
	/Users/tim/repositories/github.com/sdgoij/otto/clone.go:29 +0x1b9
_/Users/tim/repositories/github.com/sdgoij/otto.(*Otto).Copy(0x2086ed3c0, 0x75)
	/Users/tim/repositories/github.com/sdgoij/otto/otto.go:471 +0x2b
_/Users/tim/repositories/github.com/sdgoij/otto.func·098()
	/Users/tim/repositories/github.com/sdgoij/otto/bug_test.go:592 +0xf5
_/Users/tim/repositories/github.com/sdgoij/otto/terst.func·002()
	/Users/tim/repositories/github.com/sdgoij/otto/terst/terst.go:479 +0x21a
_/Users/tim/repositories/github.com/sdgoij/otto/terst.Terst(0x20873a1b0, 0x20878ff40, 0x1, 0x1)
	/Users/tim/repositories/github.com/sdgoij/otto/terst/terst.go:480 +0x196
_/Users/tim/repositories/github.com/sdgoij/otto.tt(0x20873a1b0, 0x20878ff40, 0x1, 0x1)
	/Users/tim/repositories/github.com/sdgoij/otto/testing_test.go:19 +0x16a
_/Users/tim/repositories/github.com/sdgoij/otto.Test_issue86(0x20873a1b0)
	/Users/tim/repositories/github.com/sdgoij/otto/bug_test.go:594 +0x72
testing.tRunner(0x20873a1b0, 0x6277f0)
	/usr/local/go/src/pkg/testing/testing.go:422 +0x8b
created by testing.RunTests
	/usr/local/go/src/pkg/testing/testing.go:504 +0x8db

goroutine 16 [chan receive]:
testing.RunTests(0x4baf48, 0x6273a0, 0x172, 0x172, 0x1)
	/usr/local/go/src/pkg/testing/testing.go:505 +0x923
testing.Main(0x4baf48, 0x6273a0, 0x172, 0x172, 0x6219e0, 0x3, 0x3, 0x621aa0, 0x2, 0x2)
	/usr/local/go/src/pkg/testing/testing.go:435 +0x84
main.main()
	_/Users/tim/repositories/github.com/sdgoij/otto/_test/_testmain.go:795 +0x9c

goroutine 19 [finalizer wait]:
runtime.park(0x157e0, 0x629838, 0x626809)
	/usr/local/go/src/pkg/runtime/proc.c:1369 +0x89
runtime.parkunlock(0x629838, 0x626809)
	/usr/local/go/src/pkg/runtime/proc.c:1385 +0x3b
runfinq()
	/usr/local/go/src/pkg/runtime/mgc0.c:2644 +0xcf
runtime.goexit()
	/usr/local/go/src/pkg/runtime/proc.c:1445
exit status 2
FAIL	_/Users/tim/repositories/github.com/sdgoij/otto	0.029s
```
