### PR TITLE
Have goSliceGetOwnProperty check methods as well

### DIFF
--- a/type_go_slice.go
+++ b/type_go_slice.go
@@ -67,6 +67,14 @@ func goSliceGetOwnProperty(self *_object, name string) *_property {
 		}
 	}
 
+	// Other methods
+	if method := self.value.(*_goSliceObject).value.MethodByName(name); (method != reflect.Value{}) {
+		return &_property{
+			value: self.runtime.toValue(method.Interface()),
+			mode:  0110,
+		}
+	}
+
 	return objectGetOwnProperty(self, name)
 }
 

--- a/type_go_slice_test.go
+++ b/type_go_slice_test.go
@@ -1,0 +1,23 @@
+package otto
+
+import "testing"
+
+type GoSliceTest []int
+
+func (s GoSliceTest) Sum() int {
+	sum := 0
+	for _, v := range s {
+		sum += v
+	}
+	return sum
+}
+
+func TestGoSlice(t *testing.T) {
+	tt(t, func() {
+		test, vm := test()
+		vm.Set("TestSlice", GoSliceTest{1, 2, 3})
+		is(test(`TestSlice.length`).export(), 3)
+		is(test(`TestSlice[1]`).export(), 2)
+		is(test(`TestSlice.Sum()`).export(), 6)
+	})
+}


### PR DESCRIPTION
Developers can define methods on slices by declaring a custom type. This allows access of slice methods inside the javascript VM.