### PR TITLE
Fix Array.splice(n) with single argument

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -181,8 +181,10 @@ func TestArray_splice(t *testing.T) {
             def = abc.splice(1, 2, 3, 4, 5);
             ghi = [].concat(abc);
             jkl = ghi.splice(17, 21, 7, 8, 9);
-            [ abc, def, ghi, jkl ].join(";");
-        `, "0,3,4,5;1,2;0,3,4,5,7,8,9;")
+            mno = [].concat(abc);
+            pqr = mno.splice(2);
+            [ abc, def, ghi, jkl, mno, pqr ].join(";");
+        `, "0,3,4,5;1,2;0,3,4,5,7,8,9;;0,3;4,5")
 	})
 }
 

--- a/builtin_array.go
+++ b/builtin_array.go
@@ -170,7 +170,10 @@ func builtinArray_splice(call FunctionCall) Value {
 	length := int64(toUint32(thisObject.get("length")))
 
 	start := valueToRangeIndex(call.Argument(0), length, false)
-	deleteCount := valueToRangeIndex(call.Argument(1), int64(length)-start, true)
+	deleteCount := length - start
+	if arg, ok := call.getArgument(1); ok {
+		deleteCount = valueToRangeIndex(arg, length-start, true)
+	}
 	valueArray := make([]Value, deleteCount)
 
 	for index := int64(0); index < deleteCount; index++ {


### PR DESCRIPTION
According to https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/splice, Array.splice with a single argument should remove all items starting with said argument. Otto incorrectly treats this the same as if 0 were specified, in which case it (correctly) removes nothing.