### PR TITLE
fix reporting (anonymous) file upon compile error

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -260,7 +260,7 @@ func (self *_parser) position(idx file.Idx) file.Position {
 	position := file.Position{}
 	offset := int(idx) - self.base
 	str := self.str[:offset]
-	position.Filename = self.filename
+	position.Filename = self.file.Name()
 	line, last := lineCount(str)
 	position.Line = 1 + line
 	if last >= 0 {


### PR DESCRIPTION
When running `vm.Compile("/file/path", []byte("a=/"))` filename was lost and returned as `(anonymous)` instead of `/file/path`.
Suggested fix solves the issue.

Note: I do not have a broad understanding of the difference between `parser.filename` and `parser.file.filename`. Please double check suggested fix makes sense.

I haven't written a test case. If you approve the fix is OK in theory and suggest at what level to write a test case I'm happy to send a pull request.