### PR TITLE
Handle []uint16 to boolean conversion (resolves #232)

### DIFF
--- a/value_boolean.go
+++ b/value_boolean.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"unicode/utf16"
 )
 
 func (value Value) bool() bool {
@@ -32,6 +33,8 @@ func (value Value) bool() bool {
 		return true
 	case string:
 		return 0 != len(value)
+	case []uint16:
+		return 0 != len(utf16.Decode(value))
 	}
 	if value.IsObject() {
 		return true

--- a/value_test.go
+++ b/value_test.go
@@ -98,6 +98,8 @@ func TestToBoolean(t *testing.T) {
 		//is(toValue(newObject()), true)
 		is(UndefinedValue(), false)
 		is(NullValue(), false)
+		is([]uint16{}, false)
+		is([]uint16{0x68, 0x65, 0x6c, 0x6c, 0x6f}, true)
 	})
 }
 


### PR DESCRIPTION
As mentioned in #232:

> From looking at value_string.go, it looks like value_boolean.go should be handling []uint16 as a UTF-16 string and returning true for length > 0, false otherwise.