### PR TITLE
Preventing for(;;){} and do{}while() statements hanging forever

### DIFF
--- a/cmpl_evaluate_statement.go
+++ b/cmpl_evaluate_statement.go
@@ -145,6 +145,17 @@ func (self *_runtime) cmpl_evaluate_nodeDoWhileStatement(node *_nodeDoWhileState
 	result := emptyValue
 resultBreak:
 	for {
+
+		// this is to prevent do while cycles with no body from running forever
+		if len(node.body) == 0 && self.otto.Interrupt != nil {
+			runtime.Gosched()
+			select {
+			case value := <-self.otto.Interrupt:
+				value()
+			default:
+			}
+		}
+
 		for _, node := range node.body {
 			value := self.cmpl_evaluate_nodeStatement(node)
 			switch value.kind {
@@ -259,6 +270,17 @@ resultBreak:
 				break
 			}
 		}
+
+		// this is to prevent for cycles with no body from running forever
+		if len(body) == 0 && self.otto.Interrupt != nil {
+			runtime.Gosched()
+			select {
+			case value := <-self.otto.Interrupt:
+				value()
+			default:
+			}
+		}
+
 		for _, node := range body {
 			value := self.cmpl_evaluate_nodeStatement(node)
 			switch value.kind {


### PR DESCRIPTION
Hello otto maintainers :)

This is to address the for(;;){} and do{}while(true) issues that result in 100% CPU and no timeout.

The reason the code was hanging is that the timeout check happens inside `cmpl_evaluate_nodeExpression` which is never called if `len(node.body) == 0` which is precisely what happens with the empty loops above.
`while(true){}` wasn't affected because it repeatedly calls `cmpl_evaluate_nodeExpression` on the test condition of the loop already.

I know my solution is not super elegant but it's functional and addresses a real problem that is preventing a few people from putting this library in production.