### PR TITLE
fix example to clean up watchdog goroutine

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -247,7 +247,7 @@ func runUnsafe(unsafe string) {
             }
         case <-watchdogCleanup:
         }
-      close(vm.Interrupt)
+        close(vm.Interrupt)
     }()
 
     vm.Run(unsafe) // Here be dragons (risky code)

--- a/README.markdown
+++ b/README.markdown
@@ -240,8 +240,8 @@ func runUnsafe(unsafe string) {
     defer close(watchdogCleanup)
 
     go func() {
-		select {
-		case <- time.After(2 * time.Second): // Stop after two seconds
+        select {
+        case <-time.After(2 * time.Second): // Stop after two seconds
             vm.Interrupt <- func() {
                 panic(halt)
             }

--- a/README.markdown
+++ b/README.markdown
@@ -236,12 +236,21 @@ func runUnsafe(unsafe string) {
 
     vm := otto.New()
     vm.Interrupt = make(chan func(), 1) // The buffer prevents blocking
+	watchdogCleanup := make(chan bool)
+	defer func() {
+		watchdogCleanup<-true
+		close(watchdogCleanup)
+	}()
 
     go func() {
-        time.Sleep(2 * time.Second) // Stop after two seconds
-        vm.Interrupt <- func() {
-            panic(halt)
+		select {
+		case <- time.After(2 * time.Second): // Stop after two seconds
+            vm.Interrupt <- func() {
+                panic(halt)
+            }
+        case <-watchdogCleanup:
         }
+		close(vm.Interrupt)
     }()
 
     vm.Run(unsafe) // Here be dragons (risky code)

--- a/README.markdown
+++ b/README.markdown
@@ -236,10 +236,8 @@ func runUnsafe(unsafe string) {
 
     vm := otto.New()
     vm.Interrupt = make(chan func(), 1) // The buffer prevents blocking
-	watchdogCleanup := make(chan struct{})
-	defer func() {
-		close(watchdogCleanup)
-	}()
+    watchdogCleanup := make(chan struct{})
+    defer close(watchdogCleanup)
 
     go func() {
 		select {

--- a/README.markdown
+++ b/README.markdown
@@ -236,9 +236,8 @@ func runUnsafe(unsafe string) {
 
     vm := otto.New()
     vm.Interrupt = make(chan func(), 1) // The buffer prevents blocking
-	watchdogCleanup := make(chan bool)
+	watchdogCleanup := make(chan struct{})
 	defer func() {
-		watchdogCleanup<-true
 		close(watchdogCleanup)
 	}()
 
@@ -250,7 +249,7 @@ func runUnsafe(unsafe string) {
             }
         case <-watchdogCleanup:
         }
-		close(vm.Interrupt)
+      close(vm.Interrupt)
     }()
 
     vm.Run(unsafe) // Here be dragons (risky code)


### PR DESCRIPTION
This fixes the example code for cleaning up long-running VMs.  Previously, they were killed after the timeout: the goroutine tracking this timeout holds a reference to the VM, therefore keeping the entire VM in memory for the duration of the configured timeout regardless of whether it has already completed its execution.

This change adds a second layer of communication to the watchdog goroutine, so that it will terminate itself if the VM has exited within the timeout.  This allows the VM to be garbage collected if no other references to the VM exist.