### PR TITLE
Add a an ast.Walk utility function

### DIFF
--- a/ast/walk.go
+++ b/ast/walk.go
@@ -1,0 +1,225 @@
+package ast
+
+import "fmt"
+
+// Visitor Visit method is invoked for each node encountered by Walk.
+// If the result visitor w is not nil, Walk visits each of the children
+// of node with the visitor v, followed by a call of v.Visit(nil).
+type Visitor interface {
+	Visit(n Node) (v Visitor)
+}
+
+// VisitorFunc is a helper method to use the function as the visitor. Refer to
+// Visitor documentation.
+type VisitorFunc func(Visitor, Node) Visitor
+
+// Visit method is invoked for each node encountered by Walk.
+func (vf VisitorFunc) Visit(n Node) Visitor {
+	return vf(vf, n)
+}
+
+// Walk traverses an AST in depth-first order: It starts by calling
+// v.Visit(node); node must not be nil. If the visitor v returned by
+// v.Visit(node) is not nil, Walk is invoked recursively with visitor
+// v for each of the non-nil children of node, followed by a call
+// of v.Visit(nil).
+func Walk(v Visitor, n Node) {
+	if n == nil {
+		return
+	}
+	if v = v.Visit(n); v == nil {
+		return
+	}
+
+	switch n := n.(type) {
+	case *ArrayLiteral:
+		if n != nil {
+			for _, ex := range n.Value {
+				Walk(v, ex)
+			}
+		}
+	case *AssignExpression:
+		if n != nil {
+			Walk(v, n.Left)
+			Walk(v, n.Right)
+		}
+	case *BadExpression:
+	case *BinaryExpression:
+		if n != nil {
+			Walk(v, n.Left)
+			Walk(v, n.Right)
+		}
+	case *BlockStatement:
+		if n != nil {
+			for _, s := range n.List {
+				Walk(v, s)
+			}
+		}
+	case *BooleanLiteral:
+	case *BracketExpression:
+		if n != nil {
+			Walk(v, n.Left)
+			Walk(v, n.Member)
+		}
+	case *BranchStatement:
+		if n != nil {
+			Walk(v, n.Label)
+		}
+	case *CallExpression:
+		if n != nil {
+			Walk(v, n.Callee)
+			for _, a := range n.ArgumentList {
+				Walk(v, a)
+			}
+		}
+	case *CaseStatement:
+		if n != nil {
+			Walk(v, n.Test)
+			for _, c := range n.Consequent {
+				Walk(v, c)
+			}
+		}
+	case *CatchStatement:
+		if n != nil {
+			Walk(v, n.Parameter)
+			Walk(v, n.Body)
+		}
+	case *ConditionalExpression:
+		if n != nil {
+			Walk(v, n.Test)
+			Walk(v, n.Consequent)
+			Walk(v, n.Alternate)
+		}
+	case *DebuggerStatement:
+	case *DoWhileStatement:
+		if n != nil {
+			Walk(v, n.Test)
+			Walk(v, n.Body)
+		}
+	case *DotExpression:
+		if n != nil {
+			Walk(v, n.Left)
+		}
+	case *EmptyExpression:
+	case *EmptyStatement:
+	case *ExpressionStatement:
+		if n != nil {
+			Walk(v, n.Expression)
+		}
+	case *ForInStatement:
+		if n != nil {
+			Walk(v, n.Into)
+			Walk(v, n.Source)
+			Walk(v, n.Body)
+		}
+	case *ForStatement:
+		if n != nil {
+			Walk(v, n.Initializer)
+			Walk(v, n.Update)
+			Walk(v, n.Test)
+			Walk(v, n.Body)
+		}
+	case *FunctionLiteral:
+		if n != nil {
+			Walk(v, n.Name)
+			for _, p := range n.ParameterList.List {
+				Walk(v, p)
+			}
+			Walk(v, n.Body)
+		}
+	case *FunctionStatement:
+		if n != nil {
+			Walk(v, n.Function)
+		}
+	case *Identifier:
+	case *IfStatement:
+		if n != nil {
+			Walk(v, n.Test)
+			Walk(v, n.Consequent)
+			Walk(v, n.Alternate)
+		}
+	case *LabelledStatement:
+		if n != nil {
+			Walk(v, n.Statement)
+		}
+	case *NewExpression:
+		if n != nil {
+			Walk(v, n.Callee)
+			for _, a := range n.ArgumentList {
+				Walk(v, a)
+			}
+		}
+	case *NullLiteral:
+	case *NumberLiteral:
+	case *ObjectLiteral:
+		if n != nil {
+			for _, p := range n.Value {
+				Walk(v, p.Value)
+			}
+		}
+	case *Program:
+		if n != nil {
+			for _, b := range n.Body {
+				Walk(v, b)
+			}
+		}
+	case *RegExpLiteral:
+	case *ReturnStatement:
+		if n != nil {
+			Walk(v, n.Argument)
+		}
+	case *SequenceExpression:
+		if n != nil {
+			for _, e := range n.Sequence {
+				Walk(v, e)
+			}
+		}
+	case *StringLiteral:
+	case *SwitchStatement:
+		if n != nil {
+			Walk(v, n.Discriminant)
+			for _, c := range n.Body {
+				Walk(v, c)
+			}
+		}
+	case *ThisExpression:
+	case *ThrowStatement:
+		if n != nil {
+			Walk(v, n.Argument)
+		}
+	case *TryStatement:
+		if n != nil {
+			Walk(v, n.Body)
+			Walk(v, n.Catch)
+			Walk(v, n.Finally)
+		}
+	case *UnaryExpression:
+		if n != nil {
+			Walk(v, n.Operand)
+		}
+	case *VariableExpression:
+		if n != nil {
+			Walk(v, n.Initializer)
+		}
+	case *VariableStatement:
+		if n != nil {
+			for _, e := range n.List {
+				Walk(v, e)
+			}
+		}
+	case *WhileStatement:
+		if n != nil {
+			Walk(v, n.Test)
+			Walk(v, n.Body)
+		}
+	case *WithStatement:
+		if n != nil {
+			Walk(v, n.Object)
+			Walk(v, n.Body)
+		}
+	default:
+		panic(fmt.Sprintf("Walk: unexpected node type %T", n))
+	}
+
+	Walk(v, nil)
+}

