### PR TITLE
fix: catch panic in try catch

### DIFF
--- a/issue_test.go
+++ b/issue_test.go
@@ -928,3 +928,18 @@ func Test_issue386(t *testing.T) {
 		})
 	}
 }
+
+func Test_issue382(t *testing.T) {
+	vm := New()
+	vm.Set("panicFunc", func(call FunctionCall) Value {
+		panic("test")
+	})
+	_, err := vm.Run(`
+		try {
+			panicFunc()
+		} catch (err) {
+			console.log("panic triggered:", err)
+		}
+	`)
+	require.NoError(t, err)
+}

--- a/runtime.go
+++ b/runtime.go
@@ -121,7 +121,7 @@ func (self *_runtime) tryCatchEvaluate(inner func() Value) (tryValue Value, exce
 	// throw = Something was thrown
 	// throwValue = The value of what was thrown
 	// other = Something that changes flow (return, break, continue) that is not a throw
-	// Otherwise, some sort of unknown panic happened, we'll just propagate it
+	// Otherwise, some sort of unknown panic happened, we'll just propagate it.
 	defer func() {
 		if caught := recover(); caught != nil {
 			if exception, ok := caught.(*_exception); ok {
@@ -135,13 +135,13 @@ func (self *_runtime) tryCatchEvaluate(inner func() Value) (tryValue Value, exce
 				exception = true
 				tryValue = caught
 			default:
-				panic(caught)
+				exception = true
+				tryValue = toValue(caught)
 			}
 		}
 	}()
 
-	tryValue = inner()
-	return
+	return inner(), false
 }
 
 // toObject


### PR DESCRIPTION
Ensure that a panic is caught if thrown in a try catch block.

Fixes #382