### PR TITLE
fix: number locale support

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -107,7 +107,7 @@ func TestArray_toLocaleString(t *testing.T) {
 
 		test(`
             [ 3.14159, "abc", undefined, new Date(0) ].toLocaleString();
-        `, "3.14159,abc,,1970-01-01 00:00:00")
+        `, "3.142,abc,,1970-01-01 00:00:00")
 
 		test(`raise:
             [ { toLocaleString: undefined } ].toLocaleString();

--- a/builtin_number.go
+++ b/builtin_number.go
@@ -3,6 +3,10 @@ package otto
 import (
 	"math"
 	"strconv"
+
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+	"golang.org/x/text/number"
 )
 
 // Number
@@ -96,5 +100,13 @@ func builtinNumber_isNaN(call FunctionCall) Value {
 }
 
 func builtinNumber_toLocaleString(call FunctionCall) Value {
-	return builtinNumber_toString(call)
+	value := call.thisClassObject(classNumber).primitiveValue()
+	locale := call.Argument(0)
+	lang := defaultLanguage
+	if locale.IsDefined() {
+		lang = language.MustParse(locale.string())
+	}
+
+	p := message.NewPrinter(lang)
+	return toValue_string(p.Sprintf("%v", number.Decimal(value.value)))
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.1
+	golang.org/x/text v0.4.0
 	gopkg.in/readline.v1 v1.0.0-20160726135117-62c6fe619375
 	gopkg.in/sourcemap.v1 v1.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
+golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/readline.v1 v1.0.0-20160726135117-62c6fe619375 h1:hPki/oSSWOLiI9Gc9jyIoj33O3j29fUc9PlLha2yDj0=

--- a/issue_test.go
+++ b/issue_test.go
@@ -1122,3 +1122,12 @@ func Test_issue177(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, float64(9), exp)
 }
+
+func Test_issue285(t *testing.T) {
+	vm := New()
+	val, err := vm.Run(`(1451).toLocaleString('en-US')`)
+	require.NoError(t, err)
+	exp, err := val.Export()
+	require.NoError(t, err)
+	require.Equal(t, "1,451", exp)
+}

--- a/locale.go
+++ b/locale.go
@@ -1,0 +1,7 @@
+package otto
+
+import "golang.org/x/text/language"
+
+var (
+	defaultLanguage = language.MustParse("en-US")
+)

--- a/number_test.go
+++ b/number_test.go
@@ -136,11 +136,11 @@ func TestNumber_toLocaleString(t *testing.T) {
 
 		test(`
             [
-                new Number(451).toLocaleString(),
-                new Number(451).toLocaleString(10),
-                new Number(451).toLocaleString(8)
+                new Number(4510).toLocaleString(),
+                new Number(4510).toLocaleString('en-US'),
+				new Number(4510).toLocaleString('nl-NL')
             ];
-        `, "451,451,703")
+        `, "4,510,4,510,4.510")
 	})
 }
 


### PR DESCRIPTION
Add support for Number.toLocaleString() which was previously just using toString.

Default locale is: en-US

Fixes #285