### PR TITLE
fix for casting GoArrays on in convertCallParameter

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -352,20 +352,52 @@ func (self *_runtime) convertCallParameter(v Value, t reflect.Type) reflect.Valu
 
 				tt := t.Elem()
 
-				for i := int64(0); i < l; i++ {
-					p, ok := o.property[strconv.FormatInt(i, 10)]
-					if !ok {
-						continue
+				if o.class == "Array" {
+					for i := int64(0); i < l; i++ {
+						p, ok := o.property[strconv.FormatInt(i, 10)]
+						if !ok {
+							continue
+						}
+
+						e, ok := p.value.(Value)
+						if !ok {
+							continue
+						}
+
+						ev := self.convertCallParameter(e, tt)
+
+						s.Index(int(i)).Set(ev)
+					}
+				} else if o.class == "GoArray" {
+
+					var gslice bool
+					switch o.value.(type) {
+					case *_goSliceObject:
+						gslice = true
+					case *_goArrayObject:
+						gslice = false
 					}
 
-					e, ok := p.value.(Value)
-					if !ok {
-						continue
+					for i := int64(0); i < l; i++ {
+						var p *_property
+						if gslice {
+							p = goSliceGetOwnProperty(o, strconv.FormatInt(i, 10))
+						} else {
+							p = goArrayGetOwnProperty(o, strconv.FormatInt(i, 10))
+						}
+						if p == nil {
+							continue
+						}
+
+						e, ok := p.value.(Value)
+						if !ok {
+							continue
+						}
+
+						ev := self.convertCallParameter(e, tt)
+
+						s.Index(int(i)).Set(ev)
 					}
-
-					ev := self.convertCallParameter(e, tt)
-
-					s.Index(int(i)).Set(ev)
 				}
 
 				return s

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -832,3 +832,28 @@ func Test_random(t *testing.T) {
 		is(f1 == f2, false)
 	})
 }
+
+func Test_stringArray(t *testing.T) {
+	getStrings := func() []string {
+		return []string{"these", "are", "strings"}
+	}
+	concatStrings := func(a []string) string {
+		if len(a) == 0 {
+			return ""
+		}
+		r := a[0]
+		for i := 1; i < len(a); i++ {
+			r += " "
+			r += a[i]
+		}
+		return r
+	}
+	tt(t, func() {
+		vm := New()
+		vm.Set("getStrings", getStrings)
+		vm.Set("concatStrings", concatStrings)
+		r1, err := vm.Run(`var a = getStrings(); concatStrings(a)`)
+		is(err, nil)
+		is(r1, "these are strings")
+	})
+}


### PR DESCRIPTION
How to recreate the issue:
-From javascript, call a Go function that returns `[]string`, and store in a javascript variable.
-Pass that value, unmodified, to another Go function that takes `[]string` as a parameter.
-The parameter will be the correct length but will be all empty strings.

I ran into this issue with other types of arrays as well.

Stepping through the code, I found that arrays constructed in the otto environment have `class` = "Array", and have `properties` filled with values, using index "0", "1", "2", and so on.  My array created in Go has `class` = "GoArray", and does not have properties.  Inside `convertCallParameter`, inside the `case reflect.Slice` portion of the main switch statement, inside the loop, the existing code refers to `o.property[...]`, which has no elements for a GoArray.

My fix uses a separate loop for GoArray.  I built it with support for either `_goSliceObject` or `_goArrayObject`, although in all my tests it was always a `_goSliceObject`.