### PR TITLE
Replaced './terst' relative import with qualified name.

### DIFF
--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -1,10 +1,10 @@
 package parser
 
 import (
-	"../terst"
 	"testing"
 
 	"github.com/robertkrimen/otto/file"
+	"github.com/robertkrimen/otto/terst"
 	"github.com/robertkrimen/otto/token"
 )
 

--- a/testing_test.go
+++ b/testing_test.go
@@ -1,11 +1,12 @@
 package otto
 
 import (
-	"./terst"
 	"errors"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/robertkrimen/otto/terst"
 )
 
 func tt(t *testing.T, arguments ...func()) {

--- a/underscore_test.go
+++ b/underscore_test.go
@@ -1,9 +1,9 @@
 package otto
 
 import (
-	"./terst"
 	"testing"
 
+	"github.com/robertkrimen/otto/terst"
 	"github.com/robertkrimen/otto/underscore"
 )
 


### PR DESCRIPTION
This fixes #207 replacing the `./terst` relative import with `github.com/robertkrimen/otto/terst`.