### PR TITLE
Use stack depth limit when exporting values

### DIFF
--- a/otto_test.go
+++ b/otto_test.go
@@ -1734,6 +1734,87 @@ func Test_stackLimit(t *testing.T) {
 	})
 }
 
+func Test_exportStackLimit(t *testing.T) {
+	code := `
+		a = {};
+		a.b = {};
+		a.b.c = {};
+		a.b.c.d = {};
+		a.b.c.d.e = {};
+
+		a
+	`
+
+	// has no panic
+	tt(t, func() {
+		defer func() {
+			caught := recover()
+			is(caught == nil, true)
+		}()
+
+		_, vm := test()
+
+		val, err := vm.Run(code)
+		is(err == nil, true)
+
+		_, err = val.Export()
+		is(err == nil, true)
+	})
+
+	// has panic
+	tt(t, func() {
+		defer func() {
+			caught := recover()
+			is(caught == nil, false)
+		}()
+
+		_, vm := test()
+
+		vm.vm.SetStackDepthLimit(2)
+
+		val, err := vm.Run(code)
+		is(err == nil, true)
+
+		_, err = val.Export()
+		is(err == nil, true)
+	})
+
+	// has error
+	tt(t, func() {
+		defer func() {
+			caught := recover()
+			is(caught == nil, false)
+		}()
+
+		_, vm := test()
+
+		vm.vm.SetStackDepthLimit(4)
+
+		val, err := vm.Run(code)
+		is(err == nil, true)
+
+		val.Export()
+	})
+
+	// has no panic
+	tt(t, func() {
+		defer func() {
+			caught := recover()
+			is(caught == nil, true)
+		}()
+
+		_, vm := test()
+
+		vm.vm.SetStackDepthLimit(10)
+
+		val, err := vm.Run(code)
+		is(err == nil, true)
+
+		_, err = val.Export()
+		is(err == nil, true)
+	})
+}
+
 func BenchmarkNew(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		New()

--- a/runtime.go
+++ b/runtime.go
@@ -210,7 +210,7 @@ func (self *_runtime) safeToValue(value interface{}) (Value, error) {
 // convertNumeric converts numeric parameter val from js to that of type t if it is safe to do so, otherwise it panics.
 // This allows literals (int64), bitwise values (int32) and the general form (float64) of javascript numerics to be passed as parameters to go functions easily.
 func (self *_runtime) convertNumeric(v Value, t reflect.Type) reflect.Value {
-	val := reflect.ValueOf(v.export())
+	val := reflect.ValueOf(v.export(0))
 
 	if val.Kind() == t.Kind() {
 		return val
@@ -302,7 +302,7 @@ func (self *_runtime) convertCallParameter(v Value, t reflect.Type) reflect.Valu
 	}
 
 	if t.Kind() == reflect.Interface {
-		e := v.export()
+		e := v.export(0)
 		if e == nil {
 			return reflect.Zero(t)
 		}

--- a/type_go_slice_test.go
+++ b/type_go_slice_test.go
@@ -16,8 +16,8 @@ func TestGoSlice(t *testing.T) {
 	tt(t, func() {
 		test, vm := test()
 		vm.Set("TestSlice", GoSliceTest{1, 2, 3})
-		is(test(`TestSlice.length`).export(), 3)
-		is(test(`TestSlice[1]`).export(), 2)
-		is(test(`TestSlice.Sum()`).export(), 6)
+		is(test(`TestSlice.length`).export(0), 3)
+		is(test(`TestSlice[1]`).export(0), 2)
+		is(test(`TestSlice.Sum()`).export(0), 6)
 	})
 }

--- a/value_test.go
+++ b/value_test.go
@@ -214,23 +214,23 @@ func TestExport(t *testing.T) {
 	tt(t, func() {
 		test, vm := test()
 
-		is(test(`null;`).export(), nil)
-		is(test(`undefined;`).export(), nil)
-		is(test(`true;`).export(), true)
-		is(test(`false;`).export(), false)
-		is(test(`0;`).export(), 0)
-		is(test(`3.1459`).export(), 3.1459)
-		is(test(`"Nothing happens";`).export(), "Nothing happens")
-		is(test(`String.fromCharCode(97,98,99,100,101,102)`).export(), "abcdef")
+		is(test(`null;`).export(0), nil)
+		is(test(`undefined;`).export(0), nil)
+		is(test(`true;`).export(0), true)
+		is(test(`false;`).export(0), false)
+		is(test(`0;`).export(0), 0)
+		is(test(`3.1459`).export(0), 3.1459)
+		is(test(`"Nothing happens";`).export(0), "Nothing happens")
+		is(test(`String.fromCharCode(97,98,99,100,101,102)`).export(0), "abcdef")
 		{
-			value := test(`({ abc: 1, def: true, ghi: undefined });`).export().(map[string]interface{})
+			value := test(`({ abc: 1, def: true, ghi: undefined });`).export(0).(map[string]interface{})
 			is(value["abc"], 1)
 			is(value["def"], true)
 			_, exists := value["ghi"]
 			is(exists, false)
 		}
 		{
-			value := test(`[ "abc", 1, "def", true, undefined, null ];`).export().([]interface{})
+			value := test(`[ "abc", 1, "def", true, undefined, null ];`).export(0).([]interface{})
 			is(value[0], "abc")
 			is(value[1], 1)
 			is(value[2], "def")
@@ -240,7 +240,7 @@ func TestExport(t *testing.T) {
 			is(value[5], interface{}(nil))
 		}
 		{
-			value := test(`[ undefined, null ];`).export().([]interface{})
+			value := test(`[ undefined, null ];`).export(0).([]interface{})
 			is(value[0], nil)
 			is(value[1], nil)
 			is(value[1], interface{}(nil))
@@ -269,7 +269,7 @@ func TestExport(t *testing.T) {
 			input, err := json.Marshal(value)
 			is(err, nil)
 
-			output, err := json.Marshal(test("(" + string(input) + ");").export())
+			output, err := json.Marshal(test("(" + string(input) + ");").export(0))
 			is(err, nil)
 
 			is(string(input), string(output))
@@ -284,7 +284,7 @@ func TestExport(t *testing.T) {
 			abc.def = 3
 			abc.xyz = 3.1459
 			vm.Set("abc", abc)
-			is(test(`abc;`).export(), abc)
+			is(test(`abc;`).export(0), abc)
 		}
 	})
 }


### PR DESCRIPTION
This is a clone of #249 but with tests.

Consider the following JS executed by Otto:

```js
(function () {
	var obj = {foo: "bar"};
	obj.ob = obj;
	return obj;
})()
```

Calling `value.Export()` on the output of `vm.Run(code)` results in a

```
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow

runtime stack:
runtime.throw(0xeb62e7, 0xe)
  /usr/local/go/src/runtime/panic.go:596 +0x95
runtime.newstack(0x0)
  /usr/local/go/src/runtime/stack.go:1089 +0x3f2
runtime.morestack()
  /usr/local/go/src/runtime/asm_amd64.s:398 +0x86

goroutine 7593219 [running]:
github.com/robertkrimen/otto.(*_object).getProperty(0xc4207901e0, 0xc420e039ad, 0x3, 0x0)
  github.com/robertkrimen/otto/object.go:36 +0x60 fp=0xc442e70370 sp=0xc442e70368
github.com/robertkrimen/otto.objectGet(0xc4207901e0, 0xc420e039ad, 0x3, 0x30, 0xe67860, 0x0)
  github.com/robertkrimen/otto/object_class.go:192 +0x43 fp=0xc442e703b8 sp=0xc442e70370
github.com/robertkrimen/otto.(*_object).get(0xc4207901e0, 0xc420e039ad, 0x3, 0x40f562, 0xc4254268c0, 0x20)
  github.com/robertkrimen/otto/object.go:42 +0x47 fp=0xc442e703f8 sp=0xc442e703b8
github.com/robertkrimen/otto.Value.export.func1(0xc420e039ad, 0x3, 0xc420e039ad)
  github.com/robertkrimen/otto/value.go:725 +0x4b fp=0xc442e70460 sp=0xc442e703f8
github.com/robertkrimen/otto.objectEnumerate(0xc4207901e0, 0x0, 0xc4254268c0)
  github.com/robertkrimen/otto/object_class.go:25 +0x89 fp=0xc442e704c0 sp=0xc442e70460
github.com/robertkrimen/otto.(*_object).enumerate(0xc4207901e0, 0xc425426800, 0xc4254268c0)
  github.com/robertkrimen/otto/object.go:118 +0x46 fp=0xc442e704e8 sp=0xc442e704c0
github.com/robertkrimen/otto.Value.export(0x5, 0xe8d8c0, 0xc4207901e0, 0x5, 0xe8d8c0)
  github.com/robertkrimen/otto/value.go:730 +0x801 fp=0xc442e70690 sp=0xc442e704e8
github.com/robertkrimen/otto.Value.export.func1(0xc420e039ad, 0x3, 0xc420e039ad)
  github.com/robertkrimen/otto/value.go:727 +0x95 fp=0xc442e706f8 sp=0xc442e70690
github.com/robertkrimen/otto.objectEnumerate(0xc4207901e0, 0x0, 0xc425426880)
  github.com/robertkrimen/otto/object_class.go:25 +0x89 fp=0xc442e70758 sp=0xc442e706f8
github.com/robertkrimen/otto.(*_object).enumerate(0xc4207901e0, 0xc425426800, 0xc425426880)
  github.com/robertkrimen/otto/object.go:118 +0x46 fp=0xc442e70780 sp=0xc442e70758
etc...
```

This pull request resolves this problem similar to #168.

Let me know if you'd like to see any changes.