### PR TITLE
Seed math/rand with UnixNano for truly random numbers.

### DIFF
--- a/otto.go
+++ b/otto.go
@@ -225,10 +225,16 @@ package otto
 
 import (
 	"fmt"
+	"math/rand"
 	"strings"
+	"time"
 
 	"github.com/robertkrimen/otto/registry"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 // Otto is the representation of the JavaScript runtime. Each instance of Otto has a self-contained namespace.
 type Otto struct {


### PR DESCRIPTION
While creating a random level generator for my game engine I noticed that each time I generated a level (this happens on startup) it was the same. This is a fix that removes this bug/issue. Perhaps this is desired behaviour, but I figure that this way otto will behave more like other javascript implementations, all of which have unpredictable random numbers.

Good Day!