### PR TITLE
Extend testing timeout to 20 secs (fix #337)

### DIFF
--- a/testing_test.go
+++ b/testing_test.go
@@ -11,7 +11,7 @@ import (
 
 func tt(t *testing.T, arguments ...func()) {
 	halt := errors.New("A test was taking too long")
-	timer := time.AfterFunc(2*time.Second, func() {
+	timer := time.AfterFunc(20*time.Second, func() {
 		panic(halt)
 	})
 	defer func() {


### PR DESCRIPTION
For slow computing machines, 2 seconds is too short to PASS the testing. #337

Signed-off-by: Jongmin Kim <jmkim@pukyong.ac.kr>