### PR TITLE
fix panic: reflect.Set: value of type []string is not assignable to type []int64

### DIFF
--- a/value.go
+++ b/value.go
@@ -707,7 +707,7 @@ func (self Value) export() interface{} {
 				result = append(result, value)
 			}
 
-			if state != 1 || kind == reflect.Interface || t == nil {
+			if state != 1 || kind == reflect.Interface || kind == reflect.Slice || t == nil {
 				// No common type
 				return result
 			}


### PR DESCRIPTION
```
package main

import (
	"fmt"

	"github.com/robertkrimen/otto"
)

func main() {
	vm := otto.New()
	value, _ := vm.Run(`[["aa", "bb"], [1, 2]]`)
	result, _ := value.Export()
	fmt.Println(result)
}

```
Got panic
```
panic: reflect.Set: value of type []string is not assignable to type []int64

goroutine 1 [running]:
reflect.Value.assignTo(0x13a52e0, 0xc0001b8de0, 0x97, 0x142645e, 0xb, 0x13a42e0, 0x0, 0x2, 0xc0001c0330, 0xc0001b8fe0)
        /usr/local/go/src/reflect/value.go:2403 +0x426
reflect.Value.Set(0x13a42e0, 0xc0001c0330, 0x197, 0x13a52e0, 0xc0001b8de0, 0x97)
        /usr/local/go/src/reflect/value.go:1532 +0xbd
github.com/robertkrimen/otto.Value.export(0x5, 0x1416620, 0xc0001af920, 0x14bd780, 0x5)
        /Users/edz/projects/test/otto/vendor/github.com/robertkrimen/otto/value.go:718 +0x65a
github.com/robertkrimen/otto.Value.Export(...)
        /Users/edz/projects/test/otto/vendor/github.com/robertkrimen/otto/value.go:648
main.main()
        /Users/edz/projects/test/otto/main.go:12 +0x7a
exit status 2
```
Don't convert slice to the common type.
