### PR TITLE
ci: enable golangci-lint cache

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -32,7 +32,8 @@ jobs:
         with:
           version: ${{ matrix.golangci }}
           args: "--out-${NO_FUTURE}format colored-line-number"
-          skip-cache: true
+          skip-pkg-cache: true
+          skip-build-cache: true
 
       - name: Go Build
         run: go build ./...


### PR DESCRIPTION
Remove skip-cache: true and restore skip-pkg-cache: true and skip-build-cache: true so that we still cache golangci-lint results
which skip-cache: true disables.