### PR TITLE
go1.15: fix vet test failure

### DIFF
--- a/builtin.go
+++ b/builtin.go
@@ -48,9 +48,9 @@ var parseInt_alphabetTable = func() []string {
 	for radix := 3; radix <= 36; radix += 1 {
 		alphabet := table[radix-1]
 		if radix <= 10 {
-			alphabet += string(radix + 47)
+			alphabet += string(rune(radix + 47))
 		} else {
-			alphabet += string(radix+54) + string(radix+86)
+			alphabet += string(rune(radix+54)) + string(rune(radix+86))
 		}
 		table = append(table, alphabet)
 	}

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -256,7 +256,7 @@ func TestRegExp_controlCharacter(t *testing.T) {
 		test, _ := test()
 
 		for code := 0x41; code < 0x5a; code++ {
-			string_ := string(code - 64)
+			string_ := string(rune(code - 64))
 			test(fmt.Sprintf(`
                 var code = 0x%x;
                 var string = String.fromCharCode(code %% 32);


### PR DESCRIPTION
go1.15beta1 is out, and `go test ./...` now fails because of vet.

```bash
% go version
go version go1.15beta1 darwin/amd64
% go test ./...
# github.com/robertkrimen/otto
./builtin.go:51:16: conversion from int to string yields a string of one rune
./builtin.go:53:16: conversion from int to string yields a string of one rune
./builtin.go:53:35: conversion from int to string yields a string of one rune
./regexp_test.go:259:15: conversion from int to string yields a string of one rune
%
```

Too many people incorrectly convert with `string()`, so a new check has been added.

You are casting correctly and just [need to be explicit](https://tip.golang.org/doc/go1.15#vet).

I had problems with your path tests under 1.15, so I also needed to add a go.mod. That isn't part of this PR.