### PR TITLE
Test map[string]interface{} using Set & Call behave the same

### DIFF
--- a/otto_test.go
+++ b/otto_test.go
@@ -143,6 +143,34 @@ func TestCall(t *testing.T) {
 	})
 }
 
+func TestRunFunctionWithSetArguments(t *testing.T) {
+	tt(t, func() {
+		vm := New()
+		vm.Run(`var sillyFunction = function(record){record.silly = true; record.answer *= -1};`)
+		record := map[string]interface{}{"foo": "bar", "answer": 42}
+		// Set performs a conversion that allows the map to be addressed as a Javascript object
+		vm.Set("argument", record)
+		_, err := vm.Run("sillyFunction(argument)")
+
+		is(err, nil)
+		is(record["answer"].(float64), -42)
+		is(record["silly"].(bool), true)
+	})
+}
+
+func TestRunFunctionWithArgumentsPassedToCall(t *testing.T) {
+	tt(t, func() {
+		vm := New()
+		vm.Run(`var sillyFunction = function(record){record.silly = true; record.answer *= -1};`)
+		record := map[string]interface{}{"foo": "bar", "answer": 42}
+		_, err := vm.Call("sillyFunction", nil, record)
+
+		is(err, nil)
+		is(record["answer"].(float64), -42)
+		is(record["silly"].(bool), true)
+	})
+}
+
 func TestMember(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()


### PR DESCRIPTION
This is a P/R with a couple of tests that show a difference that is currently biting me a bit.

We're working with records that will be of the form map[string]interface{}.

If I Set() the map to a particular name, I can then Run code that calls a function and passes that name as an argument to a precompiled function.  This is the first test and it passes.

However, if I Call() the function name and attempt to pass the map as an argument, I get:
    TypeError: invalid value (map): missing runtime: map[foo:bar answer:42] (map[string]interface {})

To the extent that I can follow the code, it does look like the two are handled differently.  Should they be?  Or am I so far off in the weeds that you can barely see me?

I tried to make the tests look like what was there as much as I could, but I wasn't quite sure how to perform my  test with your test().