### PR TITLE
remove self-assignment without effect

### DIFF
--- a/terst/terst.go
+++ b/terst/terst.go
@@ -419,7 +419,6 @@ func typeKindString(value interface{}) string {
 
 func (scope *_scope) reset() {
 	scope.name = ""
-	scope.output = scope.output[:]
 	scope.start = time.Time{}
 	scope.duration = 0
 }


### PR DESCRIPTION
ineffassign and megacheck do not detect this as self-assignment,
but since `s[:]` yields value identical to `s` this is
effectively a self-assignment.

Found using https://go-critic.github.io/overview.html#unslice-ref