### PR TITLE
fix cloning getter/setter props

### DIFF
--- a/clone.go
+++ b/clone.go
@@ -141,14 +141,22 @@ func (clone *_clone) stash(in _stash) _stash {
 func (clone *_clone) property(in _property) _property {
 	out := in
 
-	switch v := in.value.(type) {
-	case _propertyGetSet:
-		out.value = _propertyGetSet{v[0], v[1]}
+	switch value := in.value.(type) {
 	case Value:
-		out.value = clone.value(v)
+		out.value = clone.value(value)
+	case _propertyGetSet:
+		p := _propertyGetSet{}
+		if value[0] != nil {
+			p[0] = clone.object(value[0])
+		}
+		if value[1] != nil {
+			p[1] = clone.object(value[1])
+		}
+		out.value = p
 	default:
-		panic(fmt.Errorf("in.value.(Value) != true"))
+		panic(fmt.Errorf("in.value.(Value) != true; in.value is %T", in.value))
 	}
+
 	return out
 }
 

--- a/clone_test.go
+++ b/clone_test.go
@@ -1,0 +1,18 @@
+package otto
+
+import (
+	"testing"
+)
+
+func TestCloneGetterSetter(t *testing.T) {
+	vm := New()
+
+	vm.Run(`var x = Object.create(null, {
+    x: {
+      get: function() {},
+      set: function() {},
+    },
+  })`)
+
+	vm.Copy()
+}


### PR DESCRIPTION
Previously, the following code would panic:

```
vm := otto.New()

vm.Run(`var x = Object.create(null, {
  x: {
    get: function() {},
    set: function() {},
  },
})`)

vm.Copy()
```

Now, it doesn't. Magic!