### PR TITLE
Export arrays to common type if possible

### DIFF
--- a/reflect_test.go
+++ b/reflect_test.go
@@ -213,9 +213,14 @@ func Test_reflectStruct(t *testing.T) {
                 abc.FuncEllipsis("abc", "def", "ghi");
             `, 3)
 
-			test(`raise:
-                abc.FuncReturn2();
-            `, "TypeError")
+			test(`
+                ret = abc.FuncReturn2();
+                if (ret && ret.length && ret.length == 2 && ret[0] == "def" && ret[1] === undefined) {
+                        true;
+                } else {
+                       false;
+                }
+            `, true)
 
 			test(`
                 abc.FuncReturnStruct();

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -523,6 +523,46 @@ func Test_reflectArray(t *testing.T) {
 			is(abc[len(abc)-1], true)
 		}
 
+		// no common type
+		{
+			test(`
+                 abc = [1, 2.2, "str"];
+                 abc;
+             `, "1,2.2,str")
+			val, err := vm.Get("abc")
+			is(err, nil)
+			abc, err := val.Export()
+			is(err, nil)
+			is(abc, []interface{}{int64(1), 2.2, "str"})
+		}
+
+		// common type int
+		{
+			test(`
+                 abc = [1, 2, 3];
+                 abc;
+             `, "1,2,3")
+			val, err := vm.Get("abc")
+			is(err, nil)
+			abc, err := val.Export()
+			is(err, nil)
+			is(abc, []int64{1, 2, 3})
+		}
+
+		// common type string
+		{
+
+			test(`
+                 abc = ["str1", "str2", "str3"];
+                 abc;
+             `, "str1,str2,str3")
+
+			val, err := vm.Get("abc")
+			is(err, nil)
+			abc, err := val.Export()
+			is(err, nil)
+			is(abc, []string{"str1", "str2", "str3"})
+		}
 	})
 }
 

--- a/runtime.go
+++ b/runtime.go
@@ -285,13 +285,21 @@ func (self *_runtime) toValue(value interface{}) Value {
 					}
 
 					out := value.Call(in)
-					if len(out) == 1 {
-						return self.toValue(out[0].Interface())
-					} else if len(out) == 0 {
+					l := len(out)
+					switch l {
+					case 0:
 						return Value{}
+					case 1:
+						return self.toValue(out[0].Interface())
 					}
 
-					panic(call.runtime.panicTypeError())
+					// Return an array of the values to emulate multi value return.
+					// In the future this can be used along side destructuring assignment.
+					s := make([]interface{}, l)
+					for i, v := range out {
+						s[i] = self.toValue(v.Interface())
+					}
+					return self.toValue(s)
 				}))
 			case reflect.Struct:
 				return toValue_object(self.newGoStructObject(value))


### PR DESCRIPTION
If there is a common type for all values in an array export to a slice of that type otherwise return a slice of interfaces.