### PR TITLE
minor spacing changes for gofmt compliance

### DIFF
--- a/dbg/dbg.go
+++ b/dbg/dbg.go
@@ -282,7 +282,7 @@ func (self *Dbgr) getEmit() _emit {
 // SetOutput will accept the following as a destination for output:
 //
 //      *log.Logger         Print*/Panic*/Fatal* of the logger
-//      io.Writer           - 
+//      io.Writer           -
 //      nil                 Reset to the default output (os.Stderr)
 //      "log"               Print*/Panic*/Fatal* via the "log" package
 //

--- a/underscore/source.go
+++ b/underscore/source.go
@@ -3456,6 +3456,7 @@ func underscore() []byte {
 		0x69, 0x73, 0x29, 0x3b, 0x0a,
 	}
 }
+
 //     Underscore.js 1.4.4
 //     http://underscorejs.org
 //     (c) 2009-2013 Jeremy Ashkenas, DocumentCloud Inc.


### PR DESCRIPTION
the tiny spacing changes done with go version go1.4.2 darwin/amd64:
```find . -name '*.go' | xargs gofmt -w```

