### PR TITLE
Add a console logger option

### DIFF
--- a/console.go
+++ b/console.go
@@ -1,27 +1,30 @@
 package otto
 
-import (
-	"fmt"
-	"os"
-	"strings"
-)
-
-func formatForConsole(argumentList []Value) string {
-	output := []string{}
+// TODO use x/exp/slices
+func argsAsAny(argumentList []Value) []interface{} {
+	output := make([]interface{}, 0, len(argumentList))
 	for _, argument := range argumentList {
-		output = append(output, fmt.Sprintf("%v", argument))
+		output = append(output, argument.String())
 	}
-	return strings.Join(output, " ")
+	return output
 }
 
-func builtinConsole_log(call FunctionCall) Value {
-	fmt.Fprintln(os.Stdout, formatForConsole(call.ArgumentList))
-	return Value{}
+func builtinConsole_log(otto *Otto) func(call FunctionCall) Value {
+	return func(call FunctionCall) Value {
+		// println("---------")
+		// args := argsAsAny(call.ArgumentList)
+		// fmt.Printf("args %v\n", args)
+		// otto.log.Print(args...)
+		otto.log.Print(argsAsAny(call.ArgumentList)...)
+		return Value{}
+	}
 }
 
-func builtinConsole_error(call FunctionCall) Value {
-	fmt.Fprintln(os.Stdout, formatForConsole(call.ArgumentList))
-	return Value{}
+func builtinConsole_error(otto *Otto) func(call FunctionCall) Value {
+	return func(call FunctionCall) Value {
+		otto.log.Error(argsAsAny(call.ArgumentList)...)
+		return Value{}
+	}
 }
 
 // Nothing happens.
@@ -46,6 +49,5 @@ func builtinConsole_assert(call FunctionCall) Value {
 }
 
 func (runtime *_runtime) newConsole() *_object {
-
 	return newConsoleObject(runtime)
 }

--- a/inline.go
+++ b/inline.go
@@ -6263,7 +6263,7 @@ func newConsoleObject(runtime *_runtime) *_object {
 			},
 			value: _nativeFunctionObject{
 				name: "log",
-				call: builtinConsole_log,
+				call: builtinConsole_log(runtime.otto),
 			},
 		}
 		debug_function := &_object{
@@ -6286,7 +6286,7 @@ func newConsoleObject(runtime *_runtime) *_object {
 			},
 			value: _nativeFunctionObject{
 				name: "debug",
-				call: builtinConsole_log,
+				call: builtinConsole_log(runtime.otto),
 			},
 		}
 		info_function := &_object{
@@ -6309,7 +6309,7 @@ func newConsoleObject(runtime *_runtime) *_object {
 			},
 			value: _nativeFunctionObject{
 				name: "info",
-				call: builtinConsole_log,
+				call: builtinConsole_log(runtime.otto),
 			},
 		}
 		error_function := &_object{
@@ -6332,7 +6332,7 @@ func newConsoleObject(runtime *_runtime) *_object {
 			},
 			value: _nativeFunctionObject{
 				name: "error",
-				call: builtinConsole_error,
+				call: builtinConsole_error(runtime.otto),
 			},
 		}
 		warn_function := &_object{
@@ -6355,7 +6355,7 @@ func newConsoleObject(runtime *_runtime) *_object {
 			},
 			value: _nativeFunctionObject{
 				name: "warn",
-				call: builtinConsole_error,
+				call: builtinConsole_error(runtime.otto),
 			},
 		}
 		dir_function := &_object{

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,23 @@
+package otto
+
+import (
+	"fmt"
+	"io"
+)
+
+type Logger interface {
+	Print(v ...interface{})
+	Error(v ...interface{})
+}
+
+type console struct {
+	out io.Writer
+}
+
+func (l *console) Print(v ...interface{}) {
+	fmt.Fprintln(l.out, v...)
+}
+
+func (l *console) Error(v ...interface{}) {
+	fmt.Fprintln(l.out, v...)
+}

--- a/options.go
+++ b/options.go
@@ -1,0 +1,9 @@
+package otto
+
+type Option func(*Otto)
+
+func WithLogger(log Logger) func(o *Otto) {
+	return func(o *Otto) {
+		o.log = log
+	}
+}

--- a/otto.go
+++ b/otto.go
@@ -226,6 +226,7 @@ package otto
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/robertkrimen/otto/file"
@@ -238,13 +239,20 @@ type Otto struct {
 	// See "Halting Problem" for more information.
 	Interrupt chan func()
 	runtime   *_runtime
+	log       Logger
 }
 
 // New will allocate a new JavaScript runtime
-func New() *Otto {
+func New(options ...Option) *Otto {
 	self := &Otto{
 		runtime: newContext(),
+		log:     &console{os.Stdout},
 	}
+
+	for _, o := range options {
+		o(self)
+	}
+
 	self.runtime.otto = self
 	self.runtime.traceLimit = 10
 	self.Set("console", self.runtime.newConsole())


### PR DESCRIPTION
This PR adds an options pattern to the `otto.New()` function and provides a `WithLogger()` option utilising a logger interface. At this point it is more a proof of concept. We'd still need to determine if this should be a `Logger` or a `Console` interface.