--- a/ast/walk_example_test.go
+++ b/ast/walk_example_test.go
@@ -1,0 +1,43 @@
+package ast_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/robertkrimen/otto/ast"
+	"github.com/robertkrimen/otto/file"
+	"github.com/robertkrimen/otto/parser"
+)
+
+func ExampleVisitorRewrite() {
+	source := `var b = function() {test(); try {} catch(e) {} var test = "test(); var test = 1"} // test`
+	program, err := parser.ParseFile(nil, "", source, 0)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var shift file.Idx
+
+	ast.Walk(ast.VisitorFunc(func(v ast.Visitor, n ast.Node) ast.Visitor {
+		if n == nil {
+			return v
+		}
+		if id, ok := n.(*ast.Identifier); ok && id != nil {
+			idx := n.Idx0() + shift - 1
+			s := source[:idx] + "new_" + source[idx:]
+			source = s
+			shift += 4
+		}
+		if v, ok := n.(*ast.VariableExpression); ok && v != nil {
+			idx := n.Idx0() + shift - 1
+			s := source[:idx] + "varnew_" + source[idx:]
+			source = s
+			shift += 7
+		}
+
+		return v
+	}), program)
+
+	fmt.Println(source)
+	// Output: var varnew_b = function() {new_test(); try {} catch(new_e) {} var varnew_test = "test(); var test = 1"} // test
+}


### PR DESCRIPTION
Add an `ast.Walk` utility function to traverse the AST in depth-first order.