### PR TITLE
ast: ThisExpression.Idx1() should point to the end of `this`

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -472,7 +472,7 @@ func (self *ObjectLiteral) Idx1() file.Idx         { return self.RightBrace }
 func (self *RegExpLiteral) Idx1() file.Idx         { return file.Idx(int(self.Idx) + len(self.Literal)) }
 func (self *SequenceExpression) Idx1() file.Idx    { return self.Sequence[0].Idx1() }
 func (self *StringLiteral) Idx1() file.Idx         { return file.Idx(int(self.Idx) + len(self.Literal)) }
-func (self *ThisExpression) Idx1() file.Idx        { return self.Idx }
+func (self *ThisExpression) Idx1() file.Idx        { return self.Idx + 4 }
 func (self *UnaryExpression) Idx1() file.Idx {
 	if self.Postfix {
 		return self.Operand.Idx1() + 2 // ++ --

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1009,6 +1009,12 @@ func TestPosition(t *testing.T) {
 		is(err, nil)
 		node = program.Body[0].(*ast.ExpressionStatement).Expression.(*ast.FunctionLiteral)
 		is(node.(*ast.FunctionLiteral).Source, "function(){ return abc; }")
+
+		parser = _newParser("", "this.style", 1, nil)
+		program, err = parser.parse()
+		node = program.Body[0].(*ast.ExpressionStatement).Expression.(*ast.DotExpression).Left.(*ast.ThisExpression)
+		is(node.Idx0(), file.Idx(1))
+		is(node.Idx1(), file.Idx(5))
 	})
 }
 


### PR DESCRIPTION
Fixed the ast position of ThisExpression.