### PR TITLE
Let the ToValue() member of Otto accept Go functions

### DIFF
--- a/otto_.go
+++ b/otto_.go
@@ -25,7 +25,7 @@ func (self *_runtime) toValueArray(arguments ...interface{}) []Value {
 
 	valueArray := make([]Value, length)
 	for index, value := range arguments {
-		valueArray[index] = toValue(value)
+		valueArray[index] = self.toValue(value)
 	}
 
 	return valueArray

--- a/value.go
+++ b/value.go
@@ -43,7 +43,7 @@ var (
 
 // ToValue will convert an interface{} value to a value digestible by otto/JavaScript
 //
-// This function will not work for advanced types (struct, map, slice/array, etc.) and
+// This function will not work for advanced types (struct, map, slice/array, func, etc.) and
 // you should use Otto.ToValue instead.
 func ToValue(value interface{}) (Value, error) {
 	result := Value{}

--- a/value_test.go
+++ b/value_test.go
@@ -47,6 +47,16 @@ func TestToValue(t *testing.T) {
 		value, _ = vm.ToValue(intAlias(5))
 		is(value, 5)
 
+		value, _ = vm.ToValue(func(call FunctionCall) Value {
+			arg, _ := call.Argument(0).ToString()
+			is(arg, "hello")
+			return UndefinedValue()
+		})
+		is(value, "function () { [native code] }")
+		if _, err := value.Call(UndefinedValue(), "hello"); err != nil {
+			panic(err)
+		}
+
 		{
 			tmp := new(int)
 


### PR DESCRIPTION
This change lets the ToValue() member of an Otto instance accept Go functions.
