### PR TITLE
fieldIndexByName: extract type from interface in fieldIndexByName

### DIFF
--- a/bug_test.go
+++ b/bug_test.go
@@ -773,3 +773,31 @@ func Test_issue266(t *testing.T) {
 
 	})
 }
+
+func Test_issue369 (t *testing.T) {
+	tt(t, func() {
+		test, tester := test()
+
+		type Test struct {
+			Value string
+		}
+
+		type PtrTest struct {
+			*Test
+		}
+
+		testItem := Test{
+			Value: "A test value",
+		}
+
+		ptrTestItem := PtrTest{
+			Test: &testItem,
+		}
+
+		tester.Set("testVariable", ptrTestItem)
+
+		test(`
+		JSON.stringify(testVariable);
+	`, `{"Test":{"Value":"A test value"}}`)
+	})
+}

--- a/runtime.go
+++ b/runtime.go
@@ -298,12 +298,6 @@ func fieldIndexByName(t reflect.Type, name string) []int {
 			continue
 		}
 
-		if f.Anonymous {
-			if a := fieldIndexByName(f.Type, name); a != nil {
-				return append([]int{i}, a...)
-			}
-		}
-
 		if a := strings.SplitN(f.Tag.Get("json"), ",", 2); a[0] != "" {
 			if a[0] == "-" {
 				continue

--- a/runtime.go
+++ b/runtime.go
@@ -291,8 +291,8 @@ func (self *_runtime) convertNumeric(v Value, t reflect.Type) reflect.Value {
 }
 
 func fieldIndexByName(t reflect.Type, name string) []int {
-	if t.Kind() != reflect.Struct {
-		return nil
+	for t.Kind() == reflect.Ptr {
+		t = reflect.ValueOf(t).Elem().Type()
 	}
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)

--- a/runtime.go
+++ b/runtime.go
@@ -291,11 +291,20 @@ func (self *_runtime) convertNumeric(v Value, t reflect.Type) reflect.Value {
 }
 
 func fieldIndexByName(t reflect.Type, name string) []int {
+	if t.Kind() != reflect.Struct {
+		return nil
+	}
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
 
 		if !validGoStructName(f.Name) {
 			continue
+		}
+
+		if f.Anonymous {
+			if a := fieldIndexByName(f.Type, name); a != nil {
+				return append([]int{i}, a...)
+			}
 		}
 
 		if a := strings.SplitN(f.Tag.Get("json"), ",", 2); a[0] != "" {


### PR DESCRIPTION
Fix #369 

This fixes the issue with no apparent regressions, but since I don't know why this check was in place, I'm not sure that's the right solution.