### PR TITLE
add mutex guard to object properties

### DIFF
--- a/clone.go
+++ b/clone.go
@@ -71,7 +71,7 @@ func (in *_runtime) clone() *_runtime {
 		clone.object(in.global.URIErrorPrototype),
 	}
 
-	out.eval = out.globalObject.property["eval"].value.(Value).value.(*_object)
+	out.eval = out.globalObject.getProperty("eval").value.(Value).value.(*_object)
 	out.globalObject.prototype = out.global.ObjectPrototype
 
 	// Not sure if this is necessary, but give some help to the GC

--- a/global.go
+++ b/global.go
@@ -50,7 +50,7 @@ func newContext() *_runtime {
 
 	_newContext(self)
 
-	self.eval = self.globalObject.property["eval"].value.(Value).value.(*_object)
+	self.eval = self.globalObject.getProperty("eval").value.(Value).value.(*_object)
 	self.globalObject.prototype = self.global.ObjectPrototype
 
 	return self

--- a/object_class.go
+++ b/object_class.go
@@ -21,7 +21,7 @@ type _objectClass struct {
 
 func objectEnumerate(self *_object, all bool, each func(string) bool) {
 	for _, name := range self.propertyOrder {
-		if all || self.property[name].enumerable() {
+		if all || self.getProperty(name).enumerable() {
 			if !each(name) {
 				return
 			}
@@ -464,8 +464,15 @@ func objectClone(in *_object, out *_object, clone *_clone) *_object {
 	if out.prototype != nil {
 		out.prototype = clone.object(in.prototype)
 	}
+
+	out.propertyMx.Lock()
+	defer out.propertyMx.Unlock()
 	out.property = make(map[string]_property, len(in.property))
 	out.propertyOrder = make([]string, len(in.propertyOrder))
+
+	in.propertyMx.RLock()
+	defer in.propertyMx.RUnlock()
+
 	copy(out.propertyOrder, in.propertyOrder)
 	for index, property := range in.property {
 		out.property[index] = clone.property(property)

--- a/runtime.go
+++ b/runtime.go
@@ -358,7 +358,9 @@ func (self *_runtime) convertCallParameter(v Value, t reflect.Type) reflect.Valu
 
 				if o.class == "Array" {
 					for i := int64(0); i < l; i++ {
+						o.propertyMx.RLock()
 						p, ok := o.property[strconv.FormatInt(i, 10)]
+						o.propertyMx.Unlock()
 						if !ok {
 							continue
 						}

--- a/stash.go
+++ b/stash.go
@@ -285,6 +285,8 @@ func getStashProperties(stash _stash) (keys []string) {
 			keys = append(keys, k)
 		}
 	case *_objectStash:
+		vars.object.propertyMx.RLock()
+		defer vars.object.propertyMx.RUnlock()
 		for k := range vars.object.property {
 			keys = append(keys, k)
 		}


### PR DESCRIPTION
Fix race:

````WARNING: DATA RACE
Write at 0x00c4247a7770 by goroutine 82:
  runtime.mapassign()
      /usr/local/go/src/runtime/hashmap.go:485 +0x0
  github.com/status-im/status-go/vendor/github.com/robertkrimen/otto.objectDefineOwnProperty()
      /home/b00ris/go/src/github.com/status-im/status-go/vendor/github.com/robertkrimen/otto/object_class.go:437 +0x455
  github.com/status-im/status-go/vendor/github.com/robertkrimen/otto.(*_object).defineOwnProperty()
      /home/b00ris/go/src/github.com/status-im/status-go/vendor/github.com/robertkrimen/otto/object.go:110 +0xad

Previous read at 0x00c4247a7770 by goroutine 21:
  runtime.mapaccess2_faststr()
      /usr/local/go/src/runtime/hashmap_fast.go:317 +0x0
  github.com/status-im/status-go/vendor/github.com/robertkrimen/otto.objectGetOwnProperty()
      /home/b00ris/go/src/github.com/status-im/status-go/vendor/github.com/robertkrimen/otto/object_class.go:171 +0x8f
  github.com/status-im/status-go/vendor/github.com/robertkrimen/otto.(*_object).getOwnProperty()
      /home/b00ris/go/src/github.com/status-im/status-go/vendor/github.com/robertkrimen/otto/object.go:32 +0x7b
  github.com/status-im/status-go/vendor/github.com/robertkrimen/otto.objectGetProperty()
````