### PR TITLE
add error creator functions

### DIFF
--- a/otto.go
+++ b/otto.go
@@ -379,6 +379,30 @@ func (self Otto) SetStackDepthLimit(limit int) {
 	self.runtime.stackLimit = limit
 }
 
+// MakeCustomError creates a new Error object with the given name and message,
+// returning it as a Value.
+func (self Otto) MakeCustomError(name, message string) Value {
+	return self.runtime.toValue(self.runtime.newError(name, self.runtime.toValue(message)))
+}
+
+// MakeRangeError creates a new RangeError object with the given message,
+// returning it as a Value.
+func (self Otto) MakeRangeError(message string) Value {
+	return self.runtime.toValue(self.runtime.newRangeError(self.runtime.toValue(message)))
+}
+
+// MakeSyntaxError creates a new SyntaxError object with the given message,
+// returning it as a Value.
+func (self Otto) MakeSyntaxError(message string) Value {
+	return self.runtime.toValue(self.runtime.newSyntaxError(self.runtime.toValue(message)))
+}
+
+// MakeTypeError creates a new TypeError object with the given message,
+// returning it as a Value.
+func (self Otto) MakeTypeError(message string) Value {
+	return self.runtime.toValue(self.runtime.newTypeError(self.runtime.toValue(message)))
+}
+
 // Context is a structure that contains information about the current execution
 // context.
 type Context struct {


### PR DESCRIPTION
This change adds a handful of functions to `otto.Otto` type that make
it easier to create proper `Error` values from native code. Previously,
the only way to do this was to call the error's constructor from
JavaScript like `vm.Call("TypeError", "message")`. `Call` can fail for
various reasons, and also modifies the current call stack.

These new functions can't fail, and since they don't involve any
JavaScript execution, won't modify the call stack. The new functions
are:

* `MakeCustomError(name, message string) Value`
* `MakeRangeError(message string) Value`
* `MakeSyntaxError(message string) Value`
* `MakeTypeError(message string) Value`

`MakeCustomError` creates an `Error` object with a specific `name` value.
The other functions cover some common error types, and call specific
functions in the runtime to construct errors with the correct prototypes.
If we need to implement any other error types, it'll mostly be copy/paste.