### PR TITLE
Fix RegExp.exec incorrect groups offsets if lastIndex is set

### DIFF
--- a/regexp_test.go
+++ b/regexp_test.go
@@ -122,6 +122,21 @@ func TestRegExp_exec(t *testing.T) {
         `, "3,7")
 
 		test(`
+            abc = /(\d)?(s)/g;
+            def = 's';
+            ghi = abc.exec(def);
+            [ ghi[1] === undefined, ghi[2] === 's' ];
+        `, "true,true")
+
+		test(`
+            abc = /(\d)?(s)/g;
+            def = '%s';
+            abc.lastIndex = 1;
+            ghi = abc.exec(def);
+            [ ghi[1] === undefined, ghi[2] === 's' ];
+        `, "true,true")
+
+		test(`
             var abc = /[abc](\d)?/.exec("a0 b c1 d3");
             [ abc.length, abc.input, abc.index, abc ];
         `, "2,a0 b c1 d3,0,a0,0")

--- a/type_regexp.go
+++ b/type_regexp.go
@@ -108,8 +108,10 @@ func execRegExp(this *_object, target string) (match bool, result []int) {
 	endIndex := int(lastIndex) + result[1]
 	// We do this shift here because the .FindStringSubmatchIndex above
 	// was done on a local subordinate slice of the string, not the whole string
-	for index, _ := range result {
-		result[index] += int(startIndex)
+	for index, offset := range result {
+		if offset != -1 {
+			result[index] += int(startIndex)
+		}
 	}
 	if global {
 		//this.defineProperty("lastIndex", toValue_(endIndex), 0111, true)


### PR DESCRIPTION
If `lastIndex` is set on `RegExp` the offset will be incorrectly increased by `lastIndex` even if there is no match. `FindStringSubmatchIndex` returns `-1` if there is no match and we should keep `-1` as is.