### PR TITLE
Allow console.log() to write to injected io.Writer, not hard-coded to os.Stdout

### DIFF
--- a/console.go
+++ b/console.go
@@ -2,7 +2,6 @@ package otto
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
@@ -15,12 +14,12 @@ func formatForConsole(argumentList []Value) string {
 }
 
 func builtinConsole_log(call FunctionCall) Value {
-	fmt.Fprintln(os.Stdout, formatForConsole(call.ArgumentList))
+	fmt.Fprintln(call.runtime.console, formatForConsole(call.ArgumentList))
 	return Value{}
 }
 
 func builtinConsole_error(call FunctionCall) Value {
-	fmt.Fprintln(os.Stdout, formatForConsole(call.ArgumentList))
+	fmt.Fprintln(call.runtime.console, formatForConsole(call.ArgumentList))
 	return Value{}
 }
 

--- a/global.go
+++ b/global.go
@@ -1,6 +1,7 @@
 package otto
 
 import (
+	"os"
 	"strconv"
 	"time"
 )
@@ -52,6 +53,8 @@ func newContext() *_runtime {
 
 	self.eval = self.globalObject.property["eval"].value.(Value).value.(*_object)
 	self.globalObject.prototype = self.global.ObjectPrototype
+
+	self.console = os.Stdout
 
 	return self
 }

--- a/otto.go
+++ b/otto.go
@@ -225,6 +225,7 @@ package otto
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/robertkrimen/otto/registry"
@@ -361,6 +362,10 @@ func (self Otto) setValue(name string, value Value) {
 
 func (self Otto) SetDebuggerHandler(fn func(vm *Otto)) {
 	self.runtime.debugger = fn
+}
+
+func (self Otto) SetConsoleWriter(w io.Writer) {
+	self.runtime.console = w
 }
 
 func (self Otto) SetRandomSource(fn func() float64) {

--- a/runtime.go
+++ b/runtime.go
@@ -3,6 +3,7 @@ package otto
 import (
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"reflect"
 	"sync"
@@ -55,6 +56,7 @@ type _runtime struct {
 	otto         *Otto
 	eval         *_object // The builtin eval, for determine indirect versus direct invocation
 	debugger     func(*Otto)
+	console      io.Writer
 	random       func() float64
 	stackLimit   int
 


### PR DESCRIPTION
This would be a huge win for my personal use case. The change does not alter the existing api/behavior, and all tests pass.

Added `func (self Otto) SetConsoleWriter(w io.Writer)` to allow access to changing from the default (Stdout).