### PR TITLE
Revert "feat: support null value returns for toValue"

### DIFF
--- a/reflect_test.go
+++ b/reflect_test.go
@@ -228,7 +228,7 @@ func Test_reflectStruct(t *testing.T) {
 
 			test(`
                 ret = abc.FuncReturn2();
-                if (ret && ret.length && ret.length == 2 && ret[0] == "def" && ret[1] === null) {
+                if (ret && ret.length && ret.length == 2 && ret[0] == "def" && ret[1] === undefined) {
                         true;
                 } else {
                        false;

--- a/value.go
+++ b/value.go
@@ -325,7 +325,8 @@ func toValue(value interface{}) Value {
 	case _result:
 		return Value{valueResult, value}
 	case nil:
-		return nullValue
+		// TODO Ugh.
+		return Value{}
 	case reflect.Value:
 		for value.Kind() == reflect.Ptr {
 			// We were given a pointer, so we'll drill down until we get a non-pointer

--- a/value_test.go
+++ b/value_test.go
@@ -39,8 +39,7 @@ func TestToValue(t *testing.T) {
 		vm := tester.vm
 
 		value, _ := vm.ToValue(nil)
-		is(value, "null")
-		is(value, nullValue)
+		is(value, "undefined")
 
 		value, _ = vm.ToValue((*byte)(nil))
 		is(value, "undefined")


### PR DESCRIPTION
Reverts robertkrimen/otto#325
This caused a regression in TestGoStructNilBoolPointerField