### PR TITLE
Fix for #202

### DIFF
--- a/error.go
+++ b/error.go
@@ -142,7 +142,7 @@ func newError(rt *_runtime, name string, stackFramesToPop int, in ...interface{}
 	description := ""
 	length := len(in)
 
-	if rt != nil {
+	if rt != nil && rt.scope != nil {
 		scope := rt.scope
 
 		for i := 0; i < stackFramesToPop; i++ {

--- a/error_test.go
+++ b/error_test.go
@@ -334,6 +334,20 @@ func TestMakeCustomError(t *testing.T) {
 	})
 }
 
+func TestMakeCustomErrorFreshVM(t *testing.T) {
+	tt(t, func() {
+		vm := New()
+		e := vm.MakeCustomError("CarrotError", "carrots is life, carrots is love")
+
+		str, err := e.ToString()
+		if err != nil {
+			panic(err)
+		}
+
+		is(str, "CarrotError: carrots is life, carrots is love")
+	})
+}
+
 func TestMakeTypeError(t *testing.T) {
 	tt(t, func() {
 		vm := New()


### PR DESCRIPTION
See #202 - newError() was crashing on new Otto instances, because `rt.scope` was nil.