### PR TITLE
Improve performance to sort array with the same values

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -321,9 +321,11 @@ func TestArray_sort(t *testing.T) {
             stu = [1,5,-10, 100, 8, 72, 401, 0.05].sort(function(x, y){
                 return x == y ? 0 : x < y ? -1 : 1
             });
+            vwx = [1,2,3,1,2,3].sort();
+            yza = [1,2,3,1,0,1,-1,0].sort();
 
-            [ abc, def, ghi, jkl, mno, pqr, stu ].join(";");
-        `, "0,1,2,3;0,1,2,3;;0;0,1;-10,0.05,1,100,401,5,72,8;-10,0.05,1,5,8,72,100,401")
+            [ abc, def, ghi, jkl, mno, pqr, stu, vwx, yza ].join(";");
+        `, "0,1,2,3;0,1,2,3;;0;0,1;-10,0.05,1,100,401,5,72,8;-10,0.05,1,5,8,72,100,401;1,1,2,2,3,3;-1,0,0,1,1,1,2,3")
 
 		test(`Array.prototype.sort.length`, 1)
 	})

--- a/builtin_array.go
+++ b/builtin_array.go
@@ -416,27 +416,33 @@ func arraySortSwap(thisObject *_object, index0, index1 uint) {
 	}
 }
 
-func arraySortQuickPartition(thisObject *_object, left, right, pivot uint, compare *_object) uint {
+func arraySortQuickPartition(thisObject *_object, left, right, pivot uint, compare *_object) (uint, uint) {
 	arraySortSwap(thisObject, pivot, right) // Right is now the pivot value
 	cursor := left
+	cursor2 := left
 	for index := left; index < right; index++ {
-		if sortCompare(thisObject, index, right, compare) < 0 { // Compare to the pivot value
+		comparison := sortCompare(thisObject, index, right, compare) // Compare to the pivot value
+		if comparison < 0 {
 			arraySortSwap(thisObject, index, cursor)
 			cursor += 1
+			cursor2 += 1
+		} else if comparison == 0 {
+			arraySortSwap(thisObject, index, cursor2)
+			cursor2 += 1
 		}
 	}
 	arraySortSwap(thisObject, cursor, right)
-	return cursor
+	return cursor, cursor2
 }
 
 func arraySortQuickSort(thisObject *_object, left, right uint, compare *_object) {
 	if left < right {
-		pivot := left + (right-left)/2
-		pivot = arraySortQuickPartition(thisObject, left, right, pivot, compare)
+		middle := left + (right-left)/2
+		pivot, pivot2 := arraySortQuickPartition(thisObject, left, right, middle, compare)
 		if pivot > 0 {
 			arraySortQuickSort(thisObject, left, pivot-1, compare)
 		}
-		arraySortQuickSort(thisObject, pivot+1, right, compare)
+		arraySortQuickSort(thisObject, pivot2+1, right, compare)
 	}
 }
 

--- a/builtin_array.go
+++ b/builtin_array.go
@@ -424,6 +424,9 @@ func arraySortQuickPartition(thisObject *_object, left, right, pivot uint, compa
 		comparison := sortCompare(thisObject, index, right, compare) // Compare to the pivot value
 		if comparison < 0 {
 			arraySortSwap(thisObject, index, cursor)
+			if cursor < cursor2 {
+				arraySortSwap(thisObject, index, cursor2)
+			}
 			cursor += 1
 			cursor2 += 1
 		} else if comparison == 0 {
@@ -431,7 +434,7 @@ func arraySortQuickPartition(thisObject *_object, left, right, pivot uint, compa
 			cursor2 += 1
 		}
 	}
-	arraySortSwap(thisObject, cursor, right)
+	arraySortSwap(thisObject, cursor2, right)
 	return cursor, cursor2
 }
 


### PR DESCRIPTION
Currently, `builtinArray_sort()` is O(n^2) operation if `sortCompare()` always returns 0.
It is common to deal with sparse arrays (almost all values are 0)
and this PR will improve performance in these cases.

```js
// sort.js
var array = new Array(1000).join('0').split('');
var count = 0;
array.sort(function (a, b) {
  count++;
  return a - b;
});
console.log(count);
```

```sh
$ time node sort.js
998

real    0m0.141s
user    0m0.000s
sys     0m0.000s

$ time otto sort.js
498501

real    0m3.627s
user    0m0.000s
sys     0m0.000s

$ time otto/otto sort.js # this version
998

real    0m0.059s
user    0m0.000s
sys     0m0.000s
```
