### PR TITLE
Support go multiple return values as an array

### DIFF
--- a/reflect_test.go
+++ b/reflect_test.go
@@ -148,9 +148,14 @@ func Test_reflectStruct(t *testing.T) {
                 abc.FuncEllipsis("abc", "def", "ghi");
             `, 3)
 
-			test(`raise:
-                abc.FuncReturn2();
-            `, "TypeError")
+			test(`
+                ret = abc.FuncReturn2();
+                if (ret && ret.length && ret.length == 2 && ret[0] == "def" && ret[1] === undefined) {
+                        true;
+                } else {
+                       false;
+                }
+            `, true)
 
 			test(`
                 abc.FuncReturnStruct();

--- a/runtime.go
+++ b/runtime.go
@@ -223,13 +223,21 @@ func (self *_runtime) toValue(value interface{}) Value {
 					}
 
 					out := value.Call(in)
-					if len(out) == 1 {
-						return self.toValue(out[0].Interface())
-					} else if len(out) == 0 {
+					l := len(out)
+					switch l {
+					case 0:
 						return Value{}
+					case 1:
+						return self.toValue(out[0].Interface())
 					}
 
-					panic(call.runtime.panicTypeError())
+					// Return an array of the values to emulate multi value return.
+					// In the future this can be used along side destructuring assignment.
+					s := make([]interface{}, l)
+					for i, v := range out {
+						s[i] = self.toValue(v.Interface())
+					}
+					return self.toValue(s)
 				}))
 			case reflect.Struct:
 				return toValue_object(self.newGoStructObject(value))


### PR DESCRIPTION
Add support for go funcs which return multiple values by returning them as an array.

In the future this can be used along side destructuring assignment to provide a nice way to deal with multiple value returns e.g.
[val, err] = MyGoFunc()