### PR TITLE
Revert "updating sourcemaps from go-sourcemaps to latest release"

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/sourcemap.v2"
+	"gopkg.in/sourcemap.v1"
 )
 
 // Idx is a compact encoding of a source position within a file set.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -40,11 +40,10 @@ import (
 	"io"
 	"io/ioutil"
 
-	"gopkg.in/sourcemap.v2"
-
 	"github.com/robertkrimen/otto/ast"
 	"github.com/robertkrimen/otto/file"
 	"github.com/robertkrimen/otto/token"
+	"gopkg.in/sourcemap.v1"
 )
 
 // A Mode value is a set of flags (or 0). They control optional parser functionality.


### PR DESCRIPTION
Reverts robertkrimen/otto#293

This fixes #295 which is caused by v2's use of internal being incompatible with the versioning provided by gopkg.in