### PR TITLE
Walk the AST

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -83,7 +83,7 @@ type (
 
 	DotExpression struct {
 		Left       Expression
-		Identifier Identifier
+		Identifier *Identifier
 	}
 
 	FunctionLiteral struct {

--- a/file/file.go
+++ b/file/file.go
@@ -122,6 +122,23 @@ func NewFile(filename, src string, base int) *File {
 	}
 }
 
+// Position converts an Idx in the FileSet into a Position.
+func (self *File) Position(idx Idx) *Position {
+	position := &Position{}
+	offset := int(idx) - self.base
+	src := self.src[:offset]
+	position.Filename = self.name
+	position.Offset = offset
+	position.Line = 1 + strings.Count(src, "\n")
+	if index := strings.LastIndex(src, "\n"); index >= 0 {
+		position.Column = offset - index
+	} else {
+		position.Column = 1 + len(src)
+	}
+
+	return position
+}
+
 func (fl *File) Name() string {
 	return fl.name
 }

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -370,7 +370,7 @@ func (self *_parser) parseDotMember(left ast.Expression) ast.Expression {
 
 	return &ast.DotExpression{
 		Left: left,
-		Identifier: ast.Identifier{
+		Identifier: &ast.Identifier{
 			Idx:  idx,
 			Name: literal,
 		},

--- a/walk/metadata.go
+++ b/walk/metadata.go
@@ -27,6 +27,24 @@ func (md Metadata) AddParent(parent ast.Node) {
 	md["parent"] = parent
 }
 
+func CurrentMetadata(metadata []Metadata) Metadata {
+	l := len(metadata)
+	if l == 0 {
+		return nil
+	}
+
+	return metadata[l-1]
+}
+
+func ParentMetadata(metadata []Metadata) Metadata {
+	l := len(metadata)
+	if l < 2 {
+		return nil
+	}
+
+	return metadata[l-2]
+}
+
 // String displays information about the metadata
 func (md Metadata) String() string {
 	return fmt.Sprintf("{parent:%v}", reflect.TypeOf(md["parent"]))

--- a/walk/metadata.go
+++ b/walk/metadata.go
@@ -6,14 +6,17 @@ import (
 	"reflect"
 )
 
-// Metadata contains information about a node
+// Metadata contains information about a node.
+// It is a map of values, by default the parent of the current node is inserted.
 type Metadata map[string]interface{}
 
+// NewMetadata returns a new instance
 func NewMetadata(parent ast.Node) Metadata {
 	md := Metadata{"parent": parent}
 	return md
 }
 
+// Parent retrieves the parent of the node
 func (md Metadata) Parent() ast.Node {
 	parent, ok := md["parent"].(ast.Node)
 	if !ok {
@@ -23,10 +26,12 @@ func (md Metadata) Parent() ast.Node {
 	return parent
 }
 
+// AddParent inserts the given node as the parent
 func (md Metadata) AddParent(parent ast.Node) {
 	md["parent"] = parent
 }
 
+// CurrentMetadata returns the last added element as the current metadata
 func CurrentMetadata(metadata []Metadata) Metadata {
 	l := len(metadata)
 	if l == 0 {
@@ -36,6 +41,7 @@ func CurrentMetadata(metadata []Metadata) Metadata {
 	return metadata[l-1]
 }
 
+// ParentMetadata returns the second last added element as the parent metadata
 func ParentMetadata(metadata []Metadata) Metadata {
 	l := len(metadata)
 	if l < 2 {

--- a/walk/metadata.go
+++ b/walk/metadata.go
@@ -8,7 +8,8 @@ import (
 )
 
 const (
-	Vars string = "vars"
+	Vars      string = "vars"
+	NodeField        = "node"
 )
 
 // Metadata contains information about a node.
@@ -16,14 +17,14 @@ const (
 type Metadata map[string]interface{}
 
 // NewMetadata returns a new instance
-func NewMetadata(parent ast.Node) Metadata {
-	md := Metadata{"parent": parent}
+func NewMetadata(node ast.Node) Metadata {
+	md := Metadata{NodeField: node}
 	return md
 }
 
 // Parent retrieves the parent of the node
-func (md Metadata) Parent() ast.Node {
-	parent, ok := md["parent"].(ast.Node)
+func (md Metadata) Node() ast.Node {
+	parent, ok := md[NodeField].(ast.Node)
 	if !ok {
 		return nil
 	}
@@ -33,7 +34,7 @@ func (md Metadata) Parent() ast.Node {
 
 // AddParent inserts the given node as the parent
 func (md Metadata) AddParent(parent ast.Node) {
-	md["parent"] = parent
+	md[NodeField] = parent
 }
 
 // CurrentMetadata returns the last added element as the current metadata
@@ -58,7 +59,7 @@ func ParentMetadata(metadata []Metadata) Metadata {
 
 // String displays information about the metadata
 func (md Metadata) String() string {
-	return fmt.Sprintf("{parent:%v}", reflect.TypeOf(md["parent"]))
+	return fmt.Sprintf("{node:%v}", reflect.TypeOf(md[NodeField]))
 }
 
 type Variables map[string]file.Idx

--- a/walk/metadata.go
+++ b/walk/metadata.go
@@ -7,11 +7,27 @@ import (
 )
 
 // Metadata contains information about a node
-type Metadata struct {
-	Parent ast.Node
+type Metadata map[string]interface{}
+
+func NewMetadata(parent ast.Node) Metadata {
+	md := Metadata{"parent": parent}
+	return md
+}
+
+func (md Metadata) Parent() ast.Node {
+	parent, ok := md["parent"].(ast.Node)
+	if !ok {
+		return nil
+	}
+
+	return parent
+}
+
+func (md Metadata) AddParent(parent ast.Node) {
+	md["parent"] = parent
 }
 
 // String displays information about the metadata
 func (md Metadata) String() string {
-	return fmt.Sprintf("{parent:%v}", reflect.TypeOf(md.Parent))
+	return fmt.Sprintf("{parent:%v}", reflect.TypeOf(md["parent"]))
 }

--- a/walk/metadata.go
+++ b/walk/metadata.go
@@ -1,0 +1,17 @@
+package walk
+
+import (
+	"fmt"
+	"github.com/robertkrimen/otto/ast"
+	"reflect"
+)
+
+// Metadata contains information about a node
+type Metadata struct {
+	Parent ast.Node
+}
+
+// String displays information about the metadata
+func (md Metadata) String() string {
+	return fmt.Sprintf("{parent:%v}", reflect.TypeOf(md.Parent))
+}

--- a/walk/metadata.go
+++ b/walk/metadata.go
@@ -3,7 +3,12 @@ package walk
 import (
 	"fmt"
 	"github.com/robertkrimen/otto/ast"
+	"github.com/robertkrimen/otto/file"
 	"reflect"
+)
+
+const (
+	Vars string = "vars"
 )
 
 // Metadata contains information about a node.
@@ -54,4 +59,10 @@ func ParentMetadata(metadata []Metadata) Metadata {
 // String displays information about the metadata
 func (md Metadata) String() string {
 	return fmt.Sprintf("{parent:%v}", reflect.TypeOf(md["parent"]))
+}
+
+type Variables map[string]file.Idx
+
+func NewVariables() Variables {
+	return Variables{}
 }

--- a/walk/walker.go
+++ b/walk/walker.go
@@ -1,0 +1,391 @@
+package walk
+
+import (
+	"fmt"
+	"github.com/robertkrimen/otto/ast"
+)
+
+// Walker can walk a given AST with a visitor
+type Walker struct {
+	Visitor Visitor
+}
+
+// Visitor interface for the walker.
+type Visitor interface {
+	VisitArray(walker *Walker, node *ast.ArrayLiteral, metadata []Metadata)
+	VisitAssign(walker *Walker, node *ast.AssignExpression, metadata []Metadata)
+	VisitBad(walker *Walker, node *ast.BadExpression, metadata []Metadata)
+	VisitBadStatement(walker *Walker, node *ast.BadStatement, metadata []Metadata)
+	VisitBinary(walker *Walker, node *ast.BinaryExpression, metadata []Metadata)
+	VisitBlock(walker *Walker, node *ast.BlockStatement, metadata []Metadata)
+	VisitBoolean(walker *Walker, node *ast.BooleanLiteral, metadata []Metadata)
+	VisitBracket(walker *Walker, node *ast.BracketExpression, metadata []Metadata)
+	VisitBranch(walker *Walker, node *ast.BranchStatement, metadata []Metadata)
+	VisitCall(walker *Walker, node *ast.CallExpression, metadata []Metadata)
+	VisitCase(walker *Walker, node *ast.CaseStatement, metadata []Metadata)
+	VisitCatch(walker *Walker, node *ast.CatchStatement, metadata []Metadata)
+	VisitConditional(walker *Walker, node *ast.ConditionalExpression, metadata []Metadata)
+	VisitDebugger(walker *Walker, node *ast.DebuggerStatement, metadata []Metadata)
+	VisitDot(walker *Walker, node *ast.DotExpression, metadata []Metadata)
+	VisitDoWhile(walker *Walker, node *ast.DoWhileStatement, metadata []Metadata)
+	VisitEmpty(walker *Walker, node *ast.EmptyStatement, metadata []Metadata)
+	VisitExpression(walker *Walker, node *ast.ExpressionStatement, metadata []Metadata)
+	VisitForIn(walker *Walker, node *ast.ForInStatement, metadata []Metadata)
+	VisitFor(walker *Walker, node *ast.ForStatement, metadata []Metadata)
+	VisitFunction(walker *Walker, node *ast.FunctionLiteral, metadata []Metadata)
+	VisitIdentifier(walker *Walker, node *ast.Identifier, metadata []Metadata)
+	VisitIf(walker *Walker, node *ast.IfStatement, metadata []Metadata)
+	VisitLabelled(walker *Walker, node *ast.LabelledStatement, metadata []Metadata)
+	VisitNew(walker *Walker, node *ast.NewExpression, metadata []Metadata)
+	VisitNull(walker *Walker, node *ast.NullLiteral, metadata []Metadata)
+	VisitNumber(walker *Walker, node *ast.NumberLiteral, metadata []Metadata)
+	VisitObject(walker *Walker, node *ast.ObjectLiteral, metadata []Metadata)
+	VisitProgram(walker *Walker, node *ast.Program, metadata []Metadata)
+	VisitReturn(walker *Walker, node *ast.ReturnStatement, metadata []Metadata)
+	VisitRegex(walker *Walker, node *ast.RegExpLiteral, metadata []Metadata)
+	VisitSequence(walker *Walker, node *ast.SequenceExpression, metadata []Metadata)
+	VisitString(walker *Walker, node *ast.StringLiteral, metadata []Metadata)
+	VisitSwitch(walker *Walker, node *ast.SwitchStatement, metadata []Metadata)
+	VisitThis(walker *Walker, node *ast.ThisExpression, metadata []Metadata)
+	VisitThrow(walker *Walker, node *ast.ThrowStatement, metadata []Metadata)
+	VisitTry(walker *Walker, node *ast.TryStatement, metadata []Metadata)
+	VisitUnary(walker *Walker, node *ast.UnaryExpression, metadata []Metadata)
+	VisitVariable(walker *Walker, node *ast.VariableExpression, metadata []Metadata)
+	VisitVariableStatement(walker *Walker, node *ast.VariableStatement, metadata []Metadata)
+	VisitWhile(walker *Walker, node *ast.WhileStatement, metadata []Metadata)
+	VisitWith(walker *Walker, node *ast.WithStatement, metadata []Metadata)
+}
+
+// Begin the walk of the given AST node
+func (w *Walker) Begin(node ast.Node) {
+	md := []Metadata{Metadata{nil}}
+	w.Walk(node, md)
+}
+
+// Walk the AST, including metadata
+func (w *Walker) Walk(node ast.Node, metadata []Metadata) {
+
+	// Append the node
+	metadata = append(metadata, Metadata{node})
+
+	switch n := node.(type) {
+	case *ast.ArrayLiteral:
+		w.Visitor.VisitArray(w, n, metadata)
+	case *ast.AssignExpression:
+		w.Visitor.VisitAssign(w, n, metadata)
+	case *ast.BadExpression:
+		w.Visitor.VisitBad(w, n, metadata)
+	case *ast.BadStatement:
+		w.Visitor.VisitBadStatement(w, n, metadata)
+	case *ast.BinaryExpression:
+		w.Visitor.VisitBinary(w, n, metadata)
+	case *ast.BlockStatement:
+		w.Visitor.VisitBlock(w, n, metadata)
+	case *ast.BooleanLiteral:
+		w.Visitor.VisitBoolean(w, n, metadata)
+	case *ast.BracketExpression:
+		w.Visitor.VisitBracket(w, n, metadata)
+	case *ast.BranchStatement:
+		w.Visitor.VisitBranch(w, n, metadata)
+	case *ast.CallExpression:
+		w.Visitor.VisitCall(w, n, metadata)
+	case *ast.CaseStatement:
+		w.Visitor.VisitCase(w, n, metadata)
+	case *ast.CatchStatement:
+		w.Visitor.VisitCatch(w, n, metadata)
+	case *ast.ConditionalExpression:
+		w.Visitor.VisitConditional(w, n, metadata)
+	case *ast.DebuggerStatement:
+		w.Visitor.VisitDebugger(w, n, metadata)
+	case *ast.DotExpression:
+		w.Visitor.VisitDot(w, n, metadata)
+	case *ast.DoWhileStatement:
+		w.Visitor.VisitDoWhile(w, n, metadata)
+	case *ast.EmptyStatement:
+		w.Visitor.VisitEmpty(w, n, metadata)
+	case *ast.ExpressionStatement:
+		w.Visitor.VisitExpression(w, n, metadata)
+	case *ast.ForInStatement:
+		w.Visitor.VisitForIn(w, n, metadata)
+	case *ast.ForStatement:
+		w.Visitor.VisitFor(w, n, metadata)
+	case *ast.FunctionLiteral:
+		w.Visitor.VisitFunction(w, n, metadata)
+	case *ast.Identifier:
+		w.Visitor.VisitIdentifier(w, n, metadata)
+	case *ast.IfStatement:
+		w.Visitor.VisitIf(w, n, metadata)
+	case *ast.LabelledStatement:
+		w.Visitor.VisitLabelled(w, n, metadata)
+	case *ast.NewExpression:
+		w.Visitor.VisitNew(w, n, metadata)
+	case *ast.NullLiteral:
+		w.Visitor.VisitNull(w, n, metadata)
+	case *ast.NumberLiteral:
+		w.Visitor.VisitNumber(w, n, metadata)
+	case *ast.ObjectLiteral:
+		w.Visitor.VisitObject(w, n, metadata)
+	case *ast.Program:
+		w.Visitor.VisitProgram(w, n, metadata)
+	case *ast.ReturnStatement:
+		w.Visitor.VisitReturn(w, n, metadata)
+	case *ast.RegExpLiteral:
+		w.Visitor.VisitRegex(w, n, metadata)
+	case *ast.SequenceExpression:
+		w.Visitor.VisitSequence(w, n, metadata)
+	case *ast.StringLiteral:
+		w.Visitor.VisitString(w, n, metadata)
+	case *ast.SwitchStatement:
+		w.Visitor.VisitSwitch(w, n, metadata)
+	case *ast.ThisExpression:
+		w.Visitor.VisitThis(w, n, metadata)
+	case *ast.ThrowStatement:
+		w.Visitor.VisitThrow(w, n, metadata)
+	case *ast.TryStatement:
+		w.Visitor.VisitTry(w, n, metadata)
+	case *ast.UnaryExpression:
+		w.Visitor.VisitUnary(w, n, metadata)
+	case *ast.VariableExpression:
+		w.Visitor.VisitVariable(w, n, metadata)
+	case *ast.VariableStatement:
+		w.Visitor.VisitVariableStatement(w, n, metadata)
+	case *ast.WhileStatement:
+		w.Visitor.VisitWhile(w, n, metadata)
+	case *ast.WithStatement:
+		w.Visitor.VisitWith(w, n, metadata)
+	}
+}
+
+// VisitorImpl is a default implementation of the Visitor interface
+type VisitorImpl struct {
+}
+
+func (v *VisitorImpl) VisitProgram(w *Walker, node *ast.Program, metadata []Metadata) {
+	for _, e := range node.Body {
+		w.Walk(e, metadata)
+	}
+
+	// Walking function and variable declarations
+	for _, value := range node.DeclarationList {
+		switch value := value.(type) {
+		case *ast.FunctionDeclaration:
+			w.Walk(value.Function, metadata)
+		case *ast.VariableDeclaration:
+			for _, value := range value.List {
+				w.Walk(value, metadata)
+			}
+		default:
+			panic(fmt.Errorf("Here be dragons: visit Program.DeclarationList(%T)", value))
+		}
+	}
+}
+
+func (v *VisitorImpl) VisitArray(w *Walker, node *ast.ArrayLiteral, metadata []Metadata) {
+	for _, e := range node.Value {
+		w.Walk(e, metadata)
+	}
+}
+
+func (v *VisitorImpl) VisitAssign(w *Walker, node *ast.AssignExpression, metadata []Metadata) {
+	w.Walk(node.Left, metadata)
+	w.Walk(node.Right, metadata)
+}
+
+func (v *VisitorImpl) VisitBad(w *Walker, node *ast.BadExpression, metadata []Metadata) {
+}
+
+func (v *VisitorImpl) VisitBadStatement(w *Walker, node *ast.BadStatement, metadata []Metadata) {
+}
+
+func (v *VisitorImpl) VisitBinary(w *Walker, node *ast.BinaryExpression, metadata []Metadata) {
+	w.Walk(node.Left, metadata)
+	w.Walk(node.Right, metadata)
+}
+
+func (v *VisitorImpl) VisitBlock(w *Walker, node *ast.BlockStatement, metadata []Metadata) {
+	for _, value := range node.List {
+		w.Walk(value, metadata)
+	}
+}
+
+func (v *VisitorImpl) VisitBoolean(w *Walker, node *ast.BooleanLiteral, metadata []Metadata) {
+}
+
+func (v *VisitorImpl) VisitBracket(w *Walker, node *ast.BracketExpression, metadata []Metadata) {
+	w.Walk(node.Left, metadata)
+	w.Walk(node.Member, metadata)
+}
+
+func (v *VisitorImpl) VisitBranch(w *Walker, node *ast.BranchStatement, metadata []Metadata) {
+	w.Walk(node.Label, metadata)
+}
+
+func (v *VisitorImpl) VisitCall(w *Walker, node *ast.CallExpression, metadata []Metadata) {
+	w.Walk(node.Callee, metadata)
+	for _, value := range node.ArgumentList {
+		w.Walk(value, metadata)
+	}
+}
+
+func (v *VisitorImpl) VisitCase(w *Walker, node *ast.CaseStatement, metadata []Metadata) {
+	w.Walk(node.Test, metadata)
+	for _, e := range node.Consequent {
+		w.Walk(e, metadata)
+	}
+}
+
+func (v *VisitorImpl) VisitCatch(w *Walker, node *ast.CatchStatement, metadata []Metadata) {
+	w.Walk(node.Parameter, metadata)
+	w.Walk(node.Body, metadata)
+}
+
+func (v *VisitorImpl) VisitConditional(w *Walker, node *ast.ConditionalExpression, metadata []Metadata) {
+	w.Walk(node.Test, metadata)
+	w.Walk(node.Consequent, metadata)
+	w.Walk(node.Alternate, metadata)
+}
+
+func (v *VisitorImpl) VisitDebugger(w *Walker, node *ast.DebuggerStatement, metadata []Metadata) {
+}
+
+func (v *VisitorImpl) VisitDot(w *Walker, node *ast.DotExpression, metadata []Metadata) {
+	w.Walk(node.Left, metadata)
+	w.Walk(node.Identifier, metadata)
+}
+
+func (v *VisitorImpl) VisitDoWhile(w *Walker, node *ast.DoWhileStatement, metadata []Metadata) {
+	w.Walk(node.Test, metadata)
+	w.Walk(node.Body, metadata)
+}
+
+func (v *VisitorImpl) VisitEmpty(w *Walker, node *ast.EmptyStatement, metadata []Metadata) {
+}
+
+func (v *VisitorImpl) VisitExpression(w *Walker, node *ast.ExpressionStatement, metadata []Metadata) {
+	w.Walk(node.Expression, metadata)
+}
+
+func (v *VisitorImpl) VisitForIn(w *Walker, node *ast.ForInStatement, metadata []Metadata) {
+	w.Walk(node.Into, metadata)
+	w.Walk(node.Source, metadata)
+	w.Walk(node.Body, metadata)
+}
+
+func (v *VisitorImpl) VisitFor(w *Walker, node *ast.ForStatement, metadata []Metadata) {
+	w.Walk(node.Initializer, metadata)
+	w.Walk(node.Test, metadata)
+	w.Walk(node.Update, metadata)
+	w.Walk(node.Body, metadata)
+}
+
+func (v *VisitorImpl) VisitFunction(w *Walker, node *ast.FunctionLiteral, metadata []Metadata) {
+	w.Walk(node.Name, metadata)
+	for _, value := range node.ParameterList.List {
+		w.Walk(value, metadata)
+	}
+	w.Walk(node.Body, metadata)
+
+	for _, value := range node.DeclarationList {
+		switch value := value.(type) {
+		case *ast.FunctionDeclaration:
+			w.Walk(value.Function, metadata)
+		case *ast.VariableDeclaration:
+			for _, value := range value.List {
+				w.Walk(value, metadata)
+			}
+		default:
+			panic(fmt.Errorf("Here be dragons: visit Function.declaration(%T)", value))
+		}
+	}
+}
+
+func (v *VisitorImpl) VisitIdentifier(w *Walker, node *ast.Identifier, metadata []Metadata) {
+}
+
+func (v *VisitorImpl) VisitIf(w *Walker, node *ast.IfStatement, metadata []Metadata) {
+	w.Walk(node.Test, metadata)
+	w.Walk(node.Consequent, metadata)
+	w.Walk(node.Alternate, metadata)
+}
+
+func (v *VisitorImpl) VisitLabelled(w *Walker, node *ast.LabelledStatement, metadata []Metadata) {
+	w.Walk(node.Label, metadata)
+	w.Walk(node.Statement, metadata)
+}
+
+func (v *VisitorImpl) VisitNew(w *Walker, node *ast.NewExpression, metadata []Metadata) {
+	w.Walk(node.Callee, metadata)
+	for _, e := range node.ArgumentList {
+		w.Walk(e, metadata)
+	}
+}
+
+func (v *VisitorImpl) VisitNull(w *Walker, node *ast.NullLiteral, metadata []Metadata) {
+}
+
+func (v *VisitorImpl) VisitNumber(w *Walker, node *ast.NumberLiteral, metadata []Metadata) {
+}
+
+func (v *VisitorImpl) VisitObject(w *Walker, node *ast.ObjectLiteral, metadata []Metadata) {
+}
+
+func (v *VisitorImpl) VisitReturn(w *Walker, node *ast.ReturnStatement, metadata []Metadata) {
+	w.Walk(node.Argument, metadata)
+}
+
+func (v *VisitorImpl) VisitRegex(w *Walker, node *ast.RegExpLiteral, metadata []Metadata) {
+}
+
+func (v *VisitorImpl) VisitSequence(w *Walker, node *ast.SequenceExpression, metadata []Metadata) {
+	for _, e := range node.Sequence {
+		w.Walk(e, metadata)
+	}
+}
+
+func (v *VisitorImpl) VisitString(w *Walker, node *ast.StringLiteral, metadata []Metadata) {
+	// No op
+}
+
+func (v *VisitorImpl) VisitSwitch(w *Walker, node *ast.SwitchStatement, metadata []Metadata) {
+	w.Walk(node.Discriminant, metadata)
+	for _, e := range node.Body {
+		w.Walk(e, metadata)
+	}
+}
+
+func (v *VisitorImpl) VisitThis(w *Walker, node *ast.ThisExpression, metadata []Metadata) {
+}
+
+func (v *VisitorImpl) VisitThrow(w *Walker, node *ast.ThrowStatement, metadata []Metadata) {
+	w.Walk(node.Argument, metadata)
+}
+
+func (v *VisitorImpl) VisitTry(w *Walker, node *ast.TryStatement, metadata []Metadata) {
+	w.Walk(node.Body, metadata)
+	w.Walk(node.Catch, metadata)
+	w.Walk(node.Finally, metadata)
+}
+
+func (v *VisitorImpl) VisitUnary(w *Walker, node *ast.UnaryExpression, metadata []Metadata) {
+	w.Walk(node.Operand, metadata)
+}
+
+func (v *VisitorImpl) VisitVariable(w *Walker, node *ast.VariableExpression, metadata []Metadata) {
+	w.Walk(node.Initializer, metadata)
+}
+
+func (v *VisitorImpl) VisitVariableStatement(w *Walker, node *ast.VariableStatement, metadata []Metadata) {
+	for _, e := range node.List {
+		w.Walk(e, metadata)
+	}
+}
+
+func (v *VisitorImpl) VisitWhile(w *Walker, node *ast.WhileStatement, metadata []Metadata) {
+	w.Walk(node.Test, metadata)
+	w.Walk(node.Body, metadata)
+}
+
+func (v *VisitorImpl) VisitWith(w *Walker, node *ast.WithStatement, metadata []Metadata) {
+	w.Walk(node.Object, metadata)
+	w.Walk(node.Body, metadata)
+}

--- a/walk/walker.go
+++ b/walk/walker.go
@@ -58,7 +58,7 @@ type Visitor interface {
 
 // Begin the walk of the given AST node
 func (w *Walker) Begin(node ast.Node) {
-	md := []Metadata{Metadata{nil}}
+	md := []Metadata{NewMetadata(nil)}
 	w.Walk(node, md)
 }
 
@@ -66,7 +66,7 @@ func (w *Walker) Begin(node ast.Node) {
 func (w *Walker) Walk(node ast.Node, metadata []Metadata) {
 
 	// Append the node
-	metadata = append(metadata, Metadata{node})
+	metadata = append(metadata, NewMetadata(node))
 
 	switch n := node.(type) {
 	case *ast.ArrayLiteral:

--- a/walk/walker.go
+++ b/walk/walker.go
@@ -171,9 +171,7 @@ func (v *VisitorImpl) VisitProgram(w *Walker, node *ast.Program, metadata []Meta
 		case *ast.FunctionDeclaration:
 			w.Walk(value.Function, metadata)
 		case *ast.VariableDeclaration:
-			for _, value := range value.List {
-				w.Walk(value, metadata)
-			}
+			// Not needed, variable declarations are found in the AST
 		default:
 			panic(fmt.Errorf("Here be dragons: visit Program.DeclarationList(%T)", value))
 		}

--- a/walk/walker.go
+++ b/walk/walker.go
@@ -12,48 +12,48 @@ type Walker struct {
 
 // Visitor interface for the walker.
 type Visitor interface {
-	VisitArray(walker *Walker, node *ast.ArrayLiteral, metadata []Metadata)
-	VisitAssign(walker *Walker, node *ast.AssignExpression, metadata []Metadata)
-	VisitBad(walker *Walker, node *ast.BadExpression, metadata []Metadata)
-	VisitBadStatement(walker *Walker, node *ast.BadStatement, metadata []Metadata)
-	VisitBinary(walker *Walker, node *ast.BinaryExpression, metadata []Metadata)
-	VisitBlock(walker *Walker, node *ast.BlockStatement, metadata []Metadata)
-	VisitBoolean(walker *Walker, node *ast.BooleanLiteral, metadata []Metadata)
-	VisitBracket(walker *Walker, node *ast.BracketExpression, metadata []Metadata)
-	VisitBranch(walker *Walker, node *ast.BranchStatement, metadata []Metadata)
-	VisitCall(walker *Walker, node *ast.CallExpression, metadata []Metadata)
-	VisitCase(walker *Walker, node *ast.CaseStatement, metadata []Metadata)
-	VisitCatch(walker *Walker, node *ast.CatchStatement, metadata []Metadata)
-	VisitConditional(walker *Walker, node *ast.ConditionalExpression, metadata []Metadata)
-	VisitDebugger(walker *Walker, node *ast.DebuggerStatement, metadata []Metadata)
-	VisitDot(walker *Walker, node *ast.DotExpression, metadata []Metadata)
-	VisitDoWhile(walker *Walker, node *ast.DoWhileStatement, metadata []Metadata)
-	VisitEmpty(walker *Walker, node *ast.EmptyStatement, metadata []Metadata)
-	VisitExpression(walker *Walker, node *ast.ExpressionStatement, metadata []Metadata)
-	VisitForIn(walker *Walker, node *ast.ForInStatement, metadata []Metadata)
-	VisitFor(walker *Walker, node *ast.ForStatement, metadata []Metadata)
-	VisitFunction(walker *Walker, node *ast.FunctionLiteral, metadata []Metadata)
-	VisitIdentifier(walker *Walker, node *ast.Identifier, metadata []Metadata)
-	VisitIf(walker *Walker, node *ast.IfStatement, metadata []Metadata)
-	VisitLabelled(walker *Walker, node *ast.LabelledStatement, metadata []Metadata)
-	VisitNew(walker *Walker, node *ast.NewExpression, metadata []Metadata)
-	VisitNull(walker *Walker, node *ast.NullLiteral, metadata []Metadata)
-	VisitNumber(walker *Walker, node *ast.NumberLiteral, metadata []Metadata)
-	VisitObject(walker *Walker, node *ast.ObjectLiteral, metadata []Metadata)
-	VisitProgram(walker *Walker, node *ast.Program, metadata []Metadata)
-	VisitReturn(walker *Walker, node *ast.ReturnStatement, metadata []Metadata)
-	VisitRegex(walker *Walker, node *ast.RegExpLiteral, metadata []Metadata)
-	VisitSequence(walker *Walker, node *ast.SequenceExpression, metadata []Metadata)
-	VisitString(walker *Walker, node *ast.StringLiteral, metadata []Metadata)
-	VisitSwitch(walker *Walker, node *ast.SwitchStatement, metadata []Metadata)
-	VisitThis(walker *Walker, node *ast.ThisExpression, metadata []Metadata)
-	VisitThrow(walker *Walker, node *ast.ThrowStatement, metadata []Metadata)
-	VisitTry(walker *Walker, node *ast.TryStatement, metadata []Metadata)
-	VisitUnary(walker *Walker, node *ast.UnaryExpression, metadata []Metadata)
-	VisitVariable(walker *Walker, node *ast.VariableExpression, metadata []Metadata)
-	VisitVariableStatement(walker *Walker, node *ast.VariableStatement, metadata []Metadata)
-	VisitWhile(walker *Walker, node *ast.WhileStatement, metadata []Metadata)
-	VisitWith(walker *Walker, node *ast.WithStatement, metadata []Metadata)
+	VisitArray(walker *Walker, node *ast.ArrayLiteral, metadata []Metadata) Metadata
+	VisitAssign(walker *Walker, node *ast.AssignExpression, metadata []Metadata) Metadata
+	VisitBad(walker *Walker, node *ast.BadExpression, metadata []Metadata) Metadata
+	VisitBadStatement(walker *Walker, node *ast.BadStatement, metadata []Metadata) Metadata
+	VisitBinary(walker *Walker, node *ast.BinaryExpression, metadata []Metadata) Metadata
+	VisitBlock(walker *Walker, node *ast.BlockStatement, metadata []Metadata) Metadata
+	VisitBoolean(walker *Walker, node *ast.BooleanLiteral, metadata []Metadata) Metadata
+	VisitBracket(walker *Walker, node *ast.BracketExpression, metadata []Metadata) Metadata
+	VisitBranch(walker *Walker, node *ast.BranchStatement, metadata []Metadata) Metadata
+	VisitCall(walker *Walker, node *ast.CallExpression, metadata []Metadata) Metadata
+	VisitCase(walker *Walker, node *ast.CaseStatement, metadata []Metadata) Metadata
+	VisitCatch(walker *Walker, node *ast.CatchStatement, metadata []Metadata) Metadata
+	VisitConditional(walker *Walker, node *ast.ConditionalExpression, metadata []Metadata) Metadata
+	VisitDebugger(walker *Walker, node *ast.DebuggerStatement, metadata []Metadata) Metadata
+	VisitDot(walker *Walker, node *ast.DotExpression, metadata []Metadata) Metadata
+	VisitDoWhile(walker *Walker, node *ast.DoWhileStatement, metadata []Metadata) Metadata
+	VisitEmpty(walker *Walker, node *ast.EmptyStatement, metadata []Metadata) Metadata
+	VisitExpression(walker *Walker, node *ast.ExpressionStatement, metadata []Metadata) Metadata
+	VisitForIn(walker *Walker, node *ast.ForInStatement, metadata []Metadata) Metadata
+	VisitFor(walker *Walker, node *ast.ForStatement, metadata []Metadata) Metadata
+	VisitFunction(walker *Walker, node *ast.FunctionLiteral, metadata []Metadata) Metadata
+	VisitIdentifier(walker *Walker, node *ast.Identifier, metadata []Metadata) Metadata
+	VisitIf(walker *Walker, node *ast.IfStatement, metadata []Metadata) Metadata
+	VisitLabelled(walker *Walker, node *ast.LabelledStatement, metadata []Metadata) Metadata
+	VisitNew(walker *Walker, node *ast.NewExpression, metadata []Metadata) Metadata
+	VisitNull(walker *Walker, node *ast.NullLiteral, metadata []Metadata) Metadata
+	VisitNumber(walker *Walker, node *ast.NumberLiteral, metadata []Metadata) Metadata
+	VisitObject(walker *Walker, node *ast.ObjectLiteral, metadata []Metadata) Metadata
+	VisitProgram(walker *Walker, node *ast.Program, metadata []Metadata) Metadata
+	VisitReturn(walker *Walker, node *ast.ReturnStatement, metadata []Metadata) Metadata
+	VisitRegex(walker *Walker, node *ast.RegExpLiteral, metadata []Metadata) Metadata
+	VisitSequence(walker *Walker, node *ast.SequenceExpression, metadata []Metadata) Metadata
+	VisitString(walker *Walker, node *ast.StringLiteral, metadata []Metadata) Metadata
+	VisitSwitch(walker *Walker, node *ast.SwitchStatement, metadata []Metadata) Metadata
+	VisitThis(walker *Walker, node *ast.ThisExpression, metadata []Metadata) Metadata
+	VisitThrow(walker *Walker, node *ast.ThrowStatement, metadata []Metadata) Metadata
+	VisitTry(walker *Walker, node *ast.TryStatement, metadata []Metadata) Metadata
+	VisitUnary(walker *Walker, node *ast.UnaryExpression, metadata []Metadata) Metadata
+	VisitVariable(walker *Walker, node *ast.VariableExpression, metadata []Metadata) Metadata
+	VisitVariableStatement(walker *Walker, node *ast.VariableStatement, metadata []Metadata) Metadata
+	VisitWhile(walker *Walker, node *ast.WhileStatement, metadata []Metadata) Metadata
+	VisitWith(walker *Walker, node *ast.WithStatement, metadata []Metadata) Metadata
 }
 
 // Begin the walk of the given AST node
@@ -63,104 +63,106 @@ func (w *Walker) Begin(node ast.Node) {
 }
 
 // Walk the AST, including metadata
-func (w *Walker) Walk(node ast.Node, metadata []Metadata) {
+func (w *Walker) Walk(node ast.Node, metadata []Metadata) Metadata {
 
 	// Append the node
 	metadata = append(metadata, NewMetadata(node))
 
 	switch n := node.(type) {
 	case *ast.ArrayLiteral:
-		w.Visitor.VisitArray(w, n, metadata)
+		return w.Visitor.VisitArray(w, n, metadata)
 	case *ast.AssignExpression:
-		w.Visitor.VisitAssign(w, n, metadata)
+		return w.Visitor.VisitAssign(w, n, metadata)
 	case *ast.BadExpression:
-		w.Visitor.VisitBad(w, n, metadata)
+		return w.Visitor.VisitBad(w, n, metadata)
 	case *ast.BadStatement:
-		w.Visitor.VisitBadStatement(w, n, metadata)
+		return w.Visitor.VisitBadStatement(w, n, metadata)
 	case *ast.BinaryExpression:
-		w.Visitor.VisitBinary(w, n, metadata)
+		return w.Visitor.VisitBinary(w, n, metadata)
 	case *ast.BlockStatement:
-		w.Visitor.VisitBlock(w, n, metadata)
+		return w.Visitor.VisitBlock(w, n, metadata)
 	case *ast.BooleanLiteral:
-		w.Visitor.VisitBoolean(w, n, metadata)
+		return w.Visitor.VisitBoolean(w, n, metadata)
 	case *ast.BracketExpression:
-		w.Visitor.VisitBracket(w, n, metadata)
+		return w.Visitor.VisitBracket(w, n, metadata)
 	case *ast.BranchStatement:
-		w.Visitor.VisitBranch(w, n, metadata)
+		return w.Visitor.VisitBranch(w, n, metadata)
 	case *ast.CallExpression:
-		w.Visitor.VisitCall(w, n, metadata)
+		return w.Visitor.VisitCall(w, n, metadata)
 	case *ast.CaseStatement:
-		w.Visitor.VisitCase(w, n, metadata)
+		return w.Visitor.VisitCase(w, n, metadata)
 	case *ast.CatchStatement:
-		w.Visitor.VisitCatch(w, n, metadata)
+		return w.Visitor.VisitCatch(w, n, metadata)
 	case *ast.ConditionalExpression:
-		w.Visitor.VisitConditional(w, n, metadata)
+		return w.Visitor.VisitConditional(w, n, metadata)
 	case *ast.DebuggerStatement:
-		w.Visitor.VisitDebugger(w, n, metadata)
+		return w.Visitor.VisitDebugger(w, n, metadata)
 	case *ast.DotExpression:
-		w.Visitor.VisitDot(w, n, metadata)
+		return w.Visitor.VisitDot(w, n, metadata)
 	case *ast.DoWhileStatement:
-		w.Visitor.VisitDoWhile(w, n, metadata)
+		return w.Visitor.VisitDoWhile(w, n, metadata)
 	case *ast.EmptyStatement:
-		w.Visitor.VisitEmpty(w, n, metadata)
+		return w.Visitor.VisitEmpty(w, n, metadata)
 	case *ast.ExpressionStatement:
-		w.Visitor.VisitExpression(w, n, metadata)
+		return w.Visitor.VisitExpression(w, n, metadata)
 	case *ast.ForInStatement:
-		w.Visitor.VisitForIn(w, n, metadata)
+		return w.Visitor.VisitForIn(w, n, metadata)
 	case *ast.ForStatement:
-		w.Visitor.VisitFor(w, n, metadata)
+		return w.Visitor.VisitFor(w, n, metadata)
 	case *ast.FunctionLiteral:
-		w.Visitor.VisitFunction(w, n, metadata)
+		return w.Visitor.VisitFunction(w, n, metadata)
 	case *ast.Identifier:
-		w.Visitor.VisitIdentifier(w, n, metadata)
+		return w.Visitor.VisitIdentifier(w, n, metadata)
 	case *ast.IfStatement:
-		w.Visitor.VisitIf(w, n, metadata)
+		return w.Visitor.VisitIf(w, n, metadata)
 	case *ast.LabelledStatement:
-		w.Visitor.VisitLabelled(w, n, metadata)
+		return w.Visitor.VisitLabelled(w, n, metadata)
 	case *ast.NewExpression:
-		w.Visitor.VisitNew(w, n, metadata)
+		return w.Visitor.VisitNew(w, n, metadata)
 	case *ast.NullLiteral:
-		w.Visitor.VisitNull(w, n, metadata)
+		return w.Visitor.VisitNull(w, n, metadata)
 	case *ast.NumberLiteral:
-		w.Visitor.VisitNumber(w, n, metadata)
+		return w.Visitor.VisitNumber(w, n, metadata)
 	case *ast.ObjectLiteral:
-		w.Visitor.VisitObject(w, n, metadata)
+		return w.Visitor.VisitObject(w, n, metadata)
 	case *ast.Program:
-		w.Visitor.VisitProgram(w, n, metadata)
+		return w.Visitor.VisitProgram(w, n, metadata)
 	case *ast.ReturnStatement:
-		w.Visitor.VisitReturn(w, n, metadata)
+		return w.Visitor.VisitReturn(w, n, metadata)
 	case *ast.RegExpLiteral:
-		w.Visitor.VisitRegex(w, n, metadata)
+		return w.Visitor.VisitRegex(w, n, metadata)
 	case *ast.SequenceExpression:
-		w.Visitor.VisitSequence(w, n, metadata)
+		return w.Visitor.VisitSequence(w, n, metadata)
 	case *ast.StringLiteral:
-		w.Visitor.VisitString(w, n, metadata)
+		return w.Visitor.VisitString(w, n, metadata)
 	case *ast.SwitchStatement:
-		w.Visitor.VisitSwitch(w, n, metadata)
+		return w.Visitor.VisitSwitch(w, n, metadata)
 	case *ast.ThisExpression:
-		w.Visitor.VisitThis(w, n, metadata)
+		return w.Visitor.VisitThis(w, n, metadata)
 	case *ast.ThrowStatement:
-		w.Visitor.VisitThrow(w, n, metadata)
+		return w.Visitor.VisitThrow(w, n, metadata)
 	case *ast.TryStatement:
-		w.Visitor.VisitTry(w, n, metadata)
+		return w.Visitor.VisitTry(w, n, metadata)
 	case *ast.UnaryExpression:
-		w.Visitor.VisitUnary(w, n, metadata)
+		return w.Visitor.VisitUnary(w, n, metadata)
 	case *ast.VariableExpression:
-		w.Visitor.VisitVariable(w, n, metadata)
+		return w.Visitor.VisitVariable(w, n, metadata)
 	case *ast.VariableStatement:
-		w.Visitor.VisitVariableStatement(w, n, metadata)
+		return w.Visitor.VisitVariableStatement(w, n, metadata)
 	case *ast.WhileStatement:
-		w.Visitor.VisitWhile(w, n, metadata)
+		return w.Visitor.VisitWhile(w, n, metadata)
 	case *ast.WithStatement:
-		w.Visitor.VisitWith(w, n, metadata)
+		return w.Visitor.VisitWith(w, n, metadata)
 	}
+
+	return nil
 }
 
 // VisitorImpl is a default implementation of the Visitor interface
 type VisitorImpl struct {
 }
 
-func (v *VisitorImpl) VisitProgram(w *Walker, node *ast.Program, metadata []Metadata) {
+func (v *VisitorImpl) VisitProgram(w *Walker, node *ast.Program, metadata []Metadata) Metadata {
 	for _, e := range node.Body {
 		w.Walk(e, metadata)
 	}
@@ -176,107 +178,146 @@ func (v *VisitorImpl) VisitProgram(w *Walker, node *ast.Program, metadata []Meta
 			panic(fmt.Errorf("Here be dragons: visit Program.DeclarationList(%T)", value))
 		}
 	}
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitArray(w *Walker, node *ast.ArrayLiteral, metadata []Metadata) {
+func (v *VisitorImpl) VisitArray(w *Walker, node *ast.ArrayLiteral, metadata []Metadata) Metadata {
 	for _, e := range node.Value {
 		w.Walk(e, metadata)
 	}
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitAssign(w *Walker, node *ast.AssignExpression, metadata []Metadata) {
+func (v *VisitorImpl) VisitAssign(w *Walker, node *ast.AssignExpression, metadata []Metadata) Metadata {
 	w.Walk(node.Left, metadata)
 	w.Walk(node.Right, metadata)
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitBad(w *Walker, node *ast.BadExpression, metadata []Metadata) {
+func (v *VisitorImpl) VisitBad(w *Walker, node *ast.BadExpression, metadata []Metadata) Metadata {
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitBadStatement(w *Walker, node *ast.BadStatement, metadata []Metadata) {
+func (v *VisitorImpl) VisitBadStatement(w *Walker, node *ast.BadStatement, metadata []Metadata) Metadata {
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitBinary(w *Walker, node *ast.BinaryExpression, metadata []Metadata) {
+func (v *VisitorImpl) VisitBinary(w *Walker, node *ast.BinaryExpression, metadata []Metadata) Metadata {
 	w.Walk(node.Left, metadata)
 	w.Walk(node.Right, metadata)
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitBlock(w *Walker, node *ast.BlockStatement, metadata []Metadata) {
+func (v *VisitorImpl) VisitBlock(w *Walker, node *ast.BlockStatement, metadata []Metadata) Metadata {
 	for _, value := range node.List {
 		w.Walk(value, metadata)
 	}
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitBoolean(w *Walker, node *ast.BooleanLiteral, metadata []Metadata) {
+func (v *VisitorImpl) VisitBoolean(w *Walker, node *ast.BooleanLiteral, metadata []Metadata) Metadata {
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitBracket(w *Walker, node *ast.BracketExpression, metadata []Metadata) {
+func (v *VisitorImpl) VisitBracket(w *Walker, node *ast.BracketExpression, metadata []Metadata) Metadata {
 	w.Walk(node.Left, metadata)
 	w.Walk(node.Member, metadata)
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitBranch(w *Walker, node *ast.BranchStatement, metadata []Metadata) {
-	w.Walk(node.Label, metadata)
+func (v *VisitorImpl) VisitBranch(w *Walker, node *ast.BranchStatement, metadata []Metadata) Metadata {
+	if node.Label != nil {
+		w.Walk(node.Label, metadata)
+	}
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitCall(w *Walker, node *ast.CallExpression, metadata []Metadata) {
+func (v *VisitorImpl) VisitCall(w *Walker, node *ast.CallExpression, metadata []Metadata) Metadata {
 	w.Walk(node.Callee, metadata)
 	for _, value := range node.ArgumentList {
 		w.Walk(value, metadata)
 	}
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitCase(w *Walker, node *ast.CaseStatement, metadata []Metadata) {
+func (v *VisitorImpl) VisitCase(w *Walker, node *ast.CaseStatement, metadata []Metadata) Metadata {
 	w.Walk(node.Test, metadata)
 	for _, e := range node.Consequent {
 		w.Walk(e, metadata)
 	}
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitCatch(w *Walker, node *ast.CatchStatement, metadata []Metadata) {
+func (v *VisitorImpl) VisitCatch(w *Walker, node *ast.CatchStatement, metadata []Metadata) Metadata {
 	w.Walk(node.Parameter, metadata)
 	w.Walk(node.Body, metadata)
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitConditional(w *Walker, node *ast.ConditionalExpression, metadata []Metadata) {
+func (v *VisitorImpl) VisitConditional(w *Walker, node *ast.ConditionalExpression, metadata []Metadata) Metadata {
 	w.Walk(node.Test, metadata)
 	w.Walk(node.Consequent, metadata)
 	w.Walk(node.Alternate, metadata)
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitDebugger(w *Walker, node *ast.DebuggerStatement, metadata []Metadata) {
+func (v *VisitorImpl) VisitDebugger(w *Walker, node *ast.DebuggerStatement, metadata []Metadata) Metadata {
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitDot(w *Walker, node *ast.DotExpression, metadata []Metadata) {
+func (v *VisitorImpl) VisitDot(w *Walker, node *ast.DotExpression, metadata []Metadata) Metadata {
 	w.Walk(node.Left, metadata)
 	w.Walk(node.Identifier, metadata)
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitDoWhile(w *Walker, node *ast.DoWhileStatement, metadata []Metadata) {
+func (v *VisitorImpl) VisitDoWhile(w *Walker, node *ast.DoWhileStatement, metadata []Metadata) Metadata {
 	w.Walk(node.Test, metadata)
 	w.Walk(node.Body, metadata)
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitEmpty(w *Walker, node *ast.EmptyStatement, metadata []Metadata) {
+func (v *VisitorImpl) VisitEmpty(w *Walker, node *ast.EmptyStatement, metadata []Metadata) Metadata {
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitExpression(w *Walker, node *ast.ExpressionStatement, metadata []Metadata) {
+func (v *VisitorImpl) VisitExpression(w *Walker, node *ast.ExpressionStatement, metadata []Metadata) Metadata {
 	w.Walk(node.Expression, metadata)
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitForIn(w *Walker, node *ast.ForInStatement, metadata []Metadata) {
+func (v *VisitorImpl) VisitForIn(w *Walker, node *ast.ForInStatement, metadata []Metadata) Metadata {
 	w.Walk(node.Into, metadata)
 	w.Walk(node.Source, metadata)
 	w.Walk(node.Body, metadata)
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitFor(w *Walker, node *ast.ForStatement, metadata []Metadata) {
+func (v *VisitorImpl) VisitFor(w *Walker, node *ast.ForStatement, metadata []Metadata) Metadata {
 	w.Walk(node.Initializer, metadata)
 	w.Walk(node.Test, metadata)
 	w.Walk(node.Update, metadata)
 	w.Walk(node.Body, metadata)
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitFunction(w *Walker, node *ast.FunctionLiteral, metadata []Metadata) {
+func (v *VisitorImpl) VisitFunction(w *Walker, node *ast.FunctionLiteral, metadata []Metadata) Metadata {
 	w.Walk(node.Name, metadata)
 	for _, value := range node.ParameterList.List {
 		w.Walk(value, metadata)
@@ -295,95 +336,129 @@ func (v *VisitorImpl) VisitFunction(w *Walker, node *ast.FunctionLiteral, metada
 			panic(fmt.Errorf("Here be dragons: visit Function.declaration(%T)", value))
 		}
 	}
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitIdentifier(w *Walker, node *ast.Identifier, metadata []Metadata) {
+func (v *VisitorImpl) VisitIdentifier(w *Walker, node *ast.Identifier, metadata []Metadata) Metadata {
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitIf(w *Walker, node *ast.IfStatement, metadata []Metadata) {
+func (v *VisitorImpl) VisitIf(w *Walker, node *ast.IfStatement, metadata []Metadata) Metadata {
 	w.Walk(node.Test, metadata)
 	w.Walk(node.Consequent, metadata)
 	w.Walk(node.Alternate, metadata)
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitLabelled(w *Walker, node *ast.LabelledStatement, metadata []Metadata) {
+func (v *VisitorImpl) VisitLabelled(w *Walker, node *ast.LabelledStatement, metadata []Metadata) Metadata {
 	w.Walk(node.Label, metadata)
 	w.Walk(node.Statement, metadata)
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitNew(w *Walker, node *ast.NewExpression, metadata []Metadata) {
+func (v *VisitorImpl) VisitNew(w *Walker, node *ast.NewExpression, metadata []Metadata) Metadata {
 	w.Walk(node.Callee, metadata)
 	for _, e := range node.ArgumentList {
 		w.Walk(e, metadata)
 	}
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitNull(w *Walker, node *ast.NullLiteral, metadata []Metadata) {
+func (v *VisitorImpl) VisitNull(w *Walker, node *ast.NullLiteral, metadata []Metadata) Metadata {
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitNumber(w *Walker, node *ast.NumberLiteral, metadata []Metadata) {
+func (v *VisitorImpl) VisitNumber(w *Walker, node *ast.NumberLiteral, metadata []Metadata) Metadata {
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitObject(w *Walker, node *ast.ObjectLiteral, metadata []Metadata) {
+func (v *VisitorImpl) VisitObject(w *Walker, node *ast.ObjectLiteral, metadata []Metadata) Metadata {
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitReturn(w *Walker, node *ast.ReturnStatement, metadata []Metadata) {
+func (v *VisitorImpl) VisitReturn(w *Walker, node *ast.ReturnStatement, metadata []Metadata) Metadata {
 	w.Walk(node.Argument, metadata)
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitRegex(w *Walker, node *ast.RegExpLiteral, metadata []Metadata) {
+func (v *VisitorImpl) VisitRegex(w *Walker, node *ast.RegExpLiteral, metadata []Metadata) Metadata {
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitSequence(w *Walker, node *ast.SequenceExpression, metadata []Metadata) {
+func (v *VisitorImpl) VisitSequence(w *Walker, node *ast.SequenceExpression, metadata []Metadata) Metadata {
 	for _, e := range node.Sequence {
 		w.Walk(e, metadata)
 	}
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitString(w *Walker, node *ast.StringLiteral, metadata []Metadata) {
-	// No op
+func (v *VisitorImpl) VisitString(w *Walker, node *ast.StringLiteral, metadata []Metadata) Metadata {
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitSwitch(w *Walker, node *ast.SwitchStatement, metadata []Metadata) {
+func (v *VisitorImpl) VisitSwitch(w *Walker, node *ast.SwitchStatement, metadata []Metadata) Metadata {
 	w.Walk(node.Discriminant, metadata)
 	for _, e := range node.Body {
 		w.Walk(e, metadata)
 	}
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitThis(w *Walker, node *ast.ThisExpression, metadata []Metadata) {
+func (v *VisitorImpl) VisitThis(w *Walker, node *ast.ThisExpression, metadata []Metadata) Metadata {
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitThrow(w *Walker, node *ast.ThrowStatement, metadata []Metadata) {
+func (v *VisitorImpl) VisitThrow(w *Walker, node *ast.ThrowStatement, metadata []Metadata) Metadata {
 	w.Walk(node.Argument, metadata)
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitTry(w *Walker, node *ast.TryStatement, metadata []Metadata) {
+func (v *VisitorImpl) VisitTry(w *Walker, node *ast.TryStatement, metadata []Metadata) Metadata {
 	w.Walk(node.Body, metadata)
 	w.Walk(node.Catch, metadata)
 	w.Walk(node.Finally, metadata)
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitUnary(w *Walker, node *ast.UnaryExpression, metadata []Metadata) {
+func (v *VisitorImpl) VisitUnary(w *Walker, node *ast.UnaryExpression, metadata []Metadata) Metadata {
 	w.Walk(node.Operand, metadata)
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitVariable(w *Walker, node *ast.VariableExpression, metadata []Metadata) {
+func (v *VisitorImpl) VisitVariable(w *Walker, node *ast.VariableExpression, metadata []Metadata) Metadata {
 	w.Walk(node.Initializer, metadata)
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitVariableStatement(w *Walker, node *ast.VariableStatement, metadata []Metadata) {
+func (v *VisitorImpl) VisitVariableStatement(w *Walker, node *ast.VariableStatement, metadata []Metadata) Metadata {
 	for _, e := range node.List {
 		w.Walk(e, metadata)
 	}
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitWhile(w *Walker, node *ast.WhileStatement, metadata []Metadata) {
+func (v *VisitorImpl) VisitWhile(w *Walker, node *ast.WhileStatement, metadata []Metadata) Metadata {
 	w.Walk(node.Test, metadata)
 	w.Walk(node.Body, metadata)
+
+	return CurrentMetadata(metadata)
 }
 
-func (v *VisitorImpl) VisitWith(w *Walker, node *ast.WithStatement, metadata []Metadata) {
+func (v *VisitorImpl) VisitWith(w *Walker, node *ast.WithStatement, metadata []Metadata) Metadata {
 	w.Walk(node.Object, metadata)
 	w.Walk(node.Body, metadata)
+
+	return CurrentMetadata(metadata)
 }

--- a/walk/walker_test.go
+++ b/walk/walker_test.go
@@ -45,7 +45,7 @@ func TestWalker(t *testing.T) {
 			t.Errorf("[%v] Failed, number of ancestors not correct, %v != %v", i, test.size, len(visitor.ancestors))
 		}
 
-		parent := visitor.ancestors[len(visitor.ancestors)-2].Parent
+		parent := visitor.ancestors[len(visitor.ancestors)-2].Parent()
 		typeOfParent := reflect.TypeOf(parent)
 
 		if test.parent != typeOfParent {

--- a/walk/walker_test.go
+++ b/walk/walker_test.go
@@ -12,8 +12,10 @@ type testVisitor struct {
 	ancestors []Metadata
 }
 
-func (v *testVisitor) VisitIdentifier(w *Walker, node *ast.Identifier, metadata []Metadata) {
+func (v *testVisitor) VisitIdentifier(w *Walker, node *ast.Identifier, metadata []Metadata) Metadata {
 	v.ancestors = metadata
+
+	return CurrentMetadata(metadata)
 }
 
 func TestWalker(t *testing.T) {

--- a/walk/walker_test.go
+++ b/walk/walker_test.go
@@ -1,0 +1,55 @@
+package walk
+
+import (
+	"github.com/robertkrimen/otto/ast"
+	"github.com/robertkrimen/otto/parser"
+	"reflect"
+	"testing"
+)
+
+type testVisitor struct {
+	VisitorImpl
+	ancestors []Metadata
+}
+
+func (v *testVisitor) VisitIdentifier(w *Walker, node *ast.Identifier, metadata []Metadata) {
+	v.ancestors = metadata
+}
+
+func TestWalker(t *testing.T) {
+	tests := []struct {
+		src    string
+		size   int
+		parent reflect.Type
+	}{
+		{`1 + b`, 5, reflect.TypeOf((*ast.BinaryExpression)(nil))},
+		{`c++`, 5, reflect.TypeOf((*ast.UnaryExpression)(nil))},
+		{`function fun(){}`, 4, reflect.TypeOf((*ast.FunctionLiteral)(nil))},
+		{`while(i){}`, 4, reflect.TypeOf((*ast.WhileStatement)(nil))},
+		{`if(i){}`, 4, reflect.TypeOf((*ast.IfStatement)(nil))},
+		{`with(i){}`, 4, reflect.TypeOf((*ast.WithStatement)(nil))},
+		{`switch(i){}`, 4, reflect.TypeOf((*ast.SwitchStatement)(nil))},
+	}
+
+	for i, test := range tests {
+		program, err := parser.ParseFile(nil, "", test.src, 0)
+		if err != nil {
+			t.Errorf("[%v] Failed, %v", i, err)
+		}
+
+		visitor := &testVisitor{}
+		walker := Walker{visitor}
+		walker.Begin(program)
+
+		if test.size != len(visitor.ancestors) {
+			t.Errorf("[%v] Failed, number of ancestors not correct, %v != %v", i, test.size, len(visitor.ancestors))
+		}
+
+		parent := visitor.ancestors[len(visitor.ancestors)-2].Parent
+		typeOfParent := reflect.TypeOf(parent)
+
+		if test.parent != typeOfParent {
+			t.Errorf("[%v] Failed, parent not correct, %v != %v", i, test.parent, typeOfParent)
+		}
+	}
+}

--- a/walk/walker_test.go
+++ b/walk/walker_test.go
@@ -26,7 +26,7 @@ func TestWalker(t *testing.T) {
 	}{
 		{`1 + b`, 5, reflect.TypeOf((*ast.BinaryExpression)(nil))},
 		{`c++`, 5, reflect.TypeOf((*ast.UnaryExpression)(nil))},
-		{`function fun(){}`, 4, reflect.TypeOf((*ast.FunctionLiteral)(nil))},
+		{`function fun(){}`, 5, reflect.TypeOf((*ast.FunctionLiteral)(nil))},
 		{`while(i){}`, 4, reflect.TypeOf((*ast.WhileStatement)(nil))},
 		{`if(i){}`, 4, reflect.TypeOf((*ast.IfStatement)(nil))},
 		{`with(i){}`, 4, reflect.TypeOf((*ast.WithStatement)(nil))},
@@ -47,7 +47,7 @@ func TestWalker(t *testing.T) {
 			t.Errorf("[%v] Failed, number of ancestors not correct, %v != %v", i, test.size, len(visitor.ancestors))
 		}
 
-		parent := visitor.ancestors[len(visitor.ancestors)-2].Parent()
+		parent := visitor.ancestors[len(visitor.ancestors)-2].Node()
 		typeOfParent := reflect.TypeOf(parent)
 
 		if test.parent != typeOfParent {


### PR DESCRIPTION
This pull request adds walk functionality for the AST.

I considered a simpler design, like the walker/visitor implementation from golang itself. But the order in which the nodes are walked is fixed. My solution is more flexible. 
In this solution, the default implementation has a default order, but can be overridden by sub types.
The amount of work to implement a visitor is almost the same as the golang version, but requires more functions(as the design dictates).