### PR TITLE
Allow associating arbitrary data with a JS object

### DIFF
--- a/object.go
+++ b/object.go
@@ -6,6 +6,7 @@ type _object struct {
 	class       string
 	objectClass *_objectClass
 	value       interface{}
+	data        interface{}
 
 	prototype  *_object
 	extensible bool

--- a/otto.go
+++ b/otto.go
@@ -721,6 +721,14 @@ func (self Object) Set(name string, value interface{}) error {
 	}
 }
 
+func (self Object) SetPrivate(data interface{}) {
+	self.object.data = data
+}
+
+func (self Object) GetPrivate() interface{} {
+	return self.object.data
+}
+
 // Keys gets the keys for the given object.
 //
 // Equivalent to calling Object.keys on the object.


### PR DESCRIPTION
Can be useful to wrap a Go object with a JS object. I couldn't figure out if there was already some way of achieving this with the library or not, so feel free to close if this is already possible.

For example:

```go
foo, _ := vm.Object("({})")
foo.SetPrivate(bar)

foo.Set("doThing", func(call otto.FunctionCall) otto.Value {
  bar := call.This.Object().GetPrivate().(Bar)
  bar.DoThing()
  return otto.NullValue()
})
```