### PR TITLE
Use stack depth limit when exporting values

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -210,7 +210,7 @@ func (self *_runtime) safeToValue(value interface{}) (Value, error) {
 // convertNumeric converts numeric parameter val from js to that of type t if it is safe to do so, otherwise it panics.
 // This allows literals (int64), bitwise values (int32) and the general form (float64) of javascript numerics to be passed as parameters to go functions easily.
 func (self *_runtime) convertNumeric(v Value, t reflect.Type) reflect.Value {
-	val := reflect.ValueOf(v.export())
+	val := reflect.ValueOf(v.export(0))
 
 	if val.Kind() == t.Kind() {
 		return val
@@ -302,7 +302,7 @@ func (self *_runtime) convertCallParameter(v Value, t reflect.Type) reflect.Valu
 	}
 
 	if t.Kind() == reflect.Interface {
-		e := v.export()
+		e := v.export(0)
 		if e == nil {
 			return reflect.Zero(t)
 		}


### PR DESCRIPTION
Consider the following JS executed by Otto:

```js
(function () {
	var obj = {foo: "bar"};
	obj.ob = obj;
	return obj;
})()
```

Calling `value.Export()` on the output of `vm.Run(code)` results in a

```
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow

runtime stack:
runtime.throw(0xeb62e7, 0xe)
  /usr/local/go/src/runtime/panic.go:596 +0x95
runtime.newstack(0x0)
  /usr/local/go/src/runtime/stack.go:1089 +0x3f2
runtime.morestack()
  /usr/local/go/src/runtime/asm_amd64.s:398 +0x86

goroutine 7593219 [running]:
github.com/robertkrimen/otto.(*_object).getProperty(0xc4207901e0, 0xc420e039ad, 0x3, 0x0)
  github.com/robertkrimen/otto/object.go:36 +0x60 fp=0xc442e70370 sp=0xc442e70368
github.com/robertkrimen/otto.objectGet(0xc4207901e0, 0xc420e039ad, 0x3, 0x30, 0xe67860, 0x0)
  github.com/robertkrimen/otto/object_class.go:192 +0x43 fp=0xc442e703b8 sp=0xc442e70370
github.com/robertkrimen/otto.(*_object).get(0xc4207901e0, 0xc420e039ad, 0x3, 0x40f562, 0xc4254268c0, 0x20)
  github.com/robertkrimen/otto/object.go:42 +0x47 fp=0xc442e703f8 sp=0xc442e703b8
github.com/robertkrimen/otto.Value.export.func1(0xc420e039ad, 0x3, 0xc420e039ad)
  github.com/robertkrimen/otto/value.go:725 +0x4b fp=0xc442e70460 sp=0xc442e703f8
github.com/robertkrimen/otto.objectEnumerate(0xc4207901e0, 0x0, 0xc4254268c0)
  github.com/robertkrimen/otto/object_class.go:25 +0x89 fp=0xc442e704c0 sp=0xc442e70460
github.com/robertkrimen/otto.(*_object).enumerate(0xc4207901e0, 0xc425426800, 0xc4254268c0)
  github.com/robertkrimen/otto/object.go:118 +0x46 fp=0xc442e704e8 sp=0xc442e704c0
github.com/robertkrimen/otto.Value.export(0x5, 0xe8d8c0, 0xc4207901e0, 0x5, 0xe8d8c0)
  github.com/robertkrimen/otto/value.go:730 +0x801 fp=0xc442e70690 sp=0xc442e704e8
github.com/robertkrimen/otto.Value.export.func1(0xc420e039ad, 0x3, 0xc420e039ad)
  github.com/robertkrimen/otto/value.go:727 +0x95 fp=0xc442e706f8 sp=0xc442e70690
github.com/robertkrimen/otto.objectEnumerate(0xc4207901e0, 0x0, 0xc425426880)
  github.com/robertkrimen/otto/object_class.go:25 +0x89 fp=0xc442e70758 sp=0xc442e706f8
github.com/robertkrimen/otto.(*_object).enumerate(0xc4207901e0, 0xc425426800, 0xc425426880)
  github.com/robertkrimen/otto/object.go:118 +0x46 fp=0xc442e70780 sp=0xc442e70758
etc...
```

This pull request resolves this problem similar to #168.

Let me know if you'd like to see any changes. 