### PR TITLE
Add init() in math

### DIFF
--- a/builtin_math.go
+++ b/builtin_math.go
@@ -3,10 +3,13 @@ package otto
 import (
 	"math"
 	"math/rand"
+	"time"
 )
 
 // Math
-
+func init() {
+	rand.Seed(int64(time.Now().Nanosecond()))
+}
 func builtinMath_abs(call FunctionCall) Value {
 	number := call.Argument(0).float64()
 	return toValue_float64(math.Abs(number))


### PR DESCRIPTION
Add func init() for Math.random() always return  random number  at each start.