### PR TITLE
new: add a way to specify console writers

### DIFF
--- a/console.go
+++ b/console.go
@@ -2,7 +2,6 @@ package otto
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
@@ -15,12 +14,12 @@ func formatForConsole(argumentList []Value) string {
 }
 
 func builtinConsole_log(call FunctionCall) Value {
-	fmt.Fprintln(os.Stdout, formatForConsole(call.ArgumentList))
+	fmt.Fprintln(call.runtime.otto.stdOutWriter, formatForConsole(call.ArgumentList))
 	return Value{}
 }
 
 func builtinConsole_error(call FunctionCall) Value {
-	fmt.Fprintln(os.Stdout, formatForConsole(call.ArgumentList))
+	fmt.Fprintln(call.runtime.otto.stdErrWriter, formatForConsole(call.ArgumentList))
 	return Value{}
 }
 


### PR DESCRIPTION
This patch provides a way to set custom `io.Writer` for console functions.

Example
```go
stdOutBuf := &bytes.Buffer{}
stdErrBuf := &bytes.Buffer{}

jsvm := otto.New()
jsvm.SetConsoleWriters(stdOutBuf, stdErrBuf)

jsvm.Run(`console.log("out"); console.error("err")`)

fmt.Println("stdout: ", stdOutBuf())
fmt.Println("stderr: ", stdErrBuf())
```