### PR TITLE
fix: reduce current index type

### DIFF
--- a/builtin_array.go
+++ b/builtin_array.go
@@ -641,7 +641,7 @@ func builtinArray_reduce(call FunctionCall) Value {
 			}
 			for ; index < length; index++ {
 				if key := arrayIndexToString(index); thisObject.hasProperty(key) {
-					accumulator = iterator.call(call.runtime, Value{}, accumulator, thisObject.get(key), key, this)
+					accumulator = iterator.call(call.runtime, Value{}, accumulator, thisObject.get(key), index, this)
 				}
 			}
 			return accumulator

--- a/issue_test.go
+++ b/issue_test.go
@@ -1105,3 +1105,20 @@ func Test_issue252(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expBs, actBs)
 }
+
+func Test_issue177(t *testing.T) {
+	vm := New()
+	val, err := vm.Run(`
+		var ii = 33;
+		var ret = [3, 2, 1].reduce(
+			function(pv, cv, ci, a) {
+				return pv + cv + ci;
+			}
+		);
+		ret;
+	`)
+	require.NoError(t, err)
+	exp, err := val.Export()
+	require.NoError(t, err)
+	require.Equal(t, float64(9), exp)
+}


### PR DESCRIPTION
While not specified in the ECMA specification the current index has been typed as number by others, so match this instead of passing as string.

Fixes #177