### PR TITLE
add go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/robertkrimen/otto
+
+go 1.14
+
+require (
+	github.com/chzyer/logex v1.1.10 // indirect
+	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
+	gopkg.in/readline.v1 v1.0.0-20160726135117-62c6fe619375
+	gopkg.in/sourcemap.v1 v1.0.5
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+gopkg.in/readline.v1 v1.0.0-20160726135117-62c6fe619375/go.mod h1:lNEQeAhU009zbRxng+XOj5ITVgY24WcbNnQopyfKoYQ=
+gopkg.in/sourcemap.v1 v1.0.5 h1:inv58fC9f9J3TK2Y2R1NPntXEn3/wjWHkonhIUODNTI=
+gopkg.in/sourcemap.v1 v1.0.5/go.mod h1:2RlvNNSMglmRrcvhfuzp4hQHwOtjxlbjX7UPY/GXb78=


### PR DESCRIPTION
this pr adds a go.mod file to this package. go depends to github user name in path, so I used a base repo name in path and it will not build if clone directly from my fork, go.mod should be downloaded manually and added to existing installation.
to test that it works, you can do this:
1. create a fresh go environment:
mv ~/go ~/go1
2. go get source repo:
go get github.com/robertkrimen/otto
it will download it, but will not build by default, because some dependencies will be missing.
3. manually add go.mod from my fork.
4. try go build.
it should automaticly load up all dependencies and build without errors.