### PR TITLE
value.ToStruct()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,6 @@
+
+Original author: Robert Krimen github.com/robertkrimen
+
+Currator: Robert Doiel github.com/rsdoiel
+
+

--- a/value.go
+++ b/value.go
@@ -1,6 +1,7 @@
 package otto
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"reflect"
@@ -1022,4 +1023,30 @@ func stringToReflectValue(value string, kind reflect.Kind) (reflect.Value, error
 
 	// FIXME This should end up as a TypeError?
 	panic(fmt.Errorf("invalid conversion of %q to reflect.Kind: %v", value, kind))
+}
+
+// ToStruct will attempt populate a struct passed in as a parameter.
+//
+// ToStruct returns an error if it runs into a problem.
+//
+// Example:
+// a := struct{One int, Two string}{}
+// val, _ := vm.Run(`(function (){ return {One: 1, Two: "two"}}())`)
+// _ := val.ToSruct(&a)
+// fmt.Printf("One: %d, Two: %s\n", a.One, a.Two)
+//
+func (value Value) ToStruct(aStruct interface{}) error {
+	raw, err := value.Export()
+	if err != nil {
+		return fmt.Errorf("failed to export value, %s", err)
+	}
+	src, err := json.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("failed to marshal value, %s", err)
+	}
+	err = json.Unmarshal(src, &aStruct)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal value, %s", err)
+	}
+	return nil
 }

--- a/value_test.go
+++ b/value_test.go
@@ -289,3 +289,31 @@ func Test_toReflectValue(t *testing.T) {
 		is(err, nil)
 	})
 }
+
+func Test_toStructValue(t *testing.T) {
+	tt(t, func() {
+		vm := New()
+		jsSrc := `(function () {return {one: 1, two: "Two", three: 3.0, four: [1,2,3,4], five: true};}())`
+		aStruct := struct {
+			One   int     `json:"one"`
+			Two   string  `json:"two"`
+			Three float32 `json:"three"`
+			Four  []int   `json:"four"`
+			Five  bool    `json:"five"`
+		}{}
+
+		val, err := vm.Run(jsSrc)
+		is(err, nil)
+		err = val.ToStruct(&aStruct)
+		is(err, nil)
+		is(aStruct.One, 1)
+		is(aStruct.Two, "Two")
+		is(aStruct.Three, 3.0)
+		is(len(aStruct.Four), 4)
+		is(aStruct.Four[0], 1)
+		is(aStruct.Four[1], 2)
+		is(aStruct.Four[2], 3)
+		is(aStruct.Four[3], 4)
+		is(aStruct.Five, true)
+	})
+}


### PR DESCRIPTION
I added a convenience function to value called ToStruct. It wraps an value.Export() with a json.Marshal(), json.Unmarshal() call to populate a struct.  Here's how it might be used.

aStruct := {
   One: 1 `json:"one"`
   Two: "Two" `json:"two"`
}{}

val, _ := vm.Run(`(function(){ return { one: 1, two: "two"};}())`)
err := val.ToStruct(&aStruct)

fmt.Printf("One: %d, Two: %s\n", aStruct.One, aStruct.Two)
