### PR TITLE
fix: allow semicolon in nested do-while statements.

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -619,6 +619,8 @@ func TestParser(t *testing.T) {
             } while (0)
         `, nil)
 
+		test(`do do; while(0); while(0);`, nil)
+
 		test(`
             (function(){
                 try {

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -700,6 +700,9 @@ func (self *_parser) parseDoWhileStatement() ast.Statement {
 	node.Test = self.parseExpression()
 	self.expect(token.RIGHT_PARENTHESIS)
 
+	self.implicitSemicolon = true
+	self.optionalSemicolon()
+
 	if self.mode&StoreComments != 0 {
 		self.comments.CommentMap.AddComments(node, comments, ast.LEADING)
 		self.comments.CommentMap.AddComments(node, doComments, ast.DO)


### PR DESCRIPTION
In nested do-while statements, a semicolon after the inner `while` threw a parsing error. This change checks for the optional semicolon.

Fixes #309