### PR TITLE
underscore: use func value instead of wrapping lambda

### DIFF
--- a/underscore/underscore.go
+++ b/underscore/underscore.go
@@ -29,9 +29,7 @@ import (
 	"github.com/robertkrimen/otto/registry"
 )
 
-var entry *registry.Entry = registry.Register(func() string {
-	return Source()
-})
+var entry *registry.Entry = registry.Register(Source)
 
 // Enable underscore runtime inclusion.
 func Enable() {


### PR DESCRIPTION
Found using https://go-critic.github.io/overview.html#unlambda-ref