### PR TITLE
Implemented MarshalJSON for Value and Object

### DIFF
--- a/value.go
+++ b/value.go
@@ -1,6 +1,7 @@
 package otto
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"reflect"
@@ -1022,4 +1023,18 @@ func stringToReflectValue(value string, kind reflect.Kind) (reflect.Value, error
 
 	// FIXME This should end up as a TypeError?
 	panic(fmt.Errorf("invalid conversion of %q to reflect.Kind: %v", value, kind))
+}
+
+func (self Value) MarshalJSON() ([]byte, error) {
+	switch self.kind {
+	case valueUndefined, valueNull:
+		return []byte("null"), nil
+	case valueBoolean, valueNumber:
+		return json.Marshal(self.value)
+	case valueString:
+		return json.Marshal(self.string())
+	case valueObject:
+		return self.Object().MarshalJSON()
+	}
+	return nil, fmt.Errorf("invalid type %v", self.kind)
 }


### PR DESCRIPTION
Value and Object now conform to the json.Marshaler interface and produce the
correct JSON when passed (directly or indirectly) to json.Marshal().

Before, both types would marshal as "{}" because they're structs with no public
fields.

This fixes some nasty problems marshaling object trees that mix Go and JS
collections. This can happen when you pass a Go collection into a JS function,
which modifies it adding JS values; and then back in Go you marshal the
collection to JSON. Before this commit the JS values would marshal to "{}".
(The new unit test TestNestedJSONMarshaling demonstrates this.)

Fixes #262