### PR TITLE
fix Go map iteration when looping over non-string keys

### DIFF
--- a/reflect_test.go
+++ b/reflect_test.go
@@ -256,6 +256,63 @@ func Test_reflectMap(t *testing.T) {
 	})
 }
 
+func Test_reflectMapIterateKeys(t *testing.T) {
+	tt(t, func() {
+		test, vm := test()
+
+		// map[string]interface{}
+		{
+			abc := map[string]interface{}{
+				"Xyzzy": "Nothing happens.",
+				"def":   1,
+			}
+			vm.Set("abc", abc)
+			test(`
+                var keys = [];
+                for (var key in abc) {
+                  keys.push(key);
+                }
+                keys.sort();
+                keys;
+            `, "Xyzzy,def")
+		}
+
+		// map[uint]interface{}
+		{
+			abc := map[uint]interface{}{
+				456: "Nothing happens.",
+				123: 1,
+			}
+			vm.Set("abc", abc)
+			test(`
+                var keys = [];
+                for (var key in abc) {
+                  keys.push(key);
+                }
+                keys.sort();
+                keys;
+            `, "123,456")
+		}
+
+		// map[rune]interface{}
+		{
+			abc := map[byte]interface{}{
+				10: "Nothing happens.",
+				20: 1,
+			}
+			vm.Set("abc", abc)
+			test(`
+                for (var key in abc) {
+                  abc[key] = "123";
+                }
+            `)
+			is(abc[10], "123");
+			is(abc[20], "123");
+		}
+
+	})
+}
+
 func Test_reflectSlice(t *testing.T) {
 	tt(t, func() {
 		test, vm := test()

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -294,7 +294,7 @@ func Test_reflectMapIterateKeys(t *testing.T) {
             `, "123,456")
 		}
 
-		// map[rune]interface{}
+		// map[byte]interface{}
 		{
 			abc := map[byte]interface{}{
 				10: "Nothing happens.",

--- a/type_go_map.go
+++ b/type_go_map.go
@@ -60,7 +60,7 @@ func goMapEnumerate(self *_object, all bool, each func(string) bool) {
 	object := self.value.(*_goMapObject)
 	keys := object.value.MapKeys()
 	for _, key := range keys {
-		if !each(key.String()) {
+		if !each(toValue(key).String()) {
 			return
 		}
 	}


### PR DESCRIPTION
Fix for issue #96 