### PR TITLE
Improving call arguments conversion

### DIFF
--- a/reflect_test.go
+++ b/reflect_test.go
@@ -16,6 +16,8 @@ type _abcStruct struct {
 	Pqr map[string]int8
 }
 
+type customInt uint32
+
 func (abc _abcStruct) String() string {
 	return abc.Ghi
 }
@@ -689,3 +691,24 @@ func Test_reflectNil(t *testing.T) {
 		}
 	})
 }
+
+func Test_reflectCustomType(t *testing.T) {
+	tt(t, func() {
+		test, vm := test()
+		{
+			vm.Set("func", func() customInt {
+				return customInt(123)
+			})
+
+			vm.Set("func1", func(v customInt) bool {
+				return v == customInt(123)
+			})
+
+			test(`
+			var arg = func();
+			func1(arg);
+            `, true)
+		}
+	})
+}
+

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -754,9 +754,9 @@ func Test_reflectNil(t *testing.T) {
 			})
 
 			test(`
-			var arg;
-			func(arg);
-            `, true)
+				var arg;
+				func(arg);
+			`, true)
 		}
 	})
 }
@@ -774,9 +774,9 @@ func Test_reflectCustomType(t *testing.T) {
 			})
 
 			test(`
-			var arg = func();
-			func1(arg);
-            `, true)
+				var arg = func();
+				func1(arg);
+			`, true)
 		}
 	})
 }

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -673,3 +673,19 @@ func TestPassthrough(t *testing.T) {
 		}
 	})
 }
+
+func Test_reflectNil(t *testing.T) {
+	tt(t, func() {
+		test, vm := test()
+		{
+			vm.Set("func", func(s *_mnoStruct) bool {
+				return s == nil
+			})
+
+			test(`
+			var arg;
+			func(arg);
+            `, true)
+		}
+	})
+}

--- a/runtime.go
+++ b/runtime.go
@@ -291,13 +291,11 @@ func callParamConvert(val reflect.Value, t reflect.Type) reflect.Value {
 	if val.IsValid() { // Avoid "Call using zero Value argument"
 		if val.Type() != t {
 			return val.Convert(t)
-		} else {
-			return val
 		}
-	} else {
-		return reflect.New(t).Elem()
+		return val
 	}
 
+	return reflect.New(t).Elem()
 }
 
 func convertSlice(val reflect.Value, t reflect.Type) reflect.Value {


### PR DESCRIPTION
Passing nil to a 'non-native' go function results in "Call using zero Value argument". 
Also, passing custom types (for example passing uint32 to a function that expects type a uint32) results in a panic. This addresses both issues.
Please consider merging.
