### PR TITLE
support the non-standard Error.stack property

### DIFF
--- a/builtin_error.go
+++ b/builtin_error.go
@@ -5,11 +5,11 @@ import (
 )
 
 func builtinError(call FunctionCall) Value {
-	return toValue_object(call.runtime.newError("", call.Argument(0)))
+	return toValue_object(call.runtime.newError("Error", call.Argument(0)))
 }
 
 func builtinNewError(self *_object, argumentList []Value) Value {
-	return toValue_object(self.runtime.newError("", valueOfArrayIndex(argumentList, 0)))
+	return toValue_object(self.runtime.newError("Error", valueOfArrayIndex(argumentList, 0)))
 }
 
 func builtinError_toString(call FunctionCall) Value {

--- a/error.go
+++ b/error.go
@@ -32,6 +32,24 @@ type _error struct {
 	offset int
 }
 
+func (err _error) format() string {
+	if len(err.name) == 0 {
+		return err.message
+	}
+	if len(err.message) == 0 {
+		return err.name
+	}
+	return fmt.Sprintf("%s: %s", err.name, err.message)
+}
+
+func (err _error) formatWithStack() string {
+	str := err.format() + "\n"
+	for _, frame := range err.trace {
+		str += "    at " + frame.location() + "\n"
+	}
+	return str
+}
+
 type _frame struct {
 	file   *file.File
 	offset int
@@ -98,13 +116,7 @@ type Error struct {
 //    TypeError: 'def' is not a function
 //
 func (err Error) Error() string {
-	if len(err.name) == 0 {
-		return err.message
-	}
-	if len(err.message) == 0 {
-		return err.name
-	}
-	return fmt.Sprintf("%s: %s", err.name, err.message)
+	return err.format()
 }
 
 // String returns a description of the error and a trace of where the
@@ -115,11 +127,7 @@ func (err Error) Error() string {
 //        at <anonymous>:7:1/
 //
 func (err Error) String() string {
-	str := err.Error() + "\n"
-	for _, frame := range err.trace {
-		str += "    at " + frame.location() + "\n"
-	}
-	return str
+	return err.formatWithStack()
 }
 
 func (err _error) describe(format string, in ...interface{}) string {

--- a/error_test.go
+++ b/error_test.go
@@ -435,3 +435,31 @@ func TestMakeSyntaxError(t *testing.T) {
 		is(er.message, "i think you meant \"you're\"")
 	})
 }
+
+func TestErrorStackProperty(t *testing.T) {
+	tt(t, func() {
+		vm := New()
+
+		s, err := vm.Compile("test.js", `
+			function A() { throw new TypeError('uh oh'); }
+			function B() { return A(); }
+			function C() { return B(); }
+
+			var s = null;
+
+			try { C(); } catch (e) { s = e.stack; }
+
+			s;
+		`)
+		if err != nil {
+			panic(err)
+		}
+
+		v, err := vm.Run(s)
+		if err != nil {
+			panic(err)
+		}
+
+		is(v.String(), "TypeError: uh oh\n    at A (test.js:2:29)\n    at B (test.js:3:26)\n    at C (test.js:4:26)\n    at test.js:8:10\n")
+	})
+}

--- a/type_error.go
+++ b/type_error.go
@@ -9,5 +9,16 @@ func (rt *_runtime) newErrorObject(name string, message Value) *_object {
 	} else {
 		self.value = newError(rt, name)
 	}
+
+	self.defineOwnProperty("stack", _property{
+		value: _propertyGetSet{
+			rt.newNativeFunction("get", func(FunctionCall) Value {
+				return toValue_string(self.value.(_error).formatWithStack())
+			}),
+			&_nilGetSetObject,
+		},
+		mode: modeConfigureMask & modeOnMask,
+	}, false)
+
 	return self
 }


### PR DESCRIPTION
Popular runtimes (V8 [1], SpiderMonkey [2], IE [3]) support a `stack`
property on Error objects to get the error's stack as a string.

This change adds support to otto for this same feature. It's implemented
in a similar way to V8, using a getter function. This avoids generating
the stack trace (which is done in a loop with string manipulation etc)
unless the user requests it. There's no standard, or even trend, for the
actual _content_ of `stack`, so we basically just copy what V8's traces
look like.

[1]: https://github.com/v8/v8/wiki/Stack%20Trace%20API
[2]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Error/stack
[3]: http://msdn.microsoft.com/en-us/library/windows/apps/hh699850.aspx