### PR TITLE
Add Context method to aid debugging

### DIFF
--- a/stash.go
+++ b/stash.go
@@ -273,3 +273,24 @@ func (in *_fnStash) clone(clone *_clone) _stash {
 	}
 	return out
 }
+
+func getStashProperties(stash _stash) (keys []string) {
+	switch vars := stash.(type) {
+	case *_dclStash:
+		for k := range vars.property {
+			keys = append(keys, k)
+		}
+	case *_fnStash:
+		for k := range vars.property {
+			keys = append(keys, k)
+		}
+	case *_objectStash:
+		for k := range vars.object.property {
+			keys = append(keys, k)
+		}
+	default:
+		panic("unknown stash type")
+	}
+
+	return
+}


### PR DESCRIPTION
This change introduces a Context method to otto that allows developers to get
information about the current execution context. The method returns a Context
struct that contains information such as the filename, line and column of the
current execution, the current value of this, the stacktrace and the available
symbols at the current context.

Resolves #145 