### PR TITLE
updating sourcemaps from go-sourcemaps to latest release

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-sourcemap/sourcemap"
+	"gopkg.in/sourcemap.v2"
 )
 
 // Idx is a compact encoding of a source position within a file set.

--- a/file/file.go
+++ b/file/file.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/sourcemap.v1"
+	"github.com/go-sourcemap/sourcemap"
 )
 
 // Idx is a compact encoding of a source position within a file set.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -40,7 +40,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/go-sourcemap/sourcemap"
+	"gopkg.in/sourcemap.v2"
 
 	"github.com/robertkrimen/otto/ast"
 	"github.com/robertkrimen/otto/file"

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -40,10 +40,11 @@ import (
 	"io"
 	"io/ioutil"
 
+	"github.com/go-sourcemap/sourcemap"
+
 	"github.com/robertkrimen/otto/ast"
 	"github.com/robertkrimen/otto/file"
 	"github.com/robertkrimen/otto/token"
-	"gopkg.in/sourcemap.v1"
 )
 
 // A Mode value is a set of flags (or 0). They control optional parser functionality.


### PR DESCRIPTION
Avoids possible golang error discussed in #291.

- Seems like no real changes in the code are needed.
- Seems like no tests are broken.
- Tested some scripts to run and it was successful.