### PR TITLE
adding a handler to convert native error types in golang to a string

### DIFF
--- a/value.go
+++ b/value.go
@@ -314,6 +314,8 @@ func toValue(value interface{}) Value {
 	case string:
 		return Value{valueString, value}
 	// A rune is actually an int32, which is handled above
+	case error:
+		return Value{valueString, value.Error()}
 	case *_object:
 		return Value{valueObject, value}
 	case *Object:


### PR DESCRIPTION
Currently, otto does not know how to handle native error types other than converting them to uint8 representations of their length. This allows golang errors to be returned as their string `Error()` representation.