### PR TITLE
fix: array writes

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -634,6 +634,11 @@ func (self *_runtime) convertCallParameter(v Value, t reflect.Type) (reflect.Val
 }
 
 func (self *_runtime) toValue(value interface{}) Value {
+	rv, ok := value.(reflect.Value)
+	if ok {
+		value = rv.Interface()
+	}
+
 	switch value := value.(type) {
 	case Value:
 		return value
@@ -666,6 +671,10 @@ func (self *_runtime) toValue(value interface{}) Value {
 	default:
 		{
 			value := reflect.ValueOf(value)
+			if ok && value.Kind() == rv.Kind() {
+				// Use passed in rv which may be writable.
+				value = rv
+			}
 
 			switch value.Kind() {
 			case reflect.Ptr:

--- a/type_go_array.go
+++ b/type_go_array.go
@@ -20,7 +20,7 @@ type _goArrayObject struct {
 }
 
 func _newGoArrayObject(value reflect.Value) *_goArrayObject {
-	writable := value.Kind() == reflect.Ptr // The Array is addressable (like a Slice)
+	writable := value.Kind() == reflect.Ptr || value.CanSet() // The Array is addressable (like a Slice)
 	mode := _propertyMode(0010)
 	if writable {
 		mode = 0110

--- a/type_go_map.go
+++ b/type_go_map.go
@@ -54,7 +54,7 @@ func goMapGetOwnProperty(self *_object, name string) *_property {
 	}
 
 	// Other methods
-	if method := self.value.(*_goMapObject).value.MethodByName(name); (method != reflect.Value{}) {
+	if method := self.value.(*_goMapObject).value.MethodByName(name); method.IsValid() {
 		return &_property{
 			value: self.runtime.toValue(method.Interface()),
 			mode:  0110,

--- a/type_go_slice.go
+++ b/type_go_slice.go
@@ -54,8 +54,7 @@ func goSliceGetOwnProperty(self *_object, name string) *_property {
 	}
 
 	// .0, .1, .2, ...
-	index := stringToArrayIndex(name)
-	if index >= 0 {
+	if index := stringToArrayIndex(name); index >= 0 {
 		value := Value{}
 		reflectValue, exists := self.value.(*_goSliceObject).getValue(index)
 		if exists {
@@ -68,7 +67,7 @@ func goSliceGetOwnProperty(self *_object, name string) *_property {
 	}
 
 	// Other methods
-	if method := self.value.(*_goSliceObject).value.MethodByName(name); (method != reflect.Value{}) {
+	if method := self.value.(*_goSliceObject).value.MethodByName(name); method.IsValid() {
 		return &_property{
 			value: self.runtime.toValue(method.Interface()),
 			mode:  0110,
@@ -106,7 +105,7 @@ func goSliceDefineOwnProperty(self *_object, name string, descriptor _property, 
 
 func goSliceDelete(self *_object, name string, throw bool) bool {
 	// length
-	if name == "length" {
+	if name == propertyLength {
 		return self.runtime.typeErrorResult(throw)
 	}
 

--- a/type_go_struct.go
+++ b/type_go_struct.go
@@ -41,12 +41,12 @@ func (self _goStructObject) getValue(name string) reflect.Value {
 	}
 
 	if validGoStructName(name) {
-		// Do not reveal hidden or unexported fields
-		if field := reflect.Indirect(self.value).FieldByName(name); (field != reflect.Value{}) {
+		// Do not reveal hidden or unexported fields.
+		if field := reflect.Indirect(self.value).FieldByName(name); field.IsValid() {
 			return field
 		}
 
-		if method := self.value.MethodByName(name); (method != reflect.Value{}) {
+		if method := self.value.MethodByName(name); method.IsValid() {
 			return method
 		}
 	}
@@ -81,7 +81,7 @@ func goStructGetOwnProperty(self *_object, name string) *_property {
 	object := self.value.(*_goStructObject)
 	value := object.getValue(name)
 	if value.IsValid() {
-		return &_property{self.runtime.toValue(value.Interface()), 0110}
+		return &_property{self.runtime.toValue(value), 0110}
 	}
 
 	return objectGetOwnProperty(self, name)


### PR DESCRIPTION
Fix array writes not being persisted by passing in writeable reflect.Value when available instead of .Interface() which looses that property.

Also:
* Use value.IsValid() instead of comparison with zero entry.
* Use propertyLength instead of literal.

Fixes #386