### PR TITLE
chore: enable whitespace linter and fix errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,4 @@
 run:
-  concurrency: 4
   deadline: 6m
   skip-dirs:
     - terst
@@ -9,17 +8,9 @@ run:
 linters-settings:
   govet:
     check-shadowing: false
-  gocyclo:
-    min-complexity: 20
-  maligned:
-    suggest-new: true
-  dupl:
-    threshold: 100
   goconst:
     min-len: 2
     min-occurrences: 4
-  cyclop:
-    max-complexity: 15
 
 linters:
   enable-all: true
@@ -62,7 +53,6 @@ linters:
     - nakedret
     - nestif
     - revive
-    - whitespace
     - errorlint
     - exhaustive
     - forcetypeassert
@@ -81,8 +71,3 @@ linters:
     - dupword
     - gci
 
-issues:
-  exclude:
-    - .*Id.* should be .*ID.*
-  exclude-use-default: false
-  max-same-issues: 0

--- a/builtin.go
+++ b/builtin.go
@@ -287,7 +287,6 @@ func builtin_escape(input string) string {
 				)
 			}
 			index += width
-
 		} else {
 			output = append(output, input[index])
 			index += 1

--- a/builtin_array.go
+++ b/builtin_array.go
@@ -389,7 +389,6 @@ func sortCompare(thisObject *_object, index0, index1 uint, compare *_object) int
 }
 
 func arraySortSwap(thisObject *_object, index0, index1 uint) {
-
 	j := struct {
 		name   string
 		exists bool

--- a/builtin_string.go
+++ b/builtin_string.go
@@ -262,7 +262,6 @@ func builtinString_replace(call FunctionCall) Value {
 				result = append(result, []byte(replacement)...)
 				lastIndex = match[1]
 			}
-
 		} else {
 			replace := []byte(replaceValue.string())
 			for _, match := range found {
@@ -373,7 +372,6 @@ func builtinString_split(call FunctionCall) Value {
 
 	RETURN:
 		return toValue_object(call.runtime.newArrayOf(valueArray))
-
 	} else {
 		separator := separatorValue.string()
 

--- a/clone.go
+++ b/clone.go
@@ -13,7 +13,6 @@ type _clone struct {
 }
 
 func (in *_runtime) clone() *_runtime {
-
 	in.lck.Lock()
 	defer in.lck.Unlock()
 

--- a/cmpl_evaluate.go
+++ b/cmpl_evaluate.go
@@ -18,7 +18,6 @@ func (self *_runtime) cmpl_evaluate_nodeProgram(node *_nodeProgram, eval bool) V
 }
 
 func (self *_runtime) cmpl_call_nodeFunction(function *_object, stash *_fnStash, node *_nodeFunctionLiteral, this Value, argumentList []Value) Value {
-
 	indexOfParameterName := make([]string, len(argumentList))
 	// function(abc, def, ghi)
 	// indexOfParameterName[0] = "abc"

--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -23,7 +23,6 @@ func (self *_runtime) cmpl_evaluate_nodeExpression(node _nodeExpression) Value {
 	}
 
 	switch node := node.(type) {
-
 	case *_nodeArrayLiteral:
 		return self.cmpl_evaluate_nodeArrayLiteral(node)
 
@@ -102,7 +101,6 @@ func (self *_runtime) cmpl_evaluate_nodeExpression(node _nodeExpression) Value {
 }
 
 func (self *_runtime) cmpl_evaluate_nodeArrayLiteral(node *_nodeArrayLiteral) Value {
-
 	valueArray := []Value{}
 
 	for _, node := range node.value {
@@ -119,7 +117,6 @@ func (self *_runtime) cmpl_evaluate_nodeArrayLiteral(node *_nodeArrayLiteral) Va
 }
 
 func (self *_runtime) cmpl_evaluate_nodeAssignExpression(node *_nodeAssignExpression) Value {
-
 	left := self.cmpl_evaluate_nodeExpression(node.left)
 	right := self.cmpl_evaluate_nodeExpression(node.right)
 	rightValue := right.resolve()
@@ -135,7 +132,6 @@ func (self *_runtime) cmpl_evaluate_nodeAssignExpression(node *_nodeAssignExpres
 }
 
 func (self *_runtime) cmpl_evaluate_nodeBinaryExpression(node *_nodeBinaryExpression) Value {
-
 	left := self.cmpl_evaluate_nodeExpression(node.left)
 	leftValue := left.resolve()
 
@@ -159,7 +155,6 @@ func (self *_runtime) cmpl_evaluate_nodeBinaryExpression(node *_nodeBinaryExpres
 }
 
 func (self *_runtime) cmpl_evaluate_nodeBinaryExpression_comparison(node *_nodeBinaryExpression) Value {
-
 	left := self.cmpl_evaluate_nodeExpression(node.left).resolve()
 	right := self.cmpl_evaluate_nodeExpression(node.right).resolve()
 
@@ -312,7 +307,6 @@ func (self *_runtime) cmpl_evaluate_nodeNewExpression(node *_nodeNewExpression) 
 }
 
 func (self *_runtime) cmpl_evaluate_nodeObjectLiteral(node *_nodeObjectLiteral) Value {
-
 	result := self.newObject()
 
 	for _, property := range node.value {
@@ -349,7 +343,6 @@ func (self *_runtime) cmpl_evaluate_nodeSequenceExpression(node *_nodeSequenceEx
 }
 
 func (self *_runtime) cmpl_evaluate_nodeUnaryExpression(node *_nodeUnaryExpression) Value {
-
 	target := self.cmpl_evaluate_nodeExpression(node.operand)
 	switch node.operator {
 	case token.TYPEOF, token.DELETE:

--- a/cmpl_evaluate_statement.go
+++ b/cmpl_evaluate_statement.go
@@ -22,7 +22,6 @@ func (self *_runtime) cmpl_evaluate_nodeStatement(node _nodeStatement) Value {
 	}
 
 	switch node := node.(type) {
-
 	case *_nodeBlockStatement:
 		labels := self.labels
 		self.labels = nil
@@ -109,7 +108,6 @@ func (self *_runtime) cmpl_evaluate_nodeStatement(node _nodeStatement) Value {
 
 	case *_nodeWithStatement:
 		return self.cmpl_evaluate_nodeWithStatement(node)
-
 	}
 
 	panic(fmt.Errorf("Here be dragons: evaluate_nodeStatement(%T)", node))
@@ -136,7 +134,6 @@ func (self *_runtime) cmpl_evaluate_nodeStatementList(list []_nodeStatement) Val
 }
 
 func (self *_runtime) cmpl_evaluate_nodeDoWhileStatement(node *_nodeDoWhileStatement) Value {
-
 	labels := append(self.labels, "")
 	self.labels = nil
 
@@ -172,7 +169,6 @@ resultBreak:
 }
 
 func (self *_runtime) cmpl_evaluate_nodeForInStatement(node *_nodeForInStatement) Value {
-
 	labels := append(self.labels, "")
 	self.labels = nil
 
@@ -235,7 +231,6 @@ func (self *_runtime) cmpl_evaluate_nodeForInStatement(node *_nodeForInStatement
 }
 
 func (self *_runtime) cmpl_evaluate_nodeForStatement(node *_nodeForStatement) Value {
-
 	labels := append(self.labels, "")
 	self.labels = nil
 
@@ -309,7 +304,6 @@ func (self *_runtime) cmpl_evaluate_nodeIfStatement(node *_nodeIfStatement) Valu
 }
 
 func (self *_runtime) cmpl_evaluate_nodeSwitchStatement(node *_nodeSwitchStatement) Value {
-
 	labels := append(self.labels, "")
 	self.labels = nil
 
@@ -388,7 +382,6 @@ func (self *_runtime) cmpl_evaluate_nodeTryStatement(node *_nodeTryStatement) Va
 }
 
 func (self *_runtime) cmpl_evaluate_nodeWhileStatement(node *_nodeWhileStatement) Value {
-
 	test := node.test
 	body := node.body
 	labels := append(self.labels, "")

--- a/cmpl_parse.go
+++ b/cmpl_parse.go
@@ -20,7 +20,6 @@ func (cmpl *_compiler) parseExpression(in ast.Expression) _nodeExpression {
 	}
 
 	switch in := in.(type) {
-
 	case *ast.ArrayLiteral:
 		out := &_nodeArrayLiteral{
 			value: make([]_nodeExpression, len(in.Value)),
@@ -190,7 +189,6 @@ func (cmpl *_compiler) parseExpression(in ast.Expression) _nodeExpression {
 			name:        in.Name,
 			initializer: cmpl.parseExpression(in.Initializer),
 		}
-
 	}
 
 	panic(fmt.Errorf("Here be dragons: cmpl.parseExpression(%T)", in))
@@ -202,7 +200,6 @@ func (cmpl *_compiler) parseStatement(in ast.Statement) _nodeStatement {
 	}
 
 	switch in := in.(type) {
-
 	case *ast.BlockStatement:
 		out := &_nodeBlockStatement{
 			list: make([]_nodeStatement, len(in.List)),
@@ -353,7 +350,6 @@ func (cmpl *_compiler) parseStatement(in ast.Statement) _nodeStatement {
 			object: cmpl.parseExpression(in.Object),
 			body:   cmpl.parseStatement(in.Body),
 		}
-
 	}
 
 	panic(fmt.Errorf("Here be dragons: cmpl.parseStatement(%T)", in))

--- a/cmpl_test.go
+++ b/cmpl_test.go
@@ -34,7 +34,6 @@ func Test_cmpl(t *testing.T) {
 
 func TestParse_cmpl(t *testing.T) {
 	tt(t, func() {
-
 		test := func(src string) {
 			program, err := parser.ParseFile(nil, "", src, 0)
 			is(err, nil)

--- a/console.go
+++ b/console.go
@@ -46,6 +46,5 @@ func builtinConsole_assert(call FunctionCall) Value {
 }
 
 func (runtime *_runtime) newConsole() *_object {
-
 	return newConsoleObject(runtime)
 }

--- a/error_test.go
+++ b/error_test.go
@@ -245,7 +245,6 @@ func TestErrorContext(t *testing.T) {
 			is(len(err1.trace), 1)
 			is(err1.trace[0].location(), "C (file1.js:7:5)")
 		}
-
 	})
 }
 

--- a/evaluate.go
+++ b/evaluate.go
@@ -53,11 +53,9 @@ func (self *_runtime) evaluateModulo(left float64, right float64) Value {
 }
 
 func (self *_runtime) calculateBinaryExpression(operator token.Token, left Value, right Value) Value {
-
 	leftValue := left.resolve()
 
 	switch operator {
-
 	// Additive
 	case token.PLUS:
 		leftValue = toPrimitive(leftValue)
@@ -209,7 +207,6 @@ var lessThanTable [4](map[_lessThanResult]bool) = [4](map[_lessThanResult]bool){
 }
 
 func (self *_runtime) calculateComparison(comparator token.Token, left Value, right Value) bool {
-
 	// FIXME Use strictEqualityComparison?
 	// TODO This might be redundant now (with regards to evaluateComparison)
 	x := left.resolve()

--- a/global.go
+++ b/global.go
@@ -42,7 +42,6 @@ var (
 )
 
 func newContext() *_runtime {
-
 	self := &_runtime{}
 
 	self.globalStash = self.newObjectStash(nil, nil)
@@ -131,7 +130,6 @@ func (runtime *_runtime) newNumber(value Value) *_object {
 }
 
 func (runtime *_runtime) newRegExp(patternValue Value, flagsValue Value) *_object {
-
 	pattern := ""
 	flags := ""
 	if object := patternValue._object(); object != nil && object.class == classRegExp {

--- a/issue_test.go
+++ b/issue_test.go
@@ -765,7 +765,6 @@ func Test_issue266(t *testing.T) {
 				return a - b;
 			});
         `, "-200000000000,0,200000000000")
-
 	})
 }
 
@@ -929,7 +928,7 @@ func Test_issue386(t *testing.T) {
 	}
 }
 
-func Test_issue382(t *testing.T) {
+func Test_issue383(t *testing.T) {
 	vm := New()
 	vm.Set("panicFunc", func(call FunctionCall) Value {
 		panic("test")

--- a/object_class.go
+++ b/object_class.go
@@ -244,7 +244,6 @@ func _objectCanPut(self *_object, name string) (canPut bool, property *_property
 
 // 8.12.5
 func objectPut(self *_object, name string, value Value, throw bool) {
-
 	if true {
 		// Shortcut...
 		//

--- a/otto.go
+++ b/otto.go
@@ -532,7 +532,6 @@ func (self Otto) ContextSkip(limit int, skipNative bool) (ctx Context) {
 //	// value is [ 1, 2, 3, undefined, 4, 5, 6, 7, "abc" ]
 //	value, _ := vm.Call(`[ 1, 2, 3, undefined, 4 ].concat`, nil, 5, 6, 7, "abc")
 func (self Otto) Call(source string, this interface{}, argumentList ...interface{}) (Value, error) {
-
 	thisValue := Value{}
 
 	construct := false

--- a/otto_error_test.go
+++ b/otto_error_test.go
@@ -43,6 +43,5 @@ func TestOttoError(t *testing.T) {
             xyzzy
         `)
 		is(err, "ReferenceError: 'xyzzy' is not defined")
-
 	})
 }

--- a/otto_test.go
+++ b/otto_test.go
@@ -913,7 +913,6 @@ func TestDotMember(t *testing.T) {
 
 func Test_stringToFloat(t *testing.T) {
 	tt(t, func() {
-
 		is(parseNumber("10e10000"), _Infinity)
 		is(parseNumber("10e10_."), _NaN)
 	})
@@ -1350,7 +1349,6 @@ func TestOttoCall_clone(t *testing.T) {
 			is(err, nil)
 			is(value, `function() { return "abc"; },function() { return "ghi"; }`)
 		}
-
 	})
 }
 

--- a/parser/comments_test.go
+++ b/parser/comments_test.go
@@ -1418,7 +1418,6 @@ a = /*comment1*/new /*comment2*/ obj/*comment3*/()
 		is(checkComments((parser.comments.CommentMap)[program.Body[0].(*ast.ExpressionStatement).Expression.(*ast.AssignExpression).Right], []string{"comment1"}, ast.LEADING), nil)
 		is(checkComments((parser.comments.CommentMap)[program.Body[0].(*ast.ExpressionStatement).Expression.(*ast.AssignExpression).Right.(*ast.NewExpression).Callee], []string{"comment2"}, ast.LEADING), nil)
 		is(checkComments((parser.comments.CommentMap)[program.Body[0].(*ast.ExpressionStatement).Expression.(*ast.AssignExpression).Right.(*ast.NewExpression).Callee], []string{"comment3"}, ast.TRAILING), nil)
-
 	})
 }
 
@@ -1439,6 +1438,5 @@ a = /*comment1*/new /*comment2*/ obj/*comment3*/()
 		n := program.Body[0]
 		fmt.Printf("FOUND NODE: %v, number of comments: %v\n", reflect.TypeOf(n), len(parser.comments.CommentMap[n]))
 		displayComments(parser.comments.CommentMap)
-
 	})
 }

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -119,7 +119,6 @@ func (self *_parser) parsePrimaryExpression() ast.Expression {
 }
 
 func (self *_parser) parseRegExpLiteral() *ast.RegExpLiteral {
-
 	offset := self.chrOffset - 1 // Opening slash already gotten
 	if self.token == token.QUOTIENT_ASSIGN {
 		offset -= 1 // =
@@ -136,7 +135,6 @@ func (self *_parser) parseRegExpLiteral() *ast.RegExpLiteral {
 
 	flags := ""
 	if self.token == token.IDENTIFIER { // gim
-
 		flags = self.literal
 		self.next()
 		endOffset = self.chrOffset - 1
@@ -175,7 +173,6 @@ func (self *_parser) parseRegExpLiteral() *ast.RegExpLiteral {
 }
 
 func (self *_parser) parseVariableDeclaration(declarationList *[]*ast.VariableExpression) ast.Expression {
-
 	if self.token != token.IDENTIFIER {
 		idx := self.expect(token.IDENTIFIER)
 		self.nextStatement()
@@ -209,7 +206,6 @@ func (self *_parser) parseVariableDeclaration(declarationList *[]*ast.VariableEx
 }
 
 func (self *_parser) parseVariableDeclarationList(var_ file.Idx) []ast.Expression {
-
 	var declarationList []*ast.VariableExpression // Avoid bad expressions
 	var list []ast.Expression
 
@@ -485,7 +481,6 @@ func (self *_parser) parseNewExpression() ast.Expression {
 }
 
 func (self *_parser) parseLeftHandSideExpression() ast.Expression {
-
 	var left ast.Expression
 	if self.token == token.NEW {
 		left = self.parseNewExpression()
@@ -515,7 +510,6 @@ func (self *_parser) parseLeftHandSideExpression() ast.Expression {
 }
 
 func (self *_parser) parseLeftHandSideExpressionAllowCall() ast.Expression {
-
 	allowIn := self.scope.allowIn
 	self.scope.allowIn = true
 	defer func() {
@@ -601,7 +595,6 @@ func (self *_parser) parsePostfixExpression() ast.Expression {
 }
 
 func (self *_parser) parseUnaryExpression() ast.Expression {
-
 	switch self.token {
 	case token.PLUS, token.MINUS, token.NOT, token.BITWISE_NOT:
 		fallthrough

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -119,7 +119,6 @@ func isLineTerminator(chr rune) bool {
 }
 
 func (self *_parser) scan() (tkn token.Token, literal string, idx file.Idx) {
-
 	self.implicitSemicolon = false
 
 	for {
@@ -142,7 +141,6 @@ func (self *_parser) scan() (tkn token.Token, literal string, idx file.Idx) {
 				tkn, strict = token.IsKeyword(literal)
 
 				switch tkn {
-
 				case 0: // Not a keyword
 					if literal == "true" || literal == "false" {
 						self.insertSemicolon = true
@@ -174,7 +172,6 @@ func (self *_parser) scan() (tkn token.Token, literal string, idx file.Idx) {
 
 				default:
 					return
-
 				}
 			}
 			self.insertSemicolon = true
@@ -522,7 +519,6 @@ func (self *_parser) scanMantissa(base int) {
 }
 
 func (self *_parser) scanEscape(quote rune) {
-
 	var length, base uint32
 	switch self.chr {
 	//case '0', '1', '2', '3', '4', '5', '6', '7':
@@ -788,7 +784,6 @@ func parseStringLiteral(literal string) (string, error) {
 }
 
 func (self *_parser) scanNumericLiteral(decimalPoint bool) (token.Token, string) {
-
 	offset := self.chrOffset
 	tkn := token.NUMBER
 

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -381,6 +381,5 @@ Second line \
 			token.STRING, "\"\\x0G\"", 1,
 			token.EOF, "", 7,
 		)
-
 	})
 }

--- a/parser/marshal_test.go
+++ b/parser/marshal_test.go
@@ -38,7 +38,6 @@ func marshal(name string, children ...interface{}) interface{} {
 
 func testMarshalNode(node interface{}) interface{} {
 	switch node := node.(type) {
-
 	// Expression
 
 	case *ast.ArrayLiteral:
@@ -162,7 +161,6 @@ func testMarshalNode(node interface{}) interface{} {
 
 	case *ast.VariableStatement:
 		return marshal("Var", testMarshalNode(node.List))
-
 	}
 
 	{
@@ -193,7 +191,6 @@ func testMarshal(node interface{}) string {
 
 func TestParserAST(t *testing.T) {
 	tt(t, func() {
-
 		test := func(inputOutput string) {
 			match := matchBeforeAfterSeparator.FindStringIndex(inputOutput)
 			input := strings.TrimSpace(inputOutput[0:match[0]])

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -213,7 +213,6 @@ func ParseFile(fileSet *file.FileSet, filename string, src interface{}, mode Mod
 //
 // The parameter list, if any, should be a comma-separated list of identifiers.
 func ParseFunction(parameterList, body string) (*ast.FunctionLiteral, error) {
-
 	src := "(function(" + parameterList + ") {\n" + body + "\n})"
 
 	parser := _newParser("", src, 1, nil)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -425,7 +425,6 @@ func TestParserErr(t *testing.T) {
 		}
 
 		{ // Reserved words
-
 			test("class", "(anonymous): Line 1:1 Unexpected reserved word")
 			test("abc.class = 1", nil)
 			test("var class;", "(anonymous): Line 1:5 Unexpected reserved word")
@@ -456,7 +455,6 @@ func TestParserErr(t *testing.T) {
 		}
 
 		{ // Reserved words (strict)
-
 			test(`implements`, nil)
 			test(`abc.implements = 1`, nil)
 			test(`var implements;`, nil)

--- a/parser/regexp.go
+++ b/parser/regexp.go
@@ -34,7 +34,6 @@ type _RegExp_parser struct {
 // If the pattern is valid, but incompatible (contains a lookahead or backreference),
 // then this function returns the transformation (a non-empty string) AND an error.
 func TransformRegExp(pattern string) (string, error) {
-
 	if pattern == "" {
 		return "", nil
 	}
@@ -142,7 +141,6 @@ func (self *_RegExp_parser) scanEscape(inClass bool) {
 
 	var length, base uint32
 	switch self.chr {
-
 	case '0', '1', '2', '3', '4', '5', '6', '7':
 		var value int64
 		size := 0

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -49,7 +49,6 @@ func (self *_parser) parseStatementList() (list []ast.Statement) {
 }
 
 func (self *_parser) parseStatement() ast.Statement {
-
 	if self.token == token.EOF {
 		self.errorUnexpectedToken(self.token)
 		return &ast.BadStatement{From: self.idx, To: self.idx + 1}
@@ -271,7 +270,6 @@ func (self *_parser) parseFunctionStatement() *ast.FunctionStatement {
 }
 
 func (self *_parser) parseFunction(declaration bool) *ast.FunctionLiteral {
-
 	node := &ast.FunctionLiteral{
 		Function: self.expect(token.FUNCTION),
 	}
@@ -516,7 +514,6 @@ func (self *_parser) parseIterationStatement() ast.Statement {
 }
 
 func (self *_parser) parseForIn(into ast.Expression) *ast.ForInStatement {
-
 	// Already have consumed "<into> in"
 
 	source := self.parseExpression()
@@ -533,7 +530,6 @@ func (self *_parser) parseForIn(into ast.Expression) *ast.ForInStatement {
 }
 
 func (self *_parser) parseFor(initializer ast.Expression) *ast.ForStatement {
-
 	// Already have consumed "<initializer> ;"
 
 	var test, update ast.Expression
@@ -578,7 +574,6 @@ func (self *_parser) parseForOrForInStatement() ast.Statement {
 
 	forIn := false
 	if self.token != token.SEMICOLON {
-
 		allowIn := self.scope.allowIn
 		self.scope.allowIn = false
 		if self.token == token.VAR {

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -420,7 +420,6 @@ func Test_reflectMap(t *testing.T) {
 			_, exists := abc[2]
 			is(exists, false)
 		}
-
 	})
 }
 
@@ -477,7 +476,6 @@ func Test_reflectMapIterateKeys(t *testing.T) {
 			is(abc[10], "123")
 			is(abc[20], "123")
 		}
-
 	})
 }
 
@@ -640,7 +638,6 @@ func Test_reflectArray(t *testing.T) {
 
 		// common type string
 		{
-
 			test(`
                  abc = ["str1", "str2", "str3"];
                  abc;

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -307,7 +307,6 @@ func TestTryCatchError(t *testing.T) {
             }
             abc;
         `, "TypeError: 1 is not a function")
-
 	})
 }
 
@@ -548,7 +547,6 @@ func TestBinaryLogicalOperation(t *testing.T) {
             jkl = false
             result = abc && def || ghi && jkl
         `, true)
-
 	})
 }
 

--- a/test/tester.go
+++ b/test/tester.go
@@ -108,7 +108,6 @@ func main() {
 	filename := ""
 
 	err := func() error {
-
 		if flag.Arg(0) == "fetch" {
 			response, err := http.Get("http://api.cdnjs.com/libraries") //nolint: noctx
 			if err != nil {
@@ -179,7 +178,6 @@ func main() {
 
 		filename = flag.Arg(0)
 		return test(filename)
-
 	}()
 	if err != nil {
 		if filename != "" {

--- a/token/token.go
+++ b/token/token.go
@@ -25,7 +25,6 @@ func (tkn Token) String() string {
 
 // This is not used for anything
 func (tkn Token) precedence(in bool) int {
-
 	switch tkn {
 	case LOGICAL_OR:
 		return 1

--- a/type_date.go
+++ b/type_date.go
@@ -164,7 +164,6 @@ func dateFromGoDay(day Time.Weekday) int {
 }
 
 func newDateTime(argumentList []Value, location *Time.Location) (epoch float64) {
-
 	pick := func(index int, default_ float64) (float64, bool) {
 		if index >= len(argumentList) {
 			return default_, false
@@ -207,7 +206,6 @@ func newDateTime(argumentList []Value, location *Time.Location) (epoch float64) 
 
 		time := Time.Date(int(year), dateToGoMonth(int(month)), int(day), int(hour), int(minute), int(second), int(millisecond)*1000*1000, location)
 		return timeToEpoch(time)
-
 	} else if len(argumentList) == 0 { // 0-argument
 		time := Time.Now().UTC()
 		return timeToEpoch(time)

--- a/type_function.go
+++ b/type_function.go
@@ -174,7 +174,6 @@ func (self *_object) isCall() bool {
 
 func (self *_object) call(this Value, argumentList []Value, eval bool, frame _frame) Value {
 	switch fn := self.value.(type) {
-
 	case _nativeFunctionObject:
 		// Since eval is a native function, we only have to check for it here
 		if eval {
@@ -235,7 +234,6 @@ func (self *_object) call(this Value, argumentList []Value, eval bool, frame _fr
 
 func (self *_object) construct(argumentList []Value) Value {
 	switch fn := self.value.(type) {
-
 	case _nativeFunctionObject:
 		if fn.call == nil {
 			panic(self.runtime.panicTypeError("%v is not a function", toValue_object(self)))

--- a/value.go
+++ b/value.go
@@ -625,7 +625,6 @@ func (self Value) Export() (interface{}, error) {
 }
 
 func (self Value) export() interface{} {
-
 	switch self.kind {
 	case valueUndefined:
 		return nil
@@ -751,7 +750,6 @@ func (self Value) evaluateBreak(labels []string) _resultKind {
 }
 
 func (self Value) exportNative() interface{} {
-
 	switch self.kind {
 	case valueUndefined:
 		return self


### PR DESCRIPTION
Enable the whitespace linter and fix the errors resulting from it.

Also:
* Remove unneeded golangci-lint config for disabled linters.