### PR TITLE
chore: lint and naming refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /test/tester
 .idea
 dist/
+.vscode/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ run:
     - terst
   skip-files:
     - dbg/dbg.go
+    - token/token_const.go
 
 linters-settings:
   govet:
@@ -11,25 +12,17 @@ linters-settings:
   goconst:
     min-len: 2
     min-occurrences: 4
+  revive:
+    enable-all-rules: false
+    rules:
+    - name: var-naming
+      disabled: true
 
 linters:
   enable-all: true
   disable:
     - dupl
-    - gas
-    - errcheck
-    - gofmt
-    - gosimple
-    - interfacer
-    - megacheck
-    - maligned
-    - structcheck
-    - staticcheck
-    - unconvert
-    - unparam
-    - varcheck
     - lll
-    - prealloc
     - gochecknoglobals
     - gochecknoinits
     - scopelint
@@ -39,35 +32,23 @@ linters:
     - goerr113
     - wsl
     - nlreturn
-    - tagliatelle
     - gomnd
     - paralleltest
     - wrapcheck
     - testpackage
-    - golint
-    - gofumpt
-    - forbidigo
     - gocognit
-    - gocritic
-    - godot
-    - nakedret
     - nestif
-    - revive
-    - errorlint
     - exhaustive
     - forcetypeassert
-    - ifshort
-    - stylecheck
     - gocyclo
-    - misspell
     - cyclop
     - varnamelen
-    - nonamedreturns
     - maintidx
     - ireturn
     - exhaustruct
     - nosnakecase
-    - deadcode
     - dupword
-    - gci
 
+issues:
+  exclude-use-default: false
+  max-same-issues: 0

--- a/ast/comments.go
+++ b/ast/comments.go
@@ -6,32 +6,44 @@ import (
 	"github.com/robertkrimen/otto/file"
 )
 
-// CommentPosition determines where the comment is in a given context
+// CommentPosition determines where the comment is in a given context.
 type CommentPosition int
 
+// Available comment positions.
 const (
-	_        CommentPosition = iota
-	LEADING                  // Before the pertinent expression
-	TRAILING                 // After the pertinent expression
-	KEY                      // Before a key in an object
-	COLON                    // After a colon in a field declaration
-	FINAL                    // Final comments in a block, not belonging to a specific expression or the comment after a trailing , in an array or object literal
-	IF                       // After an if keyword
-	WHILE                    // After a while keyword
-	DO                       // After do keyword
-	FOR                      // After a for keyword
-	WITH                     // After a with keyword
+	_ CommentPosition = iota
+	// LEADING is before the pertinent expression.
+	LEADING
+	// TRAILING is after the pertinent expression.
+	TRAILING
+	// KEY is before a key in an object.
+	KEY
+	// COLON is after a colon in a field declaration.
+	COLON
+	// FINAL is the final comments in a block, not belonging to a specific expression or the comment after a trailing , in an array or object literal.
+	FINAL
+	// IF is after an if keyword.
+	IF
+	// WHILE is after a while keyword.
+	WHILE
+	// DO is after do keyword.
+	DO
+	// FOR is after a for keyword.
+	FOR
+	// WITH is after a with keyword.
+	WITH
+	// TBD is unknown.
 	TBD
 )
 
-// Comment contains the data of the comment
+// Comment contains the data of the comment.
 type Comment struct {
 	Begin    file.Idx
 	Text     string
 	Position CommentPosition
 }
 
-// NewComment creates a new comment
+// NewComment creates a new comment.
 func NewComment(text string, idx file.Idx) *Comment {
 	comment := &Comment{
 		Begin:    idx,
@@ -42,7 +54,7 @@ func NewComment(text string, idx file.Idx) *Comment {
 	return comment
 }
 
-// String returns a stringified version of the position
+// String returns a stringified version of the position.
 func (cp CommentPosition) String() string {
 	switch cp {
 	case LEADING:
@@ -70,23 +82,23 @@ func (cp CommentPosition) String() string {
 	}
 }
 
-// String returns a stringified version of the comment
+// String returns a stringified version of the comment.
 func (c Comment) String() string {
 	return fmt.Sprintf("Comment: %v", c.Text)
 }
 
-// Comments defines the current view of comments from the parser
+// Comments defines the current view of comments from the parser.
 type Comments struct {
 	// CommentMap is a reference to the parser comment map
 	CommentMap CommentMap
 	// Comments lists the comments scanned, not linked to a node yet
 	Comments []*Comment
-	// future lists the comments after a line break during a sequence of comments
-	future []*Comment
 	// Current is node for which comments are linked to
 	Current Expression
 
-	// wasLineBreak determines if a line break occured while scanning for comments
+	// future lists the comments after a line break during a sequence of comments
+	future []*Comment
+	// wasLineBreak determines if a line break occurred while scanning for comments
 	wasLineBreak bool
 	// primary determines whether or not processing a primary expression
 	primary bool
@@ -94,6 +106,7 @@ type Comments struct {
 	afterBlock bool
 }
 
+// NewComments returns a new Comments.
 func NewComments() *Comments {
 	comments := &Comments{
 		CommentMap: CommentMap{},
@@ -107,7 +120,7 @@ func (c *Comments) String() string {
 }
 
 // FetchAll returns all the currently scanned comments,
-// including those from the next line
+// including those from the next line.
 func (c *Comments) FetchAll() []*Comment {
 	defer func() {
 		c.Comments = nil
@@ -117,7 +130,7 @@ func (c *Comments) FetchAll() []*Comment {
 	return append(c.Comments, c.future...)
 }
 
-// Fetch returns all the currently scanned comments
+// Fetch returns all the currently scanned comments.
 func (c *Comments) Fetch() []*Comment {
 	defer func() {
 		c.Comments = nil
@@ -126,12 +139,12 @@ func (c *Comments) Fetch() []*Comment {
 	return c.Comments
 }
 
-// ResetLineBreak marks the beginning of a new statement
+// ResetLineBreak marks the beginning of a new statement.
 func (c *Comments) ResetLineBreak() {
 	c.wasLineBreak = false
 }
 
-// MarkPrimary will mark the context as processing a primary expression
+// MarkPrimary will mark the context as processing a primary expression.
 func (c *Comments) MarkPrimary() {
 	c.primary = true
 	c.wasLineBreak = false
@@ -205,7 +218,7 @@ func (c *Comments) SetExpression(node Expression) {
 	c.applyComments(node, previous, TRAILING)
 }
 
-// PostProcessNode applies all found comments to the given node
+// PostProcessNode applies all found comments to the given node.
 func (c *Comments) PostProcessNode(node Node) {
 	c.applyComments(node, nil, TRAILING)
 }
@@ -228,15 +241,15 @@ func (c *Comments) applyComments(node, previous Node, position CommentPosition) 
 	}
 }
 
-// AtLineBreak will mark a line break
+// AtLineBreak will mark a line break.
 func (c *Comments) AtLineBreak() {
 	c.wasLineBreak = true
 }
 
-// CommentMap is the data structure where all found comments are stored
+// CommentMap is the data structure where all found comments are stored.
 type CommentMap map[Node][]*Comment
 
-// AddComment adds a single comment to the map
+// AddComment adds a single comment to the map.
 func (cm CommentMap) AddComment(node Node, comment *Comment) {
 	list := cm[node]
 	list = append(list, comment)
@@ -244,7 +257,7 @@ func (cm CommentMap) AddComment(node Node, comment *Comment) {
 	cm[node] = list
 }
 
-// AddComments adds a slice of comments, given a node and an updated position
+// AddComments adds a slice of comments, given a node and an updated position.
 func (cm CommentMap) AddComments(node Node, comments []*Comment, position CommentPosition) {
 	for _, comment := range comments {
 		if comment.Position == TBD {
@@ -254,7 +267,7 @@ func (cm CommentMap) AddComments(node Node, comments []*Comment, position Commen
 	}
 }
 
-// Size returns the size of the map
+// Size returns the size of the map.
 func (cm CommentMap) Size() int {
 	size := 0
 	for _, comments := range cm {
@@ -264,7 +277,7 @@ func (cm CommentMap) Size() int {
 	return size
 }
 
-// MoveComments moves comments with a given position from a node to another
+// MoveComments moves comments with a given position from a node to another.
 func (cm CommentMap) MoveComments(from, to Node, position CommentPosition) {
 	for i, c := range cm[from] {
 		if c.Position == position {

--- a/ast/node.go
+++ b/ast/node.go
@@ -1,11 +1,8 @@
-/*
-Package ast declares types representing a JavaScript AST.
-
-# Warning
-
-The parser and AST interfaces are still works-in-progress (particularly where
-node types are concerned) and may change in the future.
-*/
+// Package ast declares types representing a JavaScript AST.
+//
+// # Warning
+// The parser and AST interfaces are still works-in-progress (particularly where
+// node types are concerned) and may change in the future.
 package ast
 
 import (
@@ -13,381 +10,929 @@ import (
 	"github.com/robertkrimen/otto/token"
 )
 
-// All nodes implement the Node interface.
+// Node is implemented by types that represent a node.
 type Node interface {
 	Idx0() file.Idx // The index of the first character belonging to the node
 	Idx1() file.Idx // The index of the first character immediately after the node
 }
 
-// ========== //
-// Expression //
-// ========== //
+// Expression is implemented by types that represent an Expression.
+type Expression interface {
+	Node
+	expression()
+}
 
-type (
-	// All expression nodes implement the Expression interface.
-	Expression interface {
-		Node
-		_expressionNode()
+// ArrayLiteral represents an array literal.
+type ArrayLiteral struct {
+	LeftBracket  file.Idx
+	RightBracket file.Idx
+	Value        []Expression
+}
+
+// Idx0 implements Node.
+func (al *ArrayLiteral) Idx0() file.Idx {
+	return al.LeftBracket
+}
+
+// Idx1 implements Node.
+func (al *ArrayLiteral) Idx1() file.Idx {
+	return al.RightBracket
+}
+
+// expression implements Expression.
+func (*ArrayLiteral) expression() {}
+
+// AssignExpression represents an assignment expression.
+type AssignExpression struct {
+	Operator token.Token
+	Left     Expression
+	Right    Expression
+}
+
+// Idx0 implements Node.
+func (ae *AssignExpression) Idx0() file.Idx {
+	return ae.Left.Idx0()
+}
+
+// Idx1 implements Node.
+func (ae *AssignExpression) Idx1() file.Idx {
+	return ae.Right.Idx1()
+}
+
+// expression implements Expression.
+func (*AssignExpression) expression() {}
+
+// BadExpression represents a bad expression.
+type BadExpression struct {
+	From file.Idx
+	To   file.Idx
+}
+
+// Idx0 implements Node.
+func (be *BadExpression) Idx0() file.Idx {
+	return be.From
+}
+
+// Idx1 implements Node.
+func (be *BadExpression) Idx1() file.Idx {
+	return be.To
+}
+
+// expression implements Expression.
+func (*BadExpression) expression() {}
+
+// BinaryExpression represents a binary expression.
+type BinaryExpression struct {
+	Operator   token.Token
+	Left       Expression
+	Right      Expression
+	Comparison bool
+}
+
+// Idx0 implements Node.
+func (be *BinaryExpression) Idx0() file.Idx {
+	return be.Left.Idx0()
+}
+
+// Idx1 implements Node.
+func (be *BinaryExpression) Idx1() file.Idx {
+	return be.Right.Idx1()
+}
+
+// expression implements Expression.
+func (*BinaryExpression) expression() {}
+
+// BooleanLiteral represents a boolean expression.
+type BooleanLiteral struct {
+	Idx     file.Idx
+	Literal string
+	Value   bool
+}
+
+// Idx0 implements Node.
+func (bl *BooleanLiteral) Idx0() file.Idx {
+	return bl.Idx
+}
+
+// Idx1 implements Node.
+func (bl *BooleanLiteral) Idx1() file.Idx {
+	return file.Idx(int(bl.Idx) + len(bl.Literal))
+}
+
+// expression implements Expression.
+func (*BooleanLiteral) expression() {}
+
+// BracketExpression represents a bracketed expression.
+type BracketExpression struct {
+	Left         Expression
+	Member       Expression
+	LeftBracket  file.Idx
+	RightBracket file.Idx
+}
+
+// Idx0 implements Node.
+func (be *BracketExpression) Idx0() file.Idx {
+	return be.Left.Idx0()
+}
+
+// Idx1 implements Node.
+func (be *BracketExpression) Idx1() file.Idx {
+	return be.RightBracket + 1
+}
+
+// expression implements Expression.
+func (*BracketExpression) expression() {}
+
+// CallExpression represents a call expression.
+type CallExpression struct {
+	Callee           Expression
+	LeftParenthesis  file.Idx
+	ArgumentList     []Expression
+	RightParenthesis file.Idx
+}
+
+// Idx0 implements Node.
+func (ce *CallExpression) Idx0() file.Idx {
+	return ce.Callee.Idx0()
+}
+
+// Idx1 implements Node.
+func (ce *CallExpression) Idx1() file.Idx {
+	return ce.RightParenthesis + 1
+}
+
+// expression implements Expression.
+func (*CallExpression) expression() {}
+
+// ConditionalExpression represents a conditional expression.
+type ConditionalExpression struct {
+	Test       Expression
+	Consequent Expression
+	Alternate  Expression
+}
+
+// Idx0 implements Node.
+func (ce *ConditionalExpression) Idx0() file.Idx {
+	return ce.Test.Idx0()
+}
+
+// Idx1 implements Node.
+func (ce *ConditionalExpression) Idx1() file.Idx {
+	return ce.Test.Idx1()
+}
+
+// expression implements Expression.
+func (*ConditionalExpression) expression() {}
+
+// DotExpression represents a dot expression.
+type DotExpression struct {
+	Left       Expression
+	Identifier *Identifier
+}
+
+// Idx0 implements Node.
+func (de *DotExpression) Idx0() file.Idx {
+	return de.Left.Idx0()
+}
+
+// Idx1 implements Node.
+func (de *DotExpression) Idx1() file.Idx {
+	return de.Identifier.Idx1()
+}
+
+// expression implements Expression.
+func (*DotExpression) expression() {}
+
+// EmptyExpression represents an empty expression.
+type EmptyExpression struct {
+	Begin file.Idx
+	End   file.Idx
+}
+
+// Idx0 implements Node.
+func (ee *EmptyExpression) Idx0() file.Idx {
+	return ee.Begin
+}
+
+// Idx1 implements Node.
+func (ee *EmptyExpression) Idx1() file.Idx {
+	return ee.End
+}
+
+// expression implements Expression.
+func (*EmptyExpression) expression() {}
+
+// FunctionLiteral represents a function literal.
+type FunctionLiteral struct {
+	Function      file.Idx
+	Name          *Identifier
+	ParameterList *ParameterList
+	Body          Statement
+	Source        string
+
+	DeclarationList []Declaration
+}
+
+// Idx0 implements Node.
+func (fl *FunctionLiteral) Idx0() file.Idx {
+	return fl.Function
+}
+
+// Idx1 implements Node.
+func (fl *FunctionLiteral) Idx1() file.Idx {
+	return fl.Body.Idx1()
+}
+
+// expression implements Expression.
+func (*FunctionLiteral) expression() {}
+
+// Identifier represents an identifier.
+type Identifier struct {
+	Name string
+	Idx  file.Idx
+}
+
+// Idx0 implements Node.
+func (i *Identifier) Idx0() file.Idx {
+	return i.Idx
+}
+
+// Idx1 implements Node.
+func (i *Identifier) Idx1() file.Idx {
+	return file.Idx(int(i.Idx) + len(i.Name))
+}
+
+// expression implements Expression.
+func (*Identifier) expression() {}
+
+// NewExpression represents a new expression.
+type NewExpression struct {
+	New              file.Idx
+	Callee           Expression
+	LeftParenthesis  file.Idx
+	ArgumentList     []Expression
+	RightParenthesis file.Idx
+}
+
+// Idx0 implements Node.
+func (ne *NewExpression) Idx0() file.Idx {
+	return ne.New
+}
+
+// Idx1 implements Node.
+func (ne *NewExpression) Idx1() file.Idx {
+	if ne.RightParenthesis > 0 {
+		return ne.RightParenthesis + 1
 	}
+	return ne.Callee.Idx1()
+}
 
-	ArrayLiteral struct {
-		LeftBracket  file.Idx
-		RightBracket file.Idx
-		Value        []Expression
+// expression implements Expression.
+func (*NewExpression) expression() {}
+
+// NullLiteral represents a null literal.
+type NullLiteral struct {
+	Idx     file.Idx
+	Literal string
+}
+
+// Idx0 implements Node.
+func (nl *NullLiteral) Idx0() file.Idx {
+	return nl.Idx
+}
+
+// Idx1 implements Node.
+func (nl *NullLiteral) Idx1() file.Idx {
+	return file.Idx(int(nl.Idx) + 4)
+}
+
+// expression implements Expression.
+func (*NullLiteral) expression() {}
+
+// NumberLiteral represents a number literal.
+type NumberLiteral struct {
+	Idx     file.Idx
+	Literal string
+	Value   interface{}
+}
+
+// Idx0 implements Node.
+func (nl *NumberLiteral) Idx0() file.Idx {
+	return nl.Idx
+}
+
+// Idx1 implements Node.
+func (nl *NumberLiteral) Idx1() file.Idx {
+	return file.Idx(int(nl.Idx) + len(nl.Literal))
+}
+
+// expression implements Expression.
+func (*NumberLiteral) expression() {}
+
+// ObjectLiteral represents an object literal.
+type ObjectLiteral struct {
+	LeftBrace  file.Idx
+	RightBrace file.Idx
+	Value      []Property
+}
+
+// Idx0 implements Node.
+func (ol *ObjectLiteral) Idx0() file.Idx {
+	return ol.LeftBrace
+}
+
+// Idx1 implements Node.
+func (ol *ObjectLiteral) Idx1() file.Idx {
+	return ol.RightBrace
+}
+
+// expression implements Expression.
+func (*ObjectLiteral) expression() {}
+
+// ParameterList represents a parameter list.
+type ParameterList struct {
+	Opening file.Idx
+	List    []*Identifier
+	Closing file.Idx
+}
+
+// Property represents a property.
+type Property struct {
+	Key   string
+	Kind  string
+	Value Expression
+}
+
+// RegExpLiteral represents a regular expression literal.
+type RegExpLiteral struct {
+	Idx     file.Idx
+	Literal string
+	Pattern string
+	Flags   string
+	Value   string
+}
+
+// Idx0 implements Node.
+func (rl *RegExpLiteral) Idx0() file.Idx {
+	return rl.Idx
+}
+
+// Idx1 implements Node.
+func (rl *RegExpLiteral) Idx1() file.Idx {
+	return file.Idx(int(rl.Idx) + len(rl.Literal))
+}
+
+// expression implements Expression.
+func (*RegExpLiteral) expression() {}
+
+// SequenceExpression represents a sequence literal.
+type SequenceExpression struct {
+	Sequence []Expression
+}
+
+// Idx0 implements Node.
+func (se *SequenceExpression) Idx0() file.Idx {
+	return se.Sequence[0].Idx0()
+}
+
+// Idx1 implements Node.
+func (se *SequenceExpression) Idx1() file.Idx {
+	return se.Sequence[0].Idx1()
+}
+
+// expression implements Expression.
+func (*SequenceExpression) expression() {}
+
+// StringLiteral represents a string literal.
+type StringLiteral struct {
+	Idx     file.Idx
+	Literal string
+	Value   string
+}
+
+// Idx0 implements Node.
+func (sl *StringLiteral) Idx0() file.Idx {
+	return sl.Idx
+}
+
+// Idx1 implements Node.
+func (sl *StringLiteral) Idx1() file.Idx {
+	return file.Idx(int(sl.Idx) + len(sl.Literal))
+}
+
+// expression implements Expression.
+func (*StringLiteral) expression() {}
+
+// ThisExpression represents a this expression.
+type ThisExpression struct {
+	Idx file.Idx
+}
+
+// Idx0 implements Node.
+func (te *ThisExpression) Idx0() file.Idx {
+	return te.Idx
+}
+
+// Idx1 implements Node.
+func (te *ThisExpression) Idx1() file.Idx {
+	return te.Idx + 4
+}
+
+// expression implements Expression.
+func (*ThisExpression) expression() {}
+
+// UnaryExpression represents a unary expression.
+type UnaryExpression struct {
+	Operator token.Token
+	Idx      file.Idx // If a prefix operation
+	Operand  Expression
+	Postfix  bool
+}
+
+// Idx0 implements Node.
+func (ue *UnaryExpression) Idx0() file.Idx {
+	return ue.Idx
+}
+
+// Idx1 implements Node.
+func (ue *UnaryExpression) Idx1() file.Idx {
+	if ue.Postfix {
+		return ue.Operand.Idx1() + 2 // ++ --
 	}
+	return ue.Operand.Idx1()
+}
 
-	AssignExpression struct {
-		Operator token.Token
-		Left     Expression
-		Right    Expression
+// expression implements Expression.
+func (*UnaryExpression) expression() {}
+
+// VariableExpression represents a variable expression.
+type VariableExpression struct {
+	Name        string
+	Idx         file.Idx
+	Initializer Expression
+}
+
+// Idx0 implements Node.
+func (ve *VariableExpression) Idx0() file.Idx {
+	return ve.Idx
+}
+
+// Idx1 implements Node.
+func (ve *VariableExpression) Idx1() file.Idx {
+	if ve.Initializer == nil {
+		return file.Idx(int(ve.Idx) + len(ve.Name) + 1)
 	}
+	return ve.Initializer.Idx1()
+}
 
-	BadExpression struct {
-		From file.Idx
-		To   file.Idx
+// expression implements Expression.
+func (*VariableExpression) expression() {}
+
+// Statement is implemented by types which represent a statement.
+type Statement interface {
+	Node
+	statement()
+}
+
+// BadStatement represents a bad statement.
+type BadStatement struct {
+	From file.Idx
+	To   file.Idx
+}
+
+// Idx0 implements Node.
+func (bs *BadStatement) Idx0() file.Idx {
+	return bs.From
+}
+
+// Idx1 implements Node.
+func (bs *BadStatement) Idx1() file.Idx {
+	return bs.To
+}
+
+// expression implements Statement.
+func (*BadStatement) statement() {}
+
+// BlockStatement represents a block statement.
+type BlockStatement struct {
+	LeftBrace  file.Idx
+	List       []Statement
+	RightBrace file.Idx
+}
+
+// Idx0 implements Node.
+func (bs *BlockStatement) Idx0() file.Idx {
+	return bs.LeftBrace
+}
+
+// Idx1 implements Node.
+func (bs *BlockStatement) Idx1() file.Idx {
+	return bs.RightBrace + 1
+}
+
+// expression implements Statement.
+func (*BlockStatement) statement() {}
+
+// BranchStatement represents a branch statement.
+type BranchStatement struct {
+	Idx   file.Idx
+	Token token.Token
+	Label *Identifier
+}
+
+// Idx1 implements Node.
+func (bs *BranchStatement) Idx1() file.Idx {
+	return bs.Idx
+}
+
+// Idx0 implements Node.
+func (bs *BranchStatement) Idx0() file.Idx {
+	return bs.Idx
+}
+
+// expression implements Statement.
+func (*BranchStatement) statement() {}
+
+// CaseStatement represents a case statement.
+type CaseStatement struct {
+	Case       file.Idx
+	Test       Expression
+	Consequent []Statement
+}
+
+// Idx0 implements Node.
+func (cs *CaseStatement) Idx0() file.Idx {
+	return cs.Case
+}
+
+// Idx1 implements Node.
+func (cs *CaseStatement) Idx1() file.Idx {
+	return cs.Consequent[len(cs.Consequent)-1].Idx1()
+}
+
+// expression implements Statement.
+func (*CaseStatement) statement() {}
+
+// CatchStatement represents a catch statement.
+type CatchStatement struct {
+	Catch     file.Idx
+	Parameter *Identifier
+	Body      Statement
+}
+
+// Idx0 implements Node.
+func (cs *CatchStatement) Idx0() file.Idx {
+	return cs.Catch
+}
+
+// Idx1 implements Node.
+func (cs *CatchStatement) Idx1() file.Idx {
+	return cs.Body.Idx1()
+}
+
+// expression implements Statement.
+func (*CatchStatement) statement() {}
+
+// DebuggerStatement represents a debugger statement.
+type DebuggerStatement struct {
+	Debugger file.Idx
+}
+
+// Idx0 implements Node.
+func (ds *DebuggerStatement) Idx0() file.Idx {
+	return ds.Debugger
+}
+
+// Idx1 implements Node.
+func (ds *DebuggerStatement) Idx1() file.Idx {
+	return ds.Debugger + 8
+}
+
+// expression implements Statement.
+func (*DebuggerStatement) statement() {}
+
+// DoWhileStatement represents a do while statement.
+type DoWhileStatement struct {
+	Do   file.Idx
+	Test Expression
+	Body Statement
+}
+
+// Idx0 implements Node.
+func (dws *DoWhileStatement) Idx0() file.Idx {
+	return dws.Do
+}
+
+// Idx1 implements Node.
+func (dws *DoWhileStatement) Idx1() file.Idx {
+	return dws.Test.Idx1()
+}
+
+// expression implements Statement.
+func (*DoWhileStatement) statement() {}
+
+// EmptyStatement represents a empty statement.
+type EmptyStatement struct {
+	Semicolon file.Idx
+}
+
+// Idx0 implements Node.
+func (es *EmptyStatement) Idx0() file.Idx {
+	return es.Semicolon
+}
+
+// Idx1 implements Node.
+func (es *EmptyStatement) Idx1() file.Idx {
+	return es.Semicolon + 1
+}
+
+// expression implements Statement.
+func (*EmptyStatement) statement() {}
+
+// ExpressionStatement represents a expression statement.
+type ExpressionStatement struct {
+	Expression Expression
+}
+
+// Idx0 implements Node.
+func (es *ExpressionStatement) Idx0() file.Idx {
+	return es.Expression.Idx0()
+}
+
+// Idx1 implements Node.
+func (es *ExpressionStatement) Idx1() file.Idx {
+	return es.Expression.Idx1()
+}
+
+// expression implements Statement.
+func (*ExpressionStatement) statement() {}
+
+// ForInStatement represents a for in statement.
+type ForInStatement struct {
+	For    file.Idx
+	Into   Expression
+	Source Expression
+	Body   Statement
+}
+
+// Idx0 implements Node.
+func (fis *ForInStatement) Idx0() file.Idx {
+	return fis.For
+}
+
+// Idx1 implements Node.
+func (fis *ForInStatement) Idx1() file.Idx {
+	return fis.Body.Idx1()
+}
+
+// expression implements Statement.
+func (*ForInStatement) statement() {}
+
+// ForStatement represents a for statement.
+type ForStatement struct {
+	For         file.Idx
+	Initializer Expression
+	Update      Expression
+	Test        Expression
+	Body        Statement
+}
+
+// Idx0 implements Node.
+func (fs *ForStatement) Idx0() file.Idx {
+	return fs.For
+}
+
+// Idx1 implements Node.
+func (fs *ForStatement) Idx1() file.Idx {
+	return fs.Body.Idx1()
+}
+
+// expression implements Statement.
+func (*ForStatement) statement() {}
+
+// FunctionStatement represents a function statement.
+type FunctionStatement struct {
+	Function *FunctionLiteral
+}
+
+// Idx0 implements Node.
+func (fs *FunctionStatement) Idx0() file.Idx {
+	return fs.Function.Idx0()
+}
+
+// Idx1 implements Node.
+func (fs *FunctionStatement) Idx1() file.Idx {
+	return fs.Function.Idx1()
+}
+
+// expression implements Statement.
+func (*FunctionStatement) statement() {}
+
+// IfStatement represents a if statement.
+type IfStatement struct {
+	If         file.Idx
+	Test       Expression
+	Consequent Statement
+	Alternate  Statement
+}
+
+// Idx0 implements Node.
+func (is *IfStatement) Idx0() file.Idx {
+	return is.If
+}
+
+// Idx1 implements Node.
+func (is *IfStatement) Idx1() file.Idx {
+	if is.Alternate != nil {
+		return is.Alternate.Idx1()
 	}
+	return is.Consequent.Idx1()
+}
 
-	BinaryExpression struct {
-		Operator   token.Token
-		Left       Expression
-		Right      Expression
-		Comparison bool
-	}
+// expression implements Statement.
+func (*IfStatement) statement() {}
 
-	BooleanLiteral struct {
-		Idx     file.Idx
-		Literal string
-		Value   bool
-	}
+// LabelledStatement represents a labelled statement.
+type LabelledStatement struct {
+	Label     *Identifier
+	Colon     file.Idx
+	Statement Statement
+}
 
-	BracketExpression struct {
-		Left         Expression
-		Member       Expression
-		LeftBracket  file.Idx
-		RightBracket file.Idx
-	}
+// Idx0 implements Node.
+func (ls *LabelledStatement) Idx0() file.Idx {
+	return ls.Label.Idx0()
+}
 
-	CallExpression struct {
-		Callee           Expression
-		LeftParenthesis  file.Idx
-		ArgumentList     []Expression
-		RightParenthesis file.Idx
-	}
+// Idx1 implements Node.
+func (ls *LabelledStatement) Idx1() file.Idx {
+	return ls.Colon + 1
+}
 
-	ConditionalExpression struct {
-		Test       Expression
-		Consequent Expression
-		Alternate  Expression
-	}
+// expression implements Statement.
+func (*LabelledStatement) statement() {}
 
-	DotExpression struct {
-		Left       Expression
-		Identifier *Identifier
-	}
+// ReturnStatement represents a return statement.
+type ReturnStatement struct {
+	Return   file.Idx
+	Argument Expression
+}
 
-	EmptyExpression struct {
-		Begin file.Idx
-		End   file.Idx
-	}
+// Idx0 implements Node.
+func (rs *ReturnStatement) Idx0() file.Idx {
+	return rs.Return
+}
 
-	FunctionLiteral struct {
-		Function      file.Idx
-		Name          *Identifier
-		ParameterList *ParameterList
-		Body          Statement
-		Source        string
+// Idx1 implements Node.
+func (rs *ReturnStatement) Idx1() file.Idx {
+	return rs.Return
+}
 
-		DeclarationList []Declaration
-	}
+// expression implements Statement.
+func (*ReturnStatement) statement() {}
 
-	Identifier struct {
-		Name string
-		Idx  file.Idx
-	}
+// SwitchStatement represents a switch statement.
+type SwitchStatement struct {
+	Switch       file.Idx
+	Discriminant Expression
+	Default      int
+	Body         []*CaseStatement
+}
 
-	NewExpression struct {
-		New              file.Idx
-		Callee           Expression
-		LeftParenthesis  file.Idx
-		ArgumentList     []Expression
-		RightParenthesis file.Idx
-	}
+// Idx0 implements Node.
+func (ss *SwitchStatement) Idx0() file.Idx {
+	return ss.Switch
+}
 
-	NullLiteral struct {
-		Idx     file.Idx
-		Literal string
-	}
+// Idx1 implements Node.
+func (ss *SwitchStatement) Idx1() file.Idx {
+	return ss.Body[len(ss.Body)-1].Idx1()
+}
 
-	NumberLiteral struct {
-		Idx     file.Idx
-		Literal string
-		Value   interface{}
-	}
+// expression implements Statement.
+func (*SwitchStatement) statement() {}
 
-	ObjectLiteral struct {
-		LeftBrace  file.Idx
-		RightBrace file.Idx
-		Value      []Property
-	}
+// ThrowStatement represents a throw statement.
+type ThrowStatement struct {
+	Throw    file.Idx
+	Argument Expression
+}
 
-	ParameterList struct {
-		Opening file.Idx
-		List    []*Identifier
-		Closing file.Idx
-	}
+// Idx0 implements Node.
+func (ts *ThrowStatement) Idx0() file.Idx {
+	return ts.Throw
+}
 
-	Property struct {
-		Key   string
-		Kind  string
-		Value Expression
-	}
+// Idx1 implements Node.
+func (ts *ThrowStatement) Idx1() file.Idx {
+	return ts.Throw
+}
 
-	RegExpLiteral struct {
-		Idx     file.Idx
-		Literal string
-		Pattern string
-		Flags   string
-		Value   string
-	}
+// expression implements Statement.
+func (*ThrowStatement) statement() {}
 
-	SequenceExpression struct {
-		Sequence []Expression
-	}
+// TryStatement represents a try statement.
+type TryStatement struct {
+	Try     file.Idx
+	Body    Statement
+	Catch   *CatchStatement
+	Finally Statement
+}
 
-	StringLiteral struct {
-		Idx     file.Idx
-		Literal string
-		Value   string
-	}
+// Idx0 implements Node.
+func (ts *TryStatement) Idx0() file.Idx {
+	return ts.Try
+}
 
-	ThisExpression struct {
-		Idx file.Idx
-	}
+// Idx1 implements Node.
+func (ts *TryStatement) Idx1() file.Idx {
+	return ts.Try
+}
 
-	UnaryExpression struct {
-		Operator token.Token
-		Idx      file.Idx // If a prefix operation
-		Operand  Expression
-		Postfix  bool
-	}
+// expression implements Statement.
+func (*TryStatement) statement() {}
 
-	VariableExpression struct {
-		Name        string
-		Idx         file.Idx
-		Initializer Expression
-	}
-)
+// VariableStatement represents a variable statement.
+type VariableStatement struct {
+	Var  file.Idx
+	List []Expression
+}
 
-// _expressionNode
+// Idx0 implements Node.
+func (vs *VariableStatement) Idx0() file.Idx {
+	return vs.Var
+}
 
-func (*ArrayLiteral) _expressionNode()          {}
-func (*AssignExpression) _expressionNode()      {}
-func (*BadExpression) _expressionNode()         {}
-func (*BinaryExpression) _expressionNode()      {}
-func (*BooleanLiteral) _expressionNode()        {}
-func (*BracketExpression) _expressionNode()     {}
-func (*CallExpression) _expressionNode()        {}
-func (*ConditionalExpression) _expressionNode() {}
-func (*DotExpression) _expressionNode()         {}
-func (*EmptyExpression) _expressionNode()       {}
-func (*FunctionLiteral) _expressionNode()       {}
-func (*Identifier) _expressionNode()            {}
-func (*NewExpression) _expressionNode()         {}
-func (*NullLiteral) _expressionNode()           {}
-func (*NumberLiteral) _expressionNode()         {}
-func (*ObjectLiteral) _expressionNode()         {}
-func (*RegExpLiteral) _expressionNode()         {}
-func (*SequenceExpression) _expressionNode()    {}
-func (*StringLiteral) _expressionNode()         {}
-func (*ThisExpression) _expressionNode()        {}
-func (*UnaryExpression) _expressionNode()       {}
-func (*VariableExpression) _expressionNode()    {}
+// Idx1 implements Node.
+func (vs *VariableStatement) Idx1() file.Idx {
+	return vs.List[len(vs.List)-1].Idx1()
+}
 
-// ========= //
-// Statement //
-// ========= //
+// expression implements Statement.
+func (*VariableStatement) statement() {}
 
-type (
-	// All statement nodes implement the Statement interface.
-	Statement interface {
-		Node
-		_statementNode()
-	}
+// WhileStatement represents a while statement.
+type WhileStatement struct {
+	While file.Idx
+	Test  Expression
+	Body  Statement
+}
 
-	BadStatement struct {
-		From file.Idx
-		To   file.Idx
-	}
+// Idx0 implements Node.
+func (ws *WhileStatement) Idx0() file.Idx {
+	return ws.While
+}
 
-	BlockStatement struct {
-		LeftBrace  file.Idx
-		List       []Statement
-		RightBrace file.Idx
-	}
+// Idx1 implements Node.
+func (ws *WhileStatement) Idx1() file.Idx {
+	return ws.Body.Idx1()
+}
 
-	BranchStatement struct {
-		Idx   file.Idx
-		Token token.Token
-		Label *Identifier
-	}
+// expression implements Statement.
+func (*WhileStatement) statement() {}
 
-	CaseStatement struct {
-		Case       file.Idx
-		Test       Expression
-		Consequent []Statement
-	}
+// WithStatement represents a with statement.
+type WithStatement struct {
+	With   file.Idx
+	Object Expression
+	Body   Statement
+}
 
-	CatchStatement struct {
-		Catch     file.Idx
-		Parameter *Identifier
-		Body      Statement
-	}
+// Idx0 implements Node.
+func (ws *WithStatement) Idx0() file.Idx {
+	return ws.With
+}
 
-	DebuggerStatement struct {
-		Debugger file.Idx
-	}
+// Idx1 implements Node.
+func (ws *WithStatement) Idx1() file.Idx {
+	return ws.Body.Idx1()
+}
 
-	DoWhileStatement struct {
-		Do   file.Idx
-		Test Expression
-		Body Statement
-	}
+// expression implements Statement.
+func (*WithStatement) statement() {}
 
-	EmptyStatement struct {
-		Semicolon file.Idx
-	}
+// Declaration is implemented by type which represent declarations.
+type Declaration interface {
+	declaration()
+}
 
-	ExpressionStatement struct {
-		Expression Expression
-	}
+// FunctionDeclaration represents a function declaration.
+type FunctionDeclaration struct {
+	Function *FunctionLiteral
+}
 
-	ForInStatement struct {
-		For    file.Idx
-		Into   Expression
-		Source Expression
-		Body   Statement
-	}
+func (*FunctionDeclaration) declaration() {}
 
-	ForStatement struct {
-		For         file.Idx
-		Initializer Expression
-		Update      Expression
-		Test        Expression
-		Body        Statement
-	}
+// VariableDeclaration represents a variable declaration.
+type VariableDeclaration struct {
+	Var  file.Idx
+	List []*VariableExpression
+}
 
-	FunctionStatement struct {
-		Function *FunctionLiteral
-	}
+// declaration implements Declaration.
+func (*VariableDeclaration) declaration() {}
 
-	IfStatement struct {
-		If         file.Idx
-		Test       Expression
-		Consequent Statement
-		Alternate  Statement
-	}
-
-	LabelledStatement struct {
-		Label     *Identifier
-		Colon     file.Idx
-		Statement Statement
-	}
-
-	ReturnStatement struct {
-		Return   file.Idx
-		Argument Expression
-	}
-
-	SwitchStatement struct {
-		Switch       file.Idx
-		Discriminant Expression
-		Default      int
-		Body         []*CaseStatement
-	}
-
-	ThrowStatement struct {
-		Throw    file.Idx
-		Argument Expression
-	}
-
-	TryStatement struct {
-		Try     file.Idx
-		Body    Statement
-		Catch   *CatchStatement
-		Finally Statement
-	}
-
-	VariableStatement struct {
-		Var  file.Idx
-		List []Expression
-	}
-
-	WhileStatement struct {
-		While file.Idx
-		Test  Expression
-		Body  Statement
-	}
-
-	WithStatement struct {
-		With   file.Idx
-		Object Expression
-		Body   Statement
-	}
-)
-
-// _statementNode
-
-func (*BadStatement) _statementNode()        {}
-func (*BlockStatement) _statementNode()      {}
-func (*BranchStatement) _statementNode()     {}
-func (*CaseStatement) _statementNode()       {}
-func (*CatchStatement) _statementNode()      {}
-func (*DebuggerStatement) _statementNode()   {}
-func (*DoWhileStatement) _statementNode()    {}
-func (*EmptyStatement) _statementNode()      {}
-func (*ExpressionStatement) _statementNode() {}
-func (*ForInStatement) _statementNode()      {}
-func (*ForStatement) _statementNode()        {}
-func (*FunctionStatement) _statementNode()   {}
-func (*IfStatement) _statementNode()         {}
-func (*LabelledStatement) _statementNode()   {}
-func (*ReturnStatement) _statementNode()     {}
-func (*SwitchStatement) _statementNode()     {}
-func (*ThrowStatement) _statementNode()      {}
-func (*TryStatement) _statementNode()        {}
-func (*VariableStatement) _statementNode()   {}
-func (*WhileStatement) _statementNode()      {}
-func (*WithStatement) _statementNode()       {}
-
-// =========== //
-// Declaration //
-// =========== //
-
-type (
-	// All declaration nodes implement the Declaration interface.
-	Declaration interface {
-		_declarationNode()
-	}
-
-	FunctionDeclaration struct {
-		Function *FunctionLiteral
-	}
-
-	VariableDeclaration struct {
-		Var  file.Idx
-		List []*VariableExpression
-	}
-)
-
-// _declarationNode
-
-func (*FunctionDeclaration) _declarationNode() {}
-func (*VariableDeclaration) _declarationNode() {}
-
-// ==== //
-// Node //
-// ==== //
-
+// Program represents a full program.
 type Program struct {
 	Body []Statement
 
@@ -398,122 +943,12 @@ type Program struct {
 	Comments CommentMap
 }
 
-// ==== //
-// Idx0 //
-// ==== //
-
-func (self *ArrayLiteral) Idx0() file.Idx          { return self.LeftBracket }
-func (self *AssignExpression) Idx0() file.Idx      { return self.Left.Idx0() }
-func (self *BadExpression) Idx0() file.Idx         { return self.From }
-func (self *BinaryExpression) Idx0() file.Idx      { return self.Left.Idx0() }
-func (self *BooleanLiteral) Idx0() file.Idx        { return self.Idx }
-func (self *BracketExpression) Idx0() file.Idx     { return self.Left.Idx0() }
-func (self *CallExpression) Idx0() file.Idx        { return self.Callee.Idx0() }
-func (self *ConditionalExpression) Idx0() file.Idx { return self.Test.Idx0() }
-func (self *DotExpression) Idx0() file.Idx         { return self.Left.Idx0() }
-func (self *EmptyExpression) Idx0() file.Idx       { return self.Begin }
-func (self *FunctionLiteral) Idx0() file.Idx       { return self.Function }
-func (self *Identifier) Idx0() file.Idx            { return self.Idx }
-func (self *NewExpression) Idx0() file.Idx         { return self.New }
-func (self *NullLiteral) Idx0() file.Idx           { return self.Idx }
-func (self *NumberLiteral) Idx0() file.Idx         { return self.Idx }
-func (self *ObjectLiteral) Idx0() file.Idx         { return self.LeftBrace }
-func (self *RegExpLiteral) Idx0() file.Idx         { return self.Idx }
-func (self *SequenceExpression) Idx0() file.Idx    { return self.Sequence[0].Idx0() }
-func (self *StringLiteral) Idx0() file.Idx         { return self.Idx }
-func (self *ThisExpression) Idx0() file.Idx        { return self.Idx }
-func (self *UnaryExpression) Idx0() file.Idx       { return self.Idx }
-func (self *VariableExpression) Idx0() file.Idx    { return self.Idx }
-
-func (self *BadStatement) Idx0() file.Idx        { return self.From }
-func (self *BlockStatement) Idx0() file.Idx      { return self.LeftBrace }
-func (self *BranchStatement) Idx0() file.Idx     { return self.Idx }
-func (self *CaseStatement) Idx0() file.Idx       { return self.Case }
-func (self *CatchStatement) Idx0() file.Idx      { return self.Catch }
-func (self *DebuggerStatement) Idx0() file.Idx   { return self.Debugger }
-func (self *DoWhileStatement) Idx0() file.Idx    { return self.Do }
-func (self *EmptyStatement) Idx0() file.Idx      { return self.Semicolon }
-func (self *ExpressionStatement) Idx0() file.Idx { return self.Expression.Idx0() }
-func (self *ForInStatement) Idx0() file.Idx      { return self.For }
-func (self *ForStatement) Idx0() file.Idx        { return self.For }
-func (self *FunctionStatement) Idx0() file.Idx   { return self.Function.Idx0() }
-func (self *IfStatement) Idx0() file.Idx         { return self.If }
-func (self *LabelledStatement) Idx0() file.Idx   { return self.Label.Idx0() }
-func (self *Program) Idx0() file.Idx             { return self.Body[0].Idx0() }
-func (self *ReturnStatement) Idx0() file.Idx     { return self.Return }
-func (self *SwitchStatement) Idx0() file.Idx     { return self.Switch }
-func (self *ThrowStatement) Idx0() file.Idx      { return self.Throw }
-func (self *TryStatement) Idx0() file.Idx        { return self.Try }
-func (self *VariableStatement) Idx0() file.Idx   { return self.Var }
-func (self *WhileStatement) Idx0() file.Idx      { return self.While }
-func (self *WithStatement) Idx0() file.Idx       { return self.With }
-
-// ==== //
-// Idx1 //
-// ==== //
-
-func (self *ArrayLiteral) Idx1() file.Idx          { return self.RightBracket }
-func (self *AssignExpression) Idx1() file.Idx      { return self.Right.Idx1() }
-func (self *BadExpression) Idx1() file.Idx         { return self.To }
-func (self *BinaryExpression) Idx1() file.Idx      { return self.Right.Idx1() }
-func (self *BooleanLiteral) Idx1() file.Idx        { return file.Idx(int(self.Idx) + len(self.Literal)) }
-func (self *BracketExpression) Idx1() file.Idx     { return self.RightBracket + 1 }
-func (self *CallExpression) Idx1() file.Idx        { return self.RightParenthesis + 1 }
-func (self *ConditionalExpression) Idx1() file.Idx { return self.Test.Idx1() }
-func (self *DotExpression) Idx1() file.Idx         { return self.Identifier.Idx1() }
-func (self *EmptyExpression) Idx1() file.Idx       { return self.End }
-func (self *FunctionLiteral) Idx1() file.Idx       { return self.Body.Idx1() }
-func (self *Identifier) Idx1() file.Idx            { return file.Idx(int(self.Idx) + len(self.Name)) }
-func (self *NewExpression) Idx1() file.Idx {
-	if self.RightParenthesis > 0 {
-		return self.RightParenthesis + 1
-	}
-	return self.Callee.Idx1()
-}
-func (self *NullLiteral) Idx1() file.Idx        { return file.Idx(int(self.Idx) + 4) } // "null"
-func (self *NumberLiteral) Idx1() file.Idx      { return file.Idx(int(self.Idx) + len(self.Literal)) }
-func (self *ObjectLiteral) Idx1() file.Idx      { return self.RightBrace }
-func (self *RegExpLiteral) Idx1() file.Idx      { return file.Idx(int(self.Idx) + len(self.Literal)) }
-func (self *SequenceExpression) Idx1() file.Idx { return self.Sequence[0].Idx1() }
-func (self *StringLiteral) Idx1() file.Idx      { return file.Idx(int(self.Idx) + len(self.Literal)) }
-func (self *ThisExpression) Idx1() file.Idx     { return self.Idx + 4 }
-func (self *UnaryExpression) Idx1() file.Idx {
-	if self.Postfix {
-		return self.Operand.Idx1() + 2 // ++ --
-	}
-	return self.Operand.Idx1()
-}
-func (self *VariableExpression) Idx1() file.Idx {
-	if self.Initializer == nil {
-		return file.Idx(int(self.Idx) + len(self.Name) + 1)
-	}
-	return self.Initializer.Idx1()
+// Idx0 implements Node.
+func (p *Program) Idx0() file.Idx {
+	return p.Body[0].Idx0()
 }
 
-func (self *BadStatement) Idx1() file.Idx        { return self.To }
-func (self *BlockStatement) Idx1() file.Idx      { return self.RightBrace + 1 }
-func (self *BranchStatement) Idx1() file.Idx     { return self.Idx }
-func (self *CaseStatement) Idx1() file.Idx       { return self.Consequent[len(self.Consequent)-1].Idx1() }
-func (self *CatchStatement) Idx1() file.Idx      { return self.Body.Idx1() }
-func (self *DebuggerStatement) Idx1() file.Idx   { return self.Debugger + 8 }
-func (self *DoWhileStatement) Idx1() file.Idx    { return self.Test.Idx1() }
-func (self *EmptyStatement) Idx1() file.Idx      { return self.Semicolon + 1 }
-func (self *ExpressionStatement) Idx1() file.Idx { return self.Expression.Idx1() }
-func (self *ForInStatement) Idx1() file.Idx      { return self.Body.Idx1() }
-func (self *ForStatement) Idx1() file.Idx        { return self.Body.Idx1() }
-func (self *FunctionStatement) Idx1() file.Idx   { return self.Function.Idx1() }
-func (self *IfStatement) Idx1() file.Idx {
-	if self.Alternate != nil {
-		return self.Alternate.Idx1()
-	}
-	return self.Consequent.Idx1()
+// Idx1 implements Node.
+func (p *Program) Idx1() file.Idx {
+	return p.Body[len(p.Body)-1].Idx1()
 }
-func (self *LabelledStatement) Idx1() file.Idx { return self.Colon + 1 }
-func (self *Program) Idx1() file.Idx           { return self.Body[len(self.Body)-1].Idx1() }
-func (self *ReturnStatement) Idx1() file.Idx   { return self.Return }
-func (self *SwitchStatement) Idx1() file.Idx   { return self.Body[len(self.Body)-1].Idx1() }
-func (self *ThrowStatement) Idx1() file.Idx    { return self.Throw }
-func (self *TryStatement) Idx1() file.Idx      { return self.Try }
-func (self *VariableStatement) Idx1() file.Idx { return self.List[len(self.List)-1].Idx1() }
-func (self *WhileStatement) Idx1() file.Idx    { return self.Body.Idx1() }
-func (self *WithStatement) Idx1() file.Idx     { return self.Body.Idx1() }

--- a/ast/walk_test.go
+++ b/ast/walk_test.go
@@ -30,8 +30,7 @@ func (w *walker) pop(n ast.Node) {
 		panic("pop of empty stack")
 	}
 
-	toPop := w.stack[size-1]
-	if toPop != n {
+	if toPop := w.stack[size-1]; toPop != n {
 		panic("pop: nodes do not equal")
 	}
 

--- a/builtin_boolean.go
+++ b/builtin_boolean.go
@@ -3,26 +3,26 @@ package otto
 // Boolean
 
 func builtinBoolean(call FunctionCall) Value {
-	return toValue_bool(call.Argument(0).bool())
+	return boolValue(call.Argument(0).bool())
 }
 
-func builtinNewBoolean(self *_object, argumentList []Value) Value {
-	return toValue_object(self.runtime.newBoolean(valueOfArrayIndex(argumentList, 0)))
+func builtinNewBoolean(obj *object, argumentList []Value) Value {
+	return objectValue(obj.runtime.newBoolean(valueOfArrayIndex(argumentList, 0)))
 }
 
-func builtinBoolean_toString(call FunctionCall) Value {
+func builtinBooleanToString(call FunctionCall) Value {
 	value := call.This
 	if !value.IsBoolean() {
 		// Will throw a TypeError if ThisObject is not a Boolean
-		value = call.thisClassObject(classBoolean).primitiveValue()
+		value = call.thisClassObject(classBooleanName).primitiveValue()
 	}
-	return toValue_string(value.string())
+	return stringValue(value.string())
 }
 
-func builtinBoolean_valueOf(call FunctionCall) Value {
+func builtinBooleanValueOf(call FunctionCall) Value {
 	value := call.This
 	if !value.IsBoolean() {
-		value = call.thisClassObject(classBoolean).primitiveValue()
+		value = call.thisClassObject(classBooleanName).primitiveValue()
 	}
 	return value
 }

--- a/builtin_date.go
+++ b/builtin_date.go
@@ -9,114 +9,111 @@ import (
 
 const (
 	// TODO Be like V8?
-	// builtinDate_goDateTimeLayout = "Mon Jan 2 2006 15:04:05 GMT-0700 (MST)"
-	builtinDate_goDateTimeLayout = Time.RFC1123 // "Mon, 02 Jan 2006 15:04:05 MST"
-	builtinDate_goDateLayout     = "Mon, 02 Jan 2006"
-	builtinDate_goTimeLayout     = "15:04:05 MST"
+	// builtinDateDateTimeLayout = "Mon Jan 2 2006 15:04:05 GMT-0700 (MST)".
+	builtinDateDateTimeLayout = Time.RFC1123 // "Mon, 02 Jan 2006 15:04:05 MST"
+	builtinDateDateLayout     = "Mon, 02 Jan 2006"
+	builtinDateTimeLayout     = "15:04:05 MST"
 )
 
-var (
-	// utcTimeZone is the time zone used for UTC calculations.
-	// It is GMT not UTC as that's what Javascript does because toUTCString is
-	// actually an alias to toGMTString.
-	utcTimeZone = Time.FixedZone("GMT", 0)
-)
+// utcTimeZone is the time zone used for UTC calculations.
+// It is GMT not UTC as that's what Javascript does because toUTCString is
+// actually an alias to toGMTString.
+var utcTimeZone = Time.FixedZone("GMT", 0)
 
 func builtinDate(call FunctionCall) Value {
-	date := &_dateObject{}
+	date := &dateObject{}
 	date.Set(newDateTime([]Value{}, Time.Local))
-	return toValue_string(date.Time().Format(builtinDate_goDateTimeLayout))
+	return stringValue(date.Time().Format(builtinDateDateTimeLayout))
 }
 
-func builtinNewDate(self *_object, argumentList []Value) Value {
-	return toValue_object(self.runtime.newDate(newDateTime(argumentList, Time.Local)))
+func builtinNewDate(obj *object, argumentList []Value) Value {
+	return objectValue(obj.runtime.newDate(newDateTime(argumentList, Time.Local)))
 }
 
-func builtinDate_toString(call FunctionCall) Value {
+func builtinDateToString(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
-		return toValue_string("Invalid Date")
+		return stringValue("Invalid Date")
 	}
-	return toValue_string(date.Time().Local().Format(builtinDate_goDateTimeLayout))
+	return stringValue(date.Time().Local().Format(builtinDateDateTimeLayout))
 }
 
-func builtinDate_toDateString(call FunctionCall) Value {
+func builtinDateToDateString(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
-		return toValue_string("Invalid Date")
+		return stringValue("Invalid Date")
 	}
-	return toValue_string(date.Time().Local().Format(builtinDate_goDateLayout))
+	return stringValue(date.Time().Local().Format(builtinDateDateLayout))
 }
 
-func builtinDate_toTimeString(call FunctionCall) Value {
+func builtinDateToTimeString(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
-		return toValue_string("Invalid Date")
+		return stringValue("Invalid Date")
 	}
-	return toValue_string(date.Time().Local().Format(builtinDate_goTimeLayout))
+	return stringValue(date.Time().Local().Format(builtinDateTimeLayout))
 }
 
-func builtinDate_toUTCString(call FunctionCall) Value {
+func builtinDateToUTCString(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
-		return toValue_string("Invalid Date")
+		return stringValue("Invalid Date")
 	}
-	return toValue_string(date.Time().In(utcTimeZone).Format(builtinDate_goDateTimeLayout))
+	return stringValue(date.Time().In(utcTimeZone).Format(builtinDateDateTimeLayout))
 }
 
-func builtinDate_toISOString(call FunctionCall) Value {
+func builtinDateToISOString(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
-		return toValue_string("Invalid Date")
+		return stringValue("Invalid Date")
 	}
-	return toValue_string(date.Time().Format("2006-01-02T15:04:05.000Z"))
+	return stringValue(date.Time().Format("2006-01-02T15:04:05.000Z"))
 }
 
-func builtinDate_toJSON(call FunctionCall) Value {
-	object := call.thisObject()
-	value := object.DefaultValue(defaultValueHintNumber) // FIXME object.primitiveNumberValue
-	{                                                    // FIXME value.isFinite
-		value := value.float64()
-		if math.IsNaN(value) || math.IsInf(value, 0) {
-			return nullValue
-		}
+func builtinDateToJSON(call FunctionCall) Value {
+	obj := call.thisObject()
+	value := obj.DefaultValue(defaultValueHintNumber) // FIXME object.primitiveNumberValue
+	// FIXME fv.isFinite
+	if fv := value.float64(); math.IsNaN(fv) || math.IsInf(fv, 0) {
+		return nullValue
 	}
-	toISOString := object.get("toISOString")
+
+	toISOString := obj.get("toISOString")
 	if !toISOString.isCallable() {
 		// FIXME
 		panic(call.runtime.panicTypeError())
 	}
-	return toISOString.call(call.runtime, toValue_object(object), []Value{})
+	return toISOString.call(call.runtime, objectValue(obj), []Value{})
 }
 
-func builtinDate_toGMTString(call FunctionCall) Value {
+func builtinDateToGMTString(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
-		return toValue_string("Invalid Date")
+		return stringValue("Invalid Date")
 	}
-	return toValue_string(date.Time().Format("Mon, 02 Jan 2006 15:04:05 GMT"))
+	return stringValue(date.Time().Format("Mon, 02 Jan 2006 15:04:05 GMT"))
 }
 
-func builtinDate_getTime(call FunctionCall) Value {
+func builtinDateGetTime(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
 	}
 	// We do this (convert away from a float) so the user
 	// does not get something back in exponential notation
-	return toValue_int64(int64(date.Epoch()))
+	return int64Value(date.Epoch())
 }
 
-func builtinDate_setTime(call FunctionCall) Value {
-	object := call.thisObject()
+func builtinDateSetTime(call FunctionCall) Value {
+	obj := call.thisObject()
 	date := dateObjectOf(call.runtime, call.thisObject())
 	date.Set(call.Argument(0).float64())
-	object.value = date
+	obj.value = date
 	return date.Value()
 }
 
-func _builtinDate_beforeSet(call FunctionCall, argumentLimit int, timeLocal bool) (*_object, *_dateObject, *_ecmaTime, []int) {
-	object := call.thisObject()
+func builtinDateBeforeSet(call FunctionCall, argumentLimit int, timeLocal bool) (*object, *dateObject, *ecmaTime, []int) {
+	obj := call.thisObject()
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return nil, nil, nil, nil
@@ -127,7 +124,7 @@ func _builtinDate_beforeSet(call FunctionCall, argumentLimit int, timeLocal bool
 	}
 
 	if argumentLimit == 0 {
-		object.value = invalidDateObject
+		obj.value = invalidDateObject
 		return nil, nil, nil, nil
 	}
 
@@ -138,7 +135,7 @@ func _builtinDate_beforeSet(call FunctionCall, argumentLimit int, timeLocal bool
 		switch nm.kind {
 		case numberInteger, numberFloat:
 		default:
-			object.value = invalidDateObject
+			obj.value = invalidDateObject
 			return nil, nil, nil, nil
 		}
 		valueList[index] = int(nm.int64)
@@ -147,52 +144,52 @@ func _builtinDate_beforeSet(call FunctionCall, argumentLimit int, timeLocal bool
 	if timeLocal {
 		baseTime = baseTime.Local()
 	}
-	ecmaTime := ecmaTime(baseTime)
-	return object, &date, &ecmaTime, valueList
+	ecmaTime := newEcmaTime(baseTime)
+	return obj, &date, &ecmaTime, valueList
 }
 
-func builtinDate_parse(call FunctionCall) Value {
+func builtinDateParse(call FunctionCall) Value {
 	date := call.Argument(0).string()
-	return toValue_float64(dateParse(date))
+	return float64Value(dateParse(date))
 }
 
-func builtinDate_UTC(call FunctionCall) Value {
-	return toValue_float64(newDateTime(call.ArgumentList, Time.UTC))
+func builtinDateUTC(call FunctionCall) Value {
+	return float64Value(newDateTime(call.ArgumentList, Time.UTC))
 }
 
-func builtinDate_now(call FunctionCall) Value {
+func builtinDateNow(call FunctionCall) Value {
 	call.ArgumentList = []Value(nil)
-	return builtinDate_UTC(call)
+	return builtinDateUTC(call)
 }
 
-// This is a placeholder
-func builtinDate_toLocaleString(call FunctionCall) Value {
+// This is a placeholder.
+func builtinDateToLocaleString(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
-		return toValue_string("Invalid Date")
+		return stringValue("Invalid Date")
 	}
-	return toValue_string(date.Time().Local().Format("2006-01-02 15:04:05"))
+	return stringValue(date.Time().Local().Format("2006-01-02 15:04:05"))
 }
 
-// This is a placeholder
-func builtinDate_toLocaleDateString(call FunctionCall) Value {
+// This is a placeholder.
+func builtinDateToLocaleDateString(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
-		return toValue_string("Invalid Date")
+		return stringValue("Invalid Date")
 	}
-	return toValue_string(date.Time().Local().Format("2006-01-02"))
+	return stringValue(date.Time().Local().Format("2006-01-02"))
 }
 
-// This is a placeholder
-func builtinDate_toLocaleTimeString(call FunctionCall) Value {
+// This is a placeholder.
+func builtinDateToLocaleTimeString(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
-		return toValue_string("Invalid Date")
+		return stringValue("Invalid Date")
 	}
-	return toValue_string(date.Time().Local().Format("15:04:05"))
+	return stringValue(date.Time().Local().Format("15:04:05"))
 }
 
-func builtinDate_valueOf(call FunctionCall) Value {
+func builtinDateValueOf(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
@@ -200,148 +197,148 @@ func builtinDate_valueOf(call FunctionCall) Value {
 	return date.Value()
 }
 
-func builtinDate_getYear(call FunctionCall) Value {
+func builtinDateGetYear(call FunctionCall) Value {
 	// Will throw a TypeError is ThisObject is nil or
 	// does not have Class of "Date"
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
 	}
-	return toValue_int(date.Time().Local().Year() - 1900)
+	return intValue(date.Time().Local().Year() - 1900)
 }
 
-func builtinDate_getFullYear(call FunctionCall) Value {
+func builtinDateGetFullYear(call FunctionCall) Value {
 	// Will throw a TypeError is ThisObject is nil or
 	// does not have Class of "Date"
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
 	}
-	return toValue_int(date.Time().Local().Year())
+	return intValue(date.Time().Local().Year())
 }
 
-func builtinDate_getUTCFullYear(call FunctionCall) Value {
+func builtinDateGetUTCFullYear(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
 	}
-	return toValue_int(date.Time().Year())
+	return intValue(date.Time().Year())
 }
 
-func builtinDate_getMonth(call FunctionCall) Value {
+func builtinDateGetMonth(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
 	}
-	return toValue_int(dateFromGoMonth(date.Time().Local().Month()))
+	return intValue(dateFromGoMonth(date.Time().Local().Month()))
 }
 
-func builtinDate_getUTCMonth(call FunctionCall) Value {
+func builtinDateGetUTCMonth(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
 	}
-	return toValue_int(dateFromGoMonth(date.Time().Month()))
+	return intValue(dateFromGoMonth(date.Time().Month()))
 }
 
-func builtinDate_getDate(call FunctionCall) Value {
+func builtinDateGetDate(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
 	}
-	return toValue_int(date.Time().Local().Day())
+	return intValue(date.Time().Local().Day())
 }
 
-func builtinDate_getUTCDate(call FunctionCall) Value {
+func builtinDateGetUTCDate(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
 	}
-	return toValue_int(date.Time().Day())
+	return intValue(date.Time().Day())
 }
 
-func builtinDate_getDay(call FunctionCall) Value {
+func builtinDateGetDay(call FunctionCall) Value {
 	// Actually day of the week
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
 	}
-	return toValue_int(dateFromGoDay(date.Time().Local().Weekday()))
+	return intValue(dateFromGoDay(date.Time().Local().Weekday()))
 }
 
-func builtinDate_getUTCDay(call FunctionCall) Value {
+func builtinDateGetUTCDay(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
 	}
-	return toValue_int(dateFromGoDay(date.Time().Weekday()))
+	return intValue(dateFromGoDay(date.Time().Weekday()))
 }
 
-func builtinDate_getHours(call FunctionCall) Value {
+func builtinDateGetHours(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
 	}
-	return toValue_int(date.Time().Local().Hour())
+	return intValue(date.Time().Local().Hour())
 }
 
-func builtinDate_getUTCHours(call FunctionCall) Value {
+func builtinDateGetUTCHours(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
 	}
-	return toValue_int(date.Time().Hour())
+	return intValue(date.Time().Hour())
 }
 
-func builtinDate_getMinutes(call FunctionCall) Value {
+func builtinDateGetMinutes(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
 	}
-	return toValue_int(date.Time().Local().Minute())
+	return intValue(date.Time().Local().Minute())
 }
 
-func builtinDate_getUTCMinutes(call FunctionCall) Value {
+func builtinDateGetUTCMinutes(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
 	}
-	return toValue_int(date.Time().Minute())
+	return intValue(date.Time().Minute())
 }
 
-func builtinDate_getSeconds(call FunctionCall) Value {
+func builtinDateGetSeconds(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
 	}
-	return toValue_int(date.Time().Local().Second())
+	return intValue(date.Time().Local().Second())
 }
 
-func builtinDate_getUTCSeconds(call FunctionCall) Value {
+func builtinDateGetUTCSeconds(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
 	}
-	return toValue_int(date.Time().Second())
+	return intValue(date.Time().Second())
 }
 
-func builtinDate_getMilliseconds(call FunctionCall) Value {
+func builtinDateGetMilliseconds(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
 	}
-	return toValue_int(date.Time().Local().Nanosecond() / (100 * 100 * 100))
+	return intValue(date.Time().Local().Nanosecond() / (100 * 100 * 100))
 }
 
-func builtinDate_getUTCMilliseconds(call FunctionCall) Value {
+func builtinDateGetUTCMilliseconds(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
 	}
-	return toValue_int(date.Time().Nanosecond() / (100 * 100 * 100))
+	return intValue(date.Time().Nanosecond() / (100 * 100 * 100))
 }
 
-func builtinDate_getTimezoneOffset(call FunctionCall) Value {
+func builtinDateGetTimezoneOffset(call FunctionCall) Value {
 	date := dateObjectOf(call.runtime, call.thisObject())
 	if date.isNaN {
 		return NaNValue()
@@ -358,11 +355,11 @@ func builtinDate_getTimezoneOffset(call FunctionCall) Value {
 		timeLocal.Nanosecond(),
 		Time.UTC,
 	)
-	return toValue_float64(date.Time().Sub(timeLocalAsUTC).Seconds() / 60)
+	return float64Value(date.Time().Sub(timeLocalAsUTC).Seconds() / 60)
 }
 
-func builtinDate_setMilliseconds(call FunctionCall) Value {
-	object, date, ecmaTime, value := _builtinDate_beforeSet(call, 1, true)
+func builtinDateSetMilliseconds(call FunctionCall) Value {
+	obj, date, ecmaTime, value := builtinDateBeforeSet(call, 1, true)
 	if ecmaTime == nil {
 		return NaNValue()
 	}
@@ -370,12 +367,12 @@ func builtinDate_setMilliseconds(call FunctionCall) Value {
 	ecmaTime.millisecond = value[0]
 
 	date.SetTime(ecmaTime.goTime())
-	object.value = *date
+	obj.value = *date
 	return date.Value()
 }
 
-func builtinDate_setUTCMilliseconds(call FunctionCall) Value {
-	object, date, ecmaTime, value := _builtinDate_beforeSet(call, 1, false)
+func builtinDateSetUTCMilliseconds(call FunctionCall) Value {
+	obj, date, ecmaTime, value := builtinDateBeforeSet(call, 1, false)
 	if ecmaTime == nil {
 		return NaNValue()
 	}
@@ -383,12 +380,12 @@ func builtinDate_setUTCMilliseconds(call FunctionCall) Value {
 	ecmaTime.millisecond = value[0]
 
 	date.SetTime(ecmaTime.goTime())
-	object.value = *date
+	obj.value = *date
 	return date.Value()
 }
 
-func builtinDate_setSeconds(call FunctionCall) Value {
-	object, date, ecmaTime, value := _builtinDate_beforeSet(call, 2, true)
+func builtinDateSetSeconds(call FunctionCall) Value {
+	obj, date, ecmaTime, value := builtinDateBeforeSet(call, 2, true)
 	if ecmaTime == nil {
 		return NaNValue()
 	}
@@ -399,12 +396,12 @@ func builtinDate_setSeconds(call FunctionCall) Value {
 	ecmaTime.second = value[0]
 
 	date.SetTime(ecmaTime.goTime())
-	object.value = *date
+	obj.value = *date
 	return date.Value()
 }
 
-func builtinDate_setUTCSeconds(call FunctionCall) Value {
-	object, date, ecmaTime, value := _builtinDate_beforeSet(call, 2, false)
+func builtinDateSetUTCSeconds(call FunctionCall) Value {
+	obj, date, ecmaTime, value := builtinDateBeforeSet(call, 2, false)
 	if ecmaTime == nil {
 		return NaNValue()
 	}
@@ -415,12 +412,12 @@ func builtinDate_setUTCSeconds(call FunctionCall) Value {
 	ecmaTime.second = value[0]
 
 	date.SetTime(ecmaTime.goTime())
-	object.value = *date
+	obj.value = *date
 	return date.Value()
 }
 
-func builtinDate_setMinutes(call FunctionCall) Value {
-	object, date, ecmaTime, value := _builtinDate_beforeSet(call, 3, true)
+func builtinDateSetMinutes(call FunctionCall) Value {
+	obj, date, ecmaTime, value := builtinDateBeforeSet(call, 3, true)
 	if ecmaTime == nil {
 		return NaNValue()
 	}
@@ -434,12 +431,12 @@ func builtinDate_setMinutes(call FunctionCall) Value {
 	ecmaTime.minute = value[0]
 
 	date.SetTime(ecmaTime.goTime())
-	object.value = *date
+	obj.value = *date
 	return date.Value()
 }
 
-func builtinDate_setUTCMinutes(call FunctionCall) Value {
-	object, date, ecmaTime, value := _builtinDate_beforeSet(call, 3, false)
+func builtinDateSetUTCMinutes(call FunctionCall) Value {
+	obj, date, ecmaTime, value := builtinDateBeforeSet(call, 3, false)
 	if ecmaTime == nil {
 		return NaNValue()
 	}
@@ -453,58 +450,58 @@ func builtinDate_setUTCMinutes(call FunctionCall) Value {
 	ecmaTime.minute = value[0]
 
 	date.SetTime(ecmaTime.goTime())
-	object.value = *date
+	obj.value = *date
 	return date.Value()
 }
 
-func builtinDate_setHours(call FunctionCall) Value {
-	object, date, ecmaTime, value := _builtinDate_beforeSet(call, 4, true)
+func builtinDateSetHours(call FunctionCall) Value {
+	obj, date, ecmaTime, value := builtinDateBeforeSet(call, 4, true)
 	if ecmaTime == nil {
 		return NaNValue()
 	}
 
-	if len(value) > 3 {
+	switch {
+	case len(value) > 3:
 		ecmaTime.millisecond = value[3]
+		fallthrough
+	case len(value) > 2:
 		ecmaTime.second = value[2]
-		ecmaTime.minute = value[1]
-	} else if len(value) > 2 {
-		ecmaTime.second = value[2]
-		ecmaTime.minute = value[1]
-	} else if len(value) > 1 {
+		fallthrough
+	case len(value) > 1:
 		ecmaTime.minute = value[1]
 	}
 	ecmaTime.hour = value[0]
 
 	date.SetTime(ecmaTime.goTime())
-	object.value = *date
+	obj.value = *date
 	return date.Value()
 }
 
-func builtinDate_setUTCHours(call FunctionCall) Value {
-	object, date, ecmaTime, value := _builtinDate_beforeSet(call, 4, false)
+func builtinDateSetUTCHours(call FunctionCall) Value {
+	obj, date, ecmaTime, value := builtinDateBeforeSet(call, 4, false)
 	if ecmaTime == nil {
 		return NaNValue()
 	}
 
-	if len(value) > 3 {
+	switch {
+	case len(value) > 3:
 		ecmaTime.millisecond = value[3]
+		fallthrough
+	case len(value) > 2:
 		ecmaTime.second = value[2]
-		ecmaTime.minute = value[1]
-	} else if len(value) > 2 {
-		ecmaTime.second = value[2]
-		ecmaTime.minute = value[1]
-	} else if len(value) > 1 {
+		fallthrough
+	case len(value) > 1:
 		ecmaTime.minute = value[1]
 	}
 	ecmaTime.hour = value[0]
 
 	date.SetTime(ecmaTime.goTime())
-	object.value = *date
+	obj.value = *date
 	return date.Value()
 }
 
-func builtinDate_setDate(call FunctionCall) Value {
-	object, date, ecmaTime, value := _builtinDate_beforeSet(call, 1, true)
+func builtinDateSetDate(call FunctionCall) Value {
+	obj, date, ecmaTime, value := builtinDateBeforeSet(call, 1, true)
 	if ecmaTime == nil {
 		return NaNValue()
 	}
@@ -512,12 +509,12 @@ func builtinDate_setDate(call FunctionCall) Value {
 	ecmaTime.day = value[0]
 
 	date.SetTime(ecmaTime.goTime())
-	object.value = *date
+	obj.value = *date
 	return date.Value()
 }
 
-func builtinDate_setUTCDate(call FunctionCall) Value {
-	object, date, ecmaTime, value := _builtinDate_beforeSet(call, 1, false)
+func builtinDateSetUTCDate(call FunctionCall) Value {
+	obj, date, ecmaTime, value := builtinDateBeforeSet(call, 1, false)
 	if ecmaTime == nil {
 		return NaNValue()
 	}
@@ -525,12 +522,12 @@ func builtinDate_setUTCDate(call FunctionCall) Value {
 	ecmaTime.day = value[0]
 
 	date.SetTime(ecmaTime.goTime())
-	object.value = *date
+	obj.value = *date
 	return date.Value()
 }
 
-func builtinDate_setMonth(call FunctionCall) Value {
-	object, date, ecmaTime, value := _builtinDate_beforeSet(call, 2, true)
+func builtinDateSetMonth(call FunctionCall) Value {
+	obj, date, ecmaTime, value := builtinDateBeforeSet(call, 2, true)
 	if ecmaTime == nil {
 		return NaNValue()
 	}
@@ -541,12 +538,12 @@ func builtinDate_setMonth(call FunctionCall) Value {
 	ecmaTime.month = value[0]
 
 	date.SetTime(ecmaTime.goTime())
-	object.value = *date
+	obj.value = *date
 	return date.Value()
 }
 
-func builtinDate_setUTCMonth(call FunctionCall) Value {
-	object, date, ecmaTime, value := _builtinDate_beforeSet(call, 2, false)
+func builtinDateSetUTCMonth(call FunctionCall) Value {
+	obj, date, ecmaTime, value := builtinDateBeforeSet(call, 2, false)
 	if ecmaTime == nil {
 		return NaNValue()
 	}
@@ -557,12 +554,12 @@ func builtinDate_setUTCMonth(call FunctionCall) Value {
 	ecmaTime.month = value[0]
 
 	date.SetTime(ecmaTime.goTime())
-	object.value = *date
+	obj.value = *date
 	return date.Value()
 }
 
-func builtinDate_setYear(call FunctionCall) Value {
-	object, date, ecmaTime, value := _builtinDate_beforeSet(call, 1, true)
+func builtinDateSetYear(call FunctionCall) Value {
+	obj, date, ecmaTime, value := builtinDateBeforeSet(call, 1, true)
 	if ecmaTime == nil {
 		return NaNValue()
 	}
@@ -574,12 +571,12 @@ func builtinDate_setYear(call FunctionCall) Value {
 	ecmaTime.year = year
 
 	date.SetTime(ecmaTime.goTime())
-	object.value = *date
+	obj.value = *date
 	return date.Value()
 }
 
-func builtinDate_setFullYear(call FunctionCall) Value {
-	object, date, ecmaTime, value := _builtinDate_beforeSet(call, 3, true)
+func builtinDateSetFullYear(call FunctionCall) Value {
+	obj, date, ecmaTime, value := builtinDateBeforeSet(call, 3, true)
 	if ecmaTime == nil {
 		return NaNValue()
 	}
@@ -593,12 +590,12 @@ func builtinDate_setFullYear(call FunctionCall) Value {
 	ecmaTime.year = value[0]
 
 	date.SetTime(ecmaTime.goTime())
-	object.value = *date
+	obj.value = *date
 	return date.Value()
 }
 
-func builtinDate_setUTCFullYear(call FunctionCall) Value {
-	object, date, ecmaTime, value := _builtinDate_beforeSet(call, 3, false)
+func builtinDateSetUTCFullYear(call FunctionCall) Value {
+	obj, date, ecmaTime, value := builtinDateBeforeSet(call, 3, false)
 	if ecmaTime == nil {
 		return NaNValue()
 	}
@@ -612,7 +609,7 @@ func builtinDate_setUTCFullYear(call FunctionCall) Value {
 	ecmaTime.year = value[0]
 
 	date.SetTime(ecmaTime.goTime())
-	object.value = *date
+	obj.value = *date
 	return date.Value()
 }
 

--- a/builtin_error.go
+++ b/builtin_error.go
@@ -5,20 +5,20 @@ import (
 )
 
 func builtinError(call FunctionCall) Value {
-	return toValue_object(call.runtime.newError(classError, call.Argument(0), 1))
+	return objectValue(call.runtime.newError(classErrorName, call.Argument(0), 1))
 }
 
-func builtinNewError(self *_object, argumentList []Value) Value {
-	return toValue_object(self.runtime.newError(classError, valueOfArrayIndex(argumentList, 0), 0))
+func builtinNewError(obj *object, argumentList []Value) Value {
+	return objectValue(obj.runtime.newError(classErrorName, valueOfArrayIndex(argumentList, 0), 0))
 }
 
-func builtinError_toString(call FunctionCall) Value {
+func builtinErrorToString(call FunctionCall) Value {
 	thisObject := call.thisObject()
 	if thisObject == nil {
 		panic(call.runtime.panicTypeError())
 	}
 
-	name := classError
+	name := classErrorName
 	nameValue := thisObject.get("name")
 	if nameValue.IsDefined() {
 		name = nameValue.string()
@@ -31,96 +31,96 @@ func builtinError_toString(call FunctionCall) Value {
 	}
 
 	if len(name) == 0 {
-		return toValue_string(message)
+		return stringValue(message)
 	}
 
 	if len(message) == 0 {
-		return toValue_string(name)
+		return stringValue(name)
 	}
 
-	return toValue_string(fmt.Sprintf("%s: %s", name, message))
+	return stringValue(fmt.Sprintf("%s: %s", name, message))
 }
 
-func (runtime *_runtime) newEvalError(message Value) *_object {
-	self := runtime.newErrorObject("EvalError", message, 0)
-	self.prototype = runtime.global.EvalErrorPrototype
-	return self
+func (rt *runtime) newEvalError(message Value) *object {
+	o := rt.newErrorObject("EvalError", message, 0)
+	o.prototype = rt.global.EvalErrorPrototype
+	return o
 }
 
 func builtinEvalError(call FunctionCall) Value {
-	return toValue_object(call.runtime.newEvalError(call.Argument(0)))
+	return objectValue(call.runtime.newEvalError(call.Argument(0)))
 }
 
-func builtinNewEvalError(self *_object, argumentList []Value) Value {
-	return toValue_object(self.runtime.newEvalError(valueOfArrayIndex(argumentList, 0)))
+func builtinNewEvalError(obj *object, argumentList []Value) Value {
+	return objectValue(obj.runtime.newEvalError(valueOfArrayIndex(argumentList, 0)))
 }
 
-func (runtime *_runtime) newTypeError(message Value) *_object {
-	self := runtime.newErrorObject("TypeError", message, 0)
-	self.prototype = runtime.global.TypeErrorPrototype
-	return self
+func (rt *runtime) newTypeError(message Value) *object {
+	o := rt.newErrorObject("TypeError", message, 0)
+	o.prototype = rt.global.TypeErrorPrototype
+	return o
 }
 
 func builtinTypeError(call FunctionCall) Value {
-	return toValue_object(call.runtime.newTypeError(call.Argument(0)))
+	return objectValue(call.runtime.newTypeError(call.Argument(0)))
 }
 
-func builtinNewTypeError(self *_object, argumentList []Value) Value {
-	return toValue_object(self.runtime.newTypeError(valueOfArrayIndex(argumentList, 0)))
+func builtinNewTypeError(obj *object, argumentList []Value) Value {
+	return objectValue(obj.runtime.newTypeError(valueOfArrayIndex(argumentList, 0)))
 }
 
-func (runtime *_runtime) newRangeError(message Value) *_object {
-	self := runtime.newErrorObject("RangeError", message, 0)
-	self.prototype = runtime.global.RangeErrorPrototype
-	return self
+func (rt *runtime) newRangeError(message Value) *object {
+	o := rt.newErrorObject("RangeError", message, 0)
+	o.prototype = rt.global.RangeErrorPrototype
+	return o
 }
 
 func builtinRangeError(call FunctionCall) Value {
-	return toValue_object(call.runtime.newRangeError(call.Argument(0)))
+	return objectValue(call.runtime.newRangeError(call.Argument(0)))
 }
 
-func builtinNewRangeError(self *_object, argumentList []Value) Value {
-	return toValue_object(self.runtime.newRangeError(valueOfArrayIndex(argumentList, 0)))
+func builtinNewRangeError(obj *object, argumentList []Value) Value {
+	return objectValue(obj.runtime.newRangeError(valueOfArrayIndex(argumentList, 0)))
 }
 
-func (runtime *_runtime) newURIError(message Value) *_object {
-	self := runtime.newErrorObject("URIError", message, 0)
-	self.prototype = runtime.global.URIErrorPrototype
-	return self
+func (rt *runtime) newURIError(message Value) *object {
+	o := rt.newErrorObject("URIError", message, 0)
+	o.prototype = rt.global.URIErrorPrototype
+	return o
 }
 
-func (runtime *_runtime) newReferenceError(message Value) *_object {
-	self := runtime.newErrorObject("ReferenceError", message, 0)
-	self.prototype = runtime.global.ReferenceErrorPrototype
-	return self
+func (rt *runtime) newReferenceError(message Value) *object {
+	o := rt.newErrorObject("ReferenceError", message, 0)
+	o.prototype = rt.global.ReferenceErrorPrototype
+	return o
 }
 
 func builtinReferenceError(call FunctionCall) Value {
-	return toValue_object(call.runtime.newReferenceError(call.Argument(0)))
+	return objectValue(call.runtime.newReferenceError(call.Argument(0)))
 }
 
-func builtinNewReferenceError(self *_object, argumentList []Value) Value {
-	return toValue_object(self.runtime.newReferenceError(valueOfArrayIndex(argumentList, 0)))
+func builtinNewReferenceError(obj *object, argumentList []Value) Value {
+	return objectValue(obj.runtime.newReferenceError(valueOfArrayIndex(argumentList, 0)))
 }
 
-func (runtime *_runtime) newSyntaxError(message Value) *_object {
-	self := runtime.newErrorObject("SyntaxError", message, 0)
-	self.prototype = runtime.global.SyntaxErrorPrototype
-	return self
+func (rt *runtime) newSyntaxError(message Value) *object {
+	o := rt.newErrorObject("SyntaxError", message, 0)
+	o.prototype = rt.global.SyntaxErrorPrototype
+	return o
 }
 
 func builtinSyntaxError(call FunctionCall) Value {
-	return toValue_object(call.runtime.newSyntaxError(call.Argument(0)))
+	return objectValue(call.runtime.newSyntaxError(call.Argument(0)))
 }
 
-func builtinNewSyntaxError(self *_object, argumentList []Value) Value {
-	return toValue_object(self.runtime.newSyntaxError(valueOfArrayIndex(argumentList, 0)))
+func builtinNewSyntaxError(obj *object, argumentList []Value) Value {
+	return objectValue(obj.runtime.newSyntaxError(valueOfArrayIndex(argumentList, 0)))
 }
 
 func builtinURIError(call FunctionCall) Value {
-	return toValue_object(call.runtime.newURIError(call.Argument(0)))
+	return objectValue(call.runtime.newURIError(call.Argument(0)))
 }
 
-func builtinNewURIError(self *_object, argumentList []Value) Value {
-	return toValue_object(self.runtime.newURIError(valueOfArrayIndex(argumentList, 0)))
+func builtinNewURIError(obj *object, argumentList []Value) Value {
+	return objectValue(obj.runtime.newURIError(valueOfArrayIndex(argumentList, 0)))
 }

--- a/builtin_math.go
+++ b/builtin_math.go
@@ -7,27 +7,27 @@ import (
 
 // Math
 
-func builtinMath_abs(call FunctionCall) Value {
+func builtinMathAbs(call FunctionCall) Value {
 	number := call.Argument(0).float64()
-	return toValue_float64(math.Abs(number))
+	return float64Value(math.Abs(number))
 }
 
-func builtinMath_acos(call FunctionCall) Value {
+func builtinMathAcos(call FunctionCall) Value {
 	number := call.Argument(0).float64()
-	return toValue_float64(math.Acos(number))
+	return float64Value(math.Acos(number))
 }
 
-func builtinMath_asin(call FunctionCall) Value {
+func builtinMathAsin(call FunctionCall) Value {
 	number := call.Argument(0).float64()
-	return toValue_float64(math.Asin(number))
+	return float64Value(math.Asin(number))
 }
 
-func builtinMath_atan(call FunctionCall) Value {
+func builtinMathAtan(call FunctionCall) Value {
 	number := call.Argument(0).float64()
-	return toValue_float64(math.Atan(number))
+	return float64Value(math.Atan(number))
 }
 
-func builtinMath_atan2(call FunctionCall) Value {
+func builtinMathAtan2(call FunctionCall) Value {
 	y := call.Argument(0).float64()
 	if math.IsNaN(y) {
 		return NaNValue()
@@ -36,40 +36,40 @@ func builtinMath_atan2(call FunctionCall) Value {
 	if math.IsNaN(x) {
 		return NaNValue()
 	}
-	return toValue_float64(math.Atan2(y, x))
+	return float64Value(math.Atan2(y, x))
 }
 
-func builtinMath_cos(call FunctionCall) Value {
+func builtinMathCos(call FunctionCall) Value {
 	number := call.Argument(0).float64()
-	return toValue_float64(math.Cos(number))
+	return float64Value(math.Cos(number))
 }
 
-func builtinMath_ceil(call FunctionCall) Value {
+func builtinMathCeil(call FunctionCall) Value {
 	number := call.Argument(0).float64()
-	return toValue_float64(math.Ceil(number))
+	return float64Value(math.Ceil(number))
 }
 
-func builtinMath_exp(call FunctionCall) Value {
+func builtinMathExp(call FunctionCall) Value {
 	number := call.Argument(0).float64()
-	return toValue_float64(math.Exp(number))
+	return float64Value(math.Exp(number))
 }
 
-func builtinMath_floor(call FunctionCall) Value {
+func builtinMathFloor(call FunctionCall) Value {
 	number := call.Argument(0).float64()
-	return toValue_float64(math.Floor(number))
+	return float64Value(math.Floor(number))
 }
 
-func builtinMath_log(call FunctionCall) Value {
+func builtinMathLog(call FunctionCall) Value {
 	number := call.Argument(0).float64()
-	return toValue_float64(math.Log(number))
+	return float64Value(math.Log(number))
 }
 
-func builtinMath_max(call FunctionCall) Value {
+func builtinMathMax(call FunctionCall) Value {
 	switch len(call.ArgumentList) {
 	case 0:
 		return negativeInfinityValue()
 	case 1:
-		return toValue_float64(call.ArgumentList[0].float64())
+		return float64Value(call.ArgumentList[0].float64())
 	}
 	result := call.ArgumentList[0].float64()
 	if math.IsNaN(result) {
@@ -82,15 +82,15 @@ func builtinMath_max(call FunctionCall) Value {
 		}
 		result = math.Max(result, value)
 	}
-	return toValue_float64(result)
+	return float64Value(result)
 }
 
-func builtinMath_min(call FunctionCall) Value {
+func builtinMathMin(call FunctionCall) Value {
 	switch len(call.ArgumentList) {
 	case 0:
 		return positiveInfinityValue()
 	case 1:
-		return toValue_float64(call.ArgumentList[0].float64())
+		return float64Value(call.ArgumentList[0].float64())
 	}
 	result := call.ArgumentList[0].float64()
 	if math.IsNaN(result) {
@@ -103,49 +103,49 @@ func builtinMath_min(call FunctionCall) Value {
 		}
 		result = math.Min(result, value)
 	}
-	return toValue_float64(result)
+	return float64Value(result)
 }
 
-func builtinMath_pow(call FunctionCall) Value {
+func builtinMathPow(call FunctionCall) Value {
 	// TODO Make sure this works according to the specification (15.8.2.13)
 	x := call.Argument(0).float64()
 	y := call.Argument(1).float64()
 	if math.Abs(x) == 1 && math.IsInf(y, 0) {
 		return NaNValue()
 	}
-	return toValue_float64(math.Pow(x, y))
+	return float64Value(math.Pow(x, y))
 }
 
-func builtinMath_random(call FunctionCall) Value {
+func builtinMathRandom(call FunctionCall) Value {
 	var v float64
 	if call.runtime.random != nil {
 		v = call.runtime.random()
 	} else {
-		v = rand.Float64()
+		v = rand.Float64() //nolint: gosec
 	}
-	return toValue_float64(v)
+	return float64Value(v)
 }
 
-func builtinMath_round(call FunctionCall) Value {
+func builtinMathRound(call FunctionCall) Value {
 	number := call.Argument(0).float64()
 	value := math.Floor(number + 0.5)
 	if value == 0 {
 		value = math.Copysign(0, number)
 	}
-	return toValue_float64(value)
+	return float64Value(value)
 }
 
-func builtinMath_sin(call FunctionCall) Value {
+func builtinMathSin(call FunctionCall) Value {
 	number := call.Argument(0).float64()
-	return toValue_float64(math.Sin(number))
+	return float64Value(math.Sin(number))
 }
 
-func builtinMath_sqrt(call FunctionCall) Value {
+func builtinMathSqrt(call FunctionCall) Value {
 	number := call.Argument(0).float64()
-	return toValue_float64(math.Sqrt(number))
+	return float64Value(math.Sqrt(number))
 }
 
-func builtinMath_tan(call FunctionCall) Value {
+func builtinMathTan(call FunctionCall) Value {
 	number := call.Argument(0).float64()
-	return toValue_float64(math.Tan(number))
+	return float64Value(math.Tan(number))
 }

--- a/builtin_number.go
+++ b/builtin_number.go
@@ -15,20 +15,20 @@ func numberValueFromNumberArgumentList(argumentList []Value) Value {
 	if len(argumentList) > 0 {
 		return argumentList[0].numberValue()
 	}
-	return toValue_int(0)
+	return intValue(0)
 }
 
 func builtinNumber(call FunctionCall) Value {
 	return numberValueFromNumberArgumentList(call.ArgumentList)
 }
 
-func builtinNewNumber(self *_object, argumentList []Value) Value {
-	return toValue_object(self.runtime.newNumber(numberValueFromNumberArgumentList(argumentList)))
+func builtinNewNumber(obj *object, argumentList []Value) Value {
+	return objectValue(obj.runtime.newNumber(numberValueFromNumberArgumentList(argumentList)))
 }
 
-func builtinNumber_toString(call FunctionCall) Value {
+func builtinNumberToString(call FunctionCall) Value {
 	// Will throw a TypeError if ThisObject is not a Number
-	value := call.thisClassObject(classNumber).primitiveValue()
+	value := call.thisClassObject(classNumberName).primitiveValue()
 	radix := 10
 	radixArgument := call.Argument(0)
 	if radixArgument.IsDefined() {
@@ -39,33 +39,32 @@ func builtinNumber_toString(call FunctionCall) Value {
 		radix = int(integer)
 	}
 	if radix == 10 {
-		return toValue_string(value.string())
+		return stringValue(value.string())
 	}
-	return toValue_string(numberToStringRadix(value, radix))
+	return stringValue(numberToStringRadix(value, radix))
 }
 
-func builtinNumber_valueOf(call FunctionCall) Value {
-	return call.thisClassObject(classNumber).primitiveValue()
+func builtinNumberValueOf(call FunctionCall) Value {
+	return call.thisClassObject(classNumberName).primitiveValue()
 }
 
-func builtinNumber_toFixed(call FunctionCall) Value {
+func builtinNumberToFixed(call FunctionCall) Value {
 	precision := toIntegerFloat(call.Argument(0))
 	if 20 < precision || 0 > precision {
 		panic(call.runtime.panicRangeError("toFixed() precision must be between 0 and 20"))
 	}
 	if call.This.IsNaN() {
-		return toValue_string("NaN")
+		return stringValue("NaN")
 	}
-	value := call.This.float64()
-	if math.Abs(value) >= 1e21 {
-		return toValue_string(floatToString(value, 64))
+	if value := call.This.float64(); math.Abs(value) >= 1e21 {
+		return stringValue(floatToString(value, 64))
 	}
-	return toValue_string(strconv.FormatFloat(call.This.float64(), 'f', int(precision), 64))
+	return stringValue(strconv.FormatFloat(call.This.float64(), 'f', int(precision), 64))
 }
 
-func builtinNumber_toExponential(call FunctionCall) Value {
+func builtinNumberToExponential(call FunctionCall) Value {
 	if call.This.IsNaN() {
-		return toValue_string("NaN")
+		return stringValue("NaN")
 	}
 	precision := float64(-1)
 	if value := call.Argument(0); value.IsDefined() {
@@ -74,33 +73,33 @@ func builtinNumber_toExponential(call FunctionCall) Value {
 			panic(call.runtime.panicRangeError("toString() radix must be between 2 and 36"))
 		}
 	}
-	return toValue_string(strconv.FormatFloat(call.This.float64(), 'e', int(precision), 64))
+	return stringValue(strconv.FormatFloat(call.This.float64(), 'e', int(precision), 64))
 }
 
-func builtinNumber_toPrecision(call FunctionCall) Value {
+func builtinNumberToPrecision(call FunctionCall) Value {
 	if call.This.IsNaN() {
-		return toValue_string("NaN")
+		return stringValue("NaN")
 	}
 	value := call.Argument(0)
 	if value.IsUndefined() {
-		return toValue_string(call.This.string())
+		return stringValue(call.This.string())
 	}
 	precision := toIntegerFloat(value)
 	if 1 > precision {
 		panic(call.runtime.panicRangeError("toPrecision() precision must be greater than 1"))
 	}
-	return toValue_string(strconv.FormatFloat(call.This.float64(), 'g', int(precision), 64))
+	return stringValue(strconv.FormatFloat(call.This.float64(), 'g', int(precision), 64))
 }
 
-func builtinNumber_isNaN(call FunctionCall) Value {
+func builtinNumberIsNaN(call FunctionCall) Value {
 	if len(call.ArgumentList) < 1 {
-		return toValue_bool(false)
+		return boolValue(false)
 	}
-	return toValue_bool(call.Argument(0).IsNaN())
+	return boolValue(call.Argument(0).IsNaN())
 }
 
-func builtinNumber_toLocaleString(call FunctionCall) Value {
-	value := call.thisClassObject(classNumber).primitiveValue()
+func builtinNumberToLocaleString(call FunctionCall) Value {
+	value := call.thisClassObject(classNumberName).primitiveValue()
 	locale := call.Argument(0)
 	lang := defaultLanguage
 	if locale.IsDefined() {
@@ -108,5 +107,5 @@ func builtinNumber_toLocaleString(call FunctionCall) Value {
 	}
 
 	p := message.NewPrinter(lang)
-	return toValue_string(p.Sprintf("%v", number.Decimal(value.value)))
+	return stringValue(p.Sprintf("%v", number.Decimal(value.value)))
 }

--- a/builtin_regexp.go
+++ b/builtin_regexp.go
@@ -9,22 +9,22 @@ import (
 func builtinRegExp(call FunctionCall) Value {
 	pattern := call.Argument(0)
 	flags := call.Argument(1)
-	if object := pattern._object(); object != nil {
-		if object.class == classRegExp && flags.IsUndefined() {
+	if obj := pattern.object(); obj != nil {
+		if obj.class == classRegExpName && flags.IsUndefined() {
 			return pattern
 		}
 	}
-	return toValue_object(call.runtime.newRegExp(pattern, flags))
+	return objectValue(call.runtime.newRegExp(pattern, flags))
 }
 
-func builtinNewRegExp(self *_object, argumentList []Value) Value {
-	return toValue_object(self.runtime.newRegExp(
+func builtinNewRegExp(obj *object, argumentList []Value) Value {
+	return objectValue(obj.runtime.newRegExp(
 		valueOfArrayIndex(argumentList, 0),
 		valueOfArrayIndex(argumentList, 1),
 	))
 }
 
-func builtinRegExp_toString(call FunctionCall) Value {
+func builtinRegExpToString(call FunctionCall) Value {
 	thisObject := call.thisObject()
 	source := thisObject.get("source").string()
 	flags := []byte{}
@@ -37,32 +37,32 @@ func builtinRegExp_toString(call FunctionCall) Value {
 	if thisObject.get("multiline").bool() {
 		flags = append(flags, 'm')
 	}
-	return toValue_string(fmt.Sprintf("/%s/%s", source, flags))
+	return stringValue(fmt.Sprintf("/%s/%s", source, flags))
 }
 
-func builtinRegExp_exec(call FunctionCall) Value {
+func builtinRegExpExec(call FunctionCall) Value {
 	thisObject := call.thisObject()
 	target := call.Argument(0).string()
 	match, result := execRegExp(thisObject, target)
 	if !match {
 		return nullValue
 	}
-	return toValue_object(execResultToArray(call.runtime, target, result))
+	return objectValue(execResultToArray(call.runtime, target, result))
 }
 
-func builtinRegExp_test(call FunctionCall) Value {
+func builtinRegExpTest(call FunctionCall) Value {
 	thisObject := call.thisObject()
 	target := call.Argument(0).string()
 	match, result := execRegExp(thisObject, target)
 
 	if !match {
-		return toValue_bool(match)
+		return boolValue(match)
 	}
 
 	// Match extract and assign input, $_ and $1 -> $9 on global RegExp.
-	input := toValue_string(target)
-	call.runtime.global.RegExp.defineProperty("$_", input, 0100, false)
-	call.runtime.global.RegExp.defineProperty("input", input, 0100, false)
+	input := stringValue(target)
+	call.runtime.global.RegExp.defineProperty("$_", input, 0o100, false)
+	call.runtime.global.RegExp.defineProperty("input", input, 0o100, false)
 
 	var start int
 	n := 1
@@ -71,7 +71,7 @@ func builtinRegExp_test(call FunctionCall) Value {
 		if i%2 == 0 {
 			start = v
 		} else {
-			re.defineProperty(fmt.Sprintf("$%d", n), toValue_string(target[start:v]), 0100, false)
+			re.defineProperty(fmt.Sprintf("$%d", n), stringValue(target[start:v]), 0o100, false)
 			n++
 			if n == 10 {
 				break
@@ -81,16 +81,16 @@ func builtinRegExp_test(call FunctionCall) Value {
 
 	if n <= 9 {
 		// Erase remaining.
-		empty := toValue_string("")
+		empty := stringValue("")
 		for i := n; i <= 9; i++ {
-			re.defineProperty(fmt.Sprintf("$%d", i), empty, 0100, false)
+			re.defineProperty(fmt.Sprintf("$%d", i), empty, 0o100, false)
 		}
 	}
 
-	return toValue_bool(match)
+	return boolValue(match)
 }
 
-func builtinRegExp_compile(call FunctionCall) Value {
+func builtinRegExpCompile(call FunctionCall) Value {
 	// This (useless) function is deprecated, but is here to provide some
 	// semblance of compatibility.
 	// Caveat emptor: it may not be around for long.

--- a/builtin_test.go
+++ b/builtin_test.go
@@ -93,25 +93,25 @@ func TestString_substr(t *testing.T) {
 
 func Test_builtin_escape(t *testing.T) {
 	tt(t, func() {
-		is(builtin_escape("abc"), "abc")
+		is(builtinEscape("abc"), "abc")
 
-		is(builtin_escape("="), "%3D")
+		is(builtinEscape("="), "%3D")
 
-		is(builtin_escape("abc=%+32"), "abc%3D%25+32")
+		is(builtinEscape("abc=%+32"), "abc%3D%25+32")
 
-		is(builtin_escape("世界"), "%u4E16%u754C")
+		is(builtinEscape("世界"), "%u4E16%u754C")
 	})
 }
 
 func Test_builtin_unescape(t *testing.T) {
 	tt(t, func() {
-		is(builtin_unescape("abc"), "abc")
+		is(builtinUnescape("abc"), "abc")
 
-		is(builtin_unescape("=%3D"), "==")
+		is(builtinUnescape("=%3D"), "==")
 
-		is(builtin_unescape("abc%3D%25+32"), "abc=%+32")
+		is(builtinUnescape("abc%3D%25+32"), "abc=%+32")
 
-		is(builtin_unescape("%u4E16%u754C"), "世界")
+		is(builtinUnescape("%u4E16%u754C"), "世界")
 	})
 }
 

--- a/call_test.go
+++ b/call_test.go
@@ -3,6 +3,8 @@ package otto
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -11,361 +13,561 @@ const (
 
 func BenchmarkNativeCallWithString(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 string) {})
-	s, _ := vm.Compile("test.js", `x("zzz")`)
+	err := vm.Set("x", func(a1 string) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x("zzz")`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithFloat32(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 float32) {})
-	s, _ := vm.Compile("test.js", `x(1.1)`)
+	err := vm.Set("x", func(a1 float32) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x(1.1)`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithFloat64(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 float64) {})
-	s, _ := vm.Compile("test.js", `x(1.1)`)
+	err := vm.Set("x", func(a1 float64) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x(1.1)`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithInt(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 int) {})
-	s, _ := vm.Compile("test.js", `x(1)`)
+	err := vm.Set("x", func(a1 int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithUint(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 uint) {})
-	s, _ := vm.Compile("test.js", `x(1)`)
+	err := vm.Set("x", func(a1 uint) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithInt8(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 int8) {})
-	s, _ := vm.Compile("test.js", `x(1)`)
+	err := vm.Set("x", func(a1 int8) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithUint8(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 uint8) {})
-	s, _ := vm.Compile("test.js", `x(1)`)
+	err := vm.Set("x", func(a1 uint8) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithInt16(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 int16) {})
-	s, _ := vm.Compile("test.js", `x(1)`)
+	err := vm.Set("x", func(a1 int16) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithUint16(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 uint16) {})
-	s, _ := vm.Compile("test.js", `x(1)`)
+	err := vm.Set("x", func(a1 uint16) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithInt32(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 int32) {})
-	s, _ := vm.Compile("test.js", `x(1)`)
+	err := vm.Set("x", func(a1 int32) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithUint32(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 uint32) {})
-	s, _ := vm.Compile("test.js", `x(1)`)
+	err := vm.Set("x", func(a1 uint32) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithInt64(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 int64) {})
-	s, _ := vm.Compile("test.js", `x(1)`)
+	err := vm.Set("x", func(a1 int64) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithUint64(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 uint64) {})
-	s, _ := vm.Compile("test.js", `x(1)`)
+	err := vm.Set("x", func(a1 uint64) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithStringInt(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 string, a2 int) {})
-	s, _ := vm.Compile("test.js", `x("zzz", 1)`)
+	err := vm.Set("x", func(a1 string, a2 int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x("zzz", 1)`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithIntVariadic0(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a ...int) {})
-	s, _ := vm.Compile("test.js", `x()`)
+	err := vm.Set("x", func(a ...int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x()`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithIntVariadic1(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a ...int) {})
-	s, _ := vm.Compile("test.js", `x(1)`)
+	err := vm.Set("x", func(a ...int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithIntVariadic3(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a ...int) {})
-	s, _ := vm.Compile("test.js", `x(1, 2, 3)`)
+	err := vm.Set("x", func(a ...int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x(1, 2, 3)`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithIntVariadic10(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a ...int) {})
-	s, _ := vm.Compile("test.js", `x(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)`)
+	err := vm.Set("x", func(a ...int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithIntArray0(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a []int) {})
-	s, _ := vm.Compile("test.js", `x([])`)
+	err := vm.Set("x", func(a []int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x([])`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithIntArray1(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a []int) {})
-	s, _ := vm.Compile("test.js", `x([1])`)
+	err := vm.Set("x", func(a []int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x([1])`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithIntArray3(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a []int) {})
-	s, _ := vm.Compile("test.js", `x([1, 2, 3])`)
+	err := vm.Set("x", func(a []int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x([1, 2, 3])`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithIntArray10(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a []int) {})
-	s, _ := vm.Compile("test.js", `x([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])`)
+	err := vm.Set("x", func(a []int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithIntVariadicArray0(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a ...int) {})
-	s, _ := vm.Compile("test.js", `x([])`)
+	err := vm.Set("x", func(a ...int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x([])`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithIntVariadicArray1(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a ...int) {})
-	s, _ := vm.Compile("test.js", `x([1])`)
+	err := vm.Set("x", func(a ...int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x([1])`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithIntVariadicArray3(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a ...int) {})
-	s, _ := vm.Compile("test.js", `x([1, 2, 3])`)
+	err := vm.Set("x", func(a ...int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x([1, 2, 3])`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithIntVariadicArray10(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a ...int) {})
-	s, _ := vm.Compile("test.js", `x([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])`)
+	err := vm.Set("x", func(a ...int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithStringIntVariadic0(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 string, a2 ...int) {})
-	s, _ := vm.Compile("test.js", `x("a")`)
+	err := vm.Set("x", func(a1 string, a2 ...int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x("a")`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithStringIntVariadic1(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 string, a2 ...int) {})
-	s, _ := vm.Compile("test.js", `x("a", 1)`)
+	err := vm.Set("x", func(a1 string, a2 ...int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x("a", 1)`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithStringIntVariadic3(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 string, a2 ...int) {})
-	s, _ := vm.Compile("test.js", `x("a", 1, 2, 3)`)
+	err := vm.Set("x", func(a1 string, a2 ...int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x("a", 1, 2, 3)`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithStringIntVariadic10(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 string, a2 ...int) {})
-	s, _ := vm.Compile("test.js", `x("a", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)`)
+	err := vm.Set("x", func(a1 string, a2 ...int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x("a", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithStringIntVariadicArray0(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 string, a2 ...int) {})
-	s, _ := vm.Compile("test.js", `x("a", [])`)
+	err := vm.Set("x", func(a1 string, a2 ...int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x("a", [])`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithStringIntVariadicArray1(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 string, a2 ...int) {})
-	s, _ := vm.Compile("test.js", `x("a", [1])`)
+	err := vm.Set("x", func(a1 string, a2 ...int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x("a", [1])`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithStringIntVariadicArray3(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 string, a2 ...int) {})
-	s, _ := vm.Compile("test.js", `x("a", [1, 2, 3])`)
+	err := vm.Set("x", func(a1 string, a2 ...int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x("a", [1, 2, 3])`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithStringIntVariadicArray10(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a1 string, a2 ...int) {})
-	s, _ := vm.Compile("test.js", `x("a", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])`)
+	err := vm.Set("x", func(a1 string, a2 ...int) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x("a", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithMap(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a map[string]string) {})
-	s, _ := vm.Compile("test.js", `x({a: "b", c: "d"})`)
+	err := vm.Set("x", func(a map[string]string) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x({a: "b", c: "d"})`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithMapVariadic(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a ...map[string]string) {})
-	s, _ := vm.Compile("test.js", `x({a: "b", c: "d"}, {w: "x", y: "z"})`)
+	err := vm.Set("x", func(a ...map[string]string) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x({a: "b", c: "d"}, {w: "x", y: "z"})`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithMapVariadicArray(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a ...map[string]string) {})
-	s, _ := vm.Compile("test.js", `x([{a: "b", c: "d"}, {w: "x", y: "z"}])`)
+	err := vm.Set("x", func(a ...map[string]string) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x([{a: "b", c: "d"}, {w: "x", y: "z"}])`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithFunction(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a func()) {})
-	s, _ := vm.Compile("test.js", `x(function() {})`)
+	err := vm.Set("x", func(a func()) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x(function() {})`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithFunctionInt(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a func(int)) {})
-	s, _ := vm.Compile("test.js", `x(function(n) {})`)
+	err := vm.Set("x", func(a func(int)) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x(function(n) {})`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkNativeCallWithFunctionString(b *testing.B) {
 	vm := New()
-	vm.Set("x", func(a func(string)) {})
-	s, _ := vm.Compile("test.js", `x(function(n) {})`)
+	err := vm.Set("x", func(a func(string)) {})
+	require.NoError(b, err)
+
+	s, err := vm.Compile("test.js", `x(function(n) {})`)
+	require.NoError(b, err)
+
 	for i := 0; i < b.N; i++ {
-		vm.Run(s)
+		_, err := vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
@@ -374,15 +576,17 @@ func TestNativeCallWithString(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 string) {
+	err := vm.Set("x", func(a1 string) {
 		if a1 != "zzz" {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x("zzz")`)
+	s, err := vm.Compile("test.js", `x("zzz")`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -399,15 +603,17 @@ func TestNativeCallWithFloat32(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 float32) {
+	err := vm.Set("x", func(a1 float32) {
 		if a1 != 1.1 {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x(1.1)`)
+	s, err := vm.Compile("test.js", `x(1.1)`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -424,15 +630,17 @@ func TestNativeCallWithFloat64(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 float64) {
+	err := vm.Set("x", func(a1 float64) {
 		if a1 != 1.1 {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x(1.1)`)
+	s, err := vm.Compile("test.js", `x(1.1)`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -449,15 +657,17 @@ func TestNativeCallWithInt(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 int) {
+	err := vm.Set("x", func(a1 int) {
 		if a1 != 1 {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x(1)`)
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -474,15 +684,17 @@ func TestNativeCallWithUint(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 uint) {
+	err := vm.Set("x", func(a1 uint) {
 		if a1 != 1 {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x(1)`)
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -499,15 +711,17 @@ func TestNativeCallWithInt8(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 int8) {
+	err := vm.Set("x", func(a1 int8) {
 		if a1 != 1 {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x(1)`)
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -524,15 +738,17 @@ func TestNativeCallWithUint8(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 uint8) {
+	err := vm.Set("x", func(a1 uint8) {
 		if a1 != 1 {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x(1)`)
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -549,15 +765,17 @@ func TestNativeCallWithInt16(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 int16) {
+	err := vm.Set("x", func(a1 int16) {
 		if a1 != 1 {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x(1)`)
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -574,15 +792,17 @@ func TestNativeCallWithUint16(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 uint16) {
+	err := vm.Set("x", func(a1 uint16) {
 		if a1 != 1 {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x(1)`)
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -599,15 +819,17 @@ func TestNativeCallWithInt32(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 int32) {
+	err := vm.Set("x", func(a1 int32) {
 		if a1 != 1 {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x(1)`)
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -624,15 +846,17 @@ func TestNativeCallWithUint32(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 uint32) {
+	err := vm.Set("x", func(a1 uint32) {
 		if a1 != 1 {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x(1)`)
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -649,15 +873,17 @@ func TestNativeCallWithInt64(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 int64) {
+	err := vm.Set("x", func(a1 int64) {
 		if a1 != 1 {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x(1)`)
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -674,15 +900,17 @@ func TestNativeCallWithUint64(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 uint64) {
+	err := vm.Set("x", func(a1 uint64) {
 		if a1 != 1 {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x(1)`)
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -699,15 +927,17 @@ func TestNativeCallWithStringInt(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 string, a2 int) {
+	err := vm.Set("x", func(a1 string, a2 int) {
 		if a1 != "zzz" || a2 != 1 {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x("zzz", 1)`)
+	s, err := vm.Compile("test.js", `x("zzz", 1)`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -724,15 +954,17 @@ func TestNativeCallWithIntVariadic0(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a ...int) {
+	err := vm.Set("x", func(a ...int) {
 		if !reflect.DeepEqual(a, []int{}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x()`)
+	s, err := vm.Compile("test.js", `x()`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -749,15 +981,17 @@ func TestNativeCallWithIntVariadic1(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a ...int) {
+	err := vm.Set("x", func(a ...int) {
 		if !reflect.DeepEqual(a, []int{1}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x(1)`)
+	s, err := vm.Compile("test.js", `x(1)`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -774,15 +1008,17 @@ func TestNativeCallWithIntVariadic3(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a ...int) {
+	err := vm.Set("x", func(a ...int) {
 		if !reflect.DeepEqual(a, []int{1, 2, 3}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x(1, 2, 3)`)
+	s, err := vm.Compile("test.js", `x(1, 2, 3)`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -799,15 +1035,17 @@ func TestNativeCallWithIntVariadic10(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a ...int) {
+	err := vm.Set("x", func(a ...int) {
 		if !reflect.DeepEqual(a, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)`)
+	s, err := vm.Compile("test.js", `x(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -824,15 +1062,17 @@ func TestNativeCallWithIntArray0(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a []int) {
+	err := vm.Set("x", func(a []int) {
 		if !reflect.DeepEqual(a, []int{}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x([])`)
+	s, err := vm.Compile("test.js", `x([])`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -849,15 +1089,17 @@ func TestNativeCallWithIntArray1(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a []int) {
+	err := vm.Set("x", func(a []int) {
 		if !reflect.DeepEqual(a, []int{1}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x([1])`)
+	s, err := vm.Compile("test.js", `x([1])`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -874,15 +1116,17 @@ func TestNativeCallWithIntArray3(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a []int) {
+	err := vm.Set("x", func(a []int) {
 		if !reflect.DeepEqual(a, []int{1, 2, 3}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x([1, 2, 3])`)
+	s, err := vm.Compile("test.js", `x([1, 2, 3])`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -899,15 +1143,17 @@ func TestNativeCallWithIntArray10(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a []int) {
+	err := vm.Set("x", func(a []int) {
 		if !reflect.DeepEqual(a, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])`)
+	s, err := vm.Compile("test.js", `x([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -924,15 +1170,17 @@ func TestNativeCallWithIntVariadicArray0(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a ...int) {
+	err := vm.Set("x", func(a ...int) {
 		if !reflect.DeepEqual(a, []int{}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x([])`)
+	s, err := vm.Compile("test.js", `x([])`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -949,15 +1197,17 @@ func TestNativeCallWithIntVariadicArray1(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a ...int) {
+	err := vm.Set("x", func(a ...int) {
 		if !reflect.DeepEqual(a, []int{1}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x([1])`)
+	s, err := vm.Compile("test.js", `x([1])`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -974,15 +1224,17 @@ func TestNativeCallWithIntVariadicArray3(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a ...int) {
+	err := vm.Set("x", func(a ...int) {
 		if !reflect.DeepEqual(a, []int{1, 2, 3}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x([1, 2, 3])`)
+	s, err := vm.Compile("test.js", `x([1, 2, 3])`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -999,15 +1251,17 @@ func TestNativeCallWithIntVariadicArray10(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a ...int) {
+	err := vm.Set("x", func(a ...int) {
 		if !reflect.DeepEqual(a, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])`)
+	s, err := vm.Compile("test.js", `x([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -1024,15 +1278,17 @@ func TestNativeCallWithStringIntVariadic0(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 string, a2 ...int) {
+	err := vm.Set("x", func(a1 string, a2 ...int) {
 		if a1 != "a" || !reflect.DeepEqual(a2, []int{}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x("a")`)
+	s, err := vm.Compile("test.js", `x("a")`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -1049,15 +1305,17 @@ func TestNativeCallWithStringIntVariadic1(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 string, a2 ...int) {
+	err := vm.Set("x", func(a1 string, a2 ...int) {
 		if a1 != "a" || !reflect.DeepEqual(a2, []int{1}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x("a", 1)`)
+	s, err := vm.Compile("test.js", `x("a", 1)`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -1074,15 +1332,17 @@ func TestNativeCallWithStringIntVariadic3(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 string, a2 ...int) {
+	err := vm.Set("x", func(a1 string, a2 ...int) {
 		if a1 != "a" || !reflect.DeepEqual(a2, []int{1, 2, 3}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x("a", 1, 2, 3)`)
+	s, err := vm.Compile("test.js", `x("a", 1, 2, 3)`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -1099,15 +1359,17 @@ func TestNativeCallWithStringIntVariadic10(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 string, a2 ...int) {
+	err := vm.Set("x", func(a1 string, a2 ...int) {
 		if a1 != "a" || !reflect.DeepEqual(a2, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x("a", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)`)
+	s, err := vm.Compile("test.js", `x("a", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -1124,15 +1386,17 @@ func TestNativeCallWithStringIntVariadicArray0(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 string, a2 ...int) {
+	err := vm.Set("x", func(a1 string, a2 ...int) {
 		if a1 != "a" || !reflect.DeepEqual(a2, []int{}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x("a", [])`)
+	s, err := vm.Compile("test.js", `x("a", [])`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -1149,15 +1413,17 @@ func TestNativeCallWithStringIntVariadicArray1(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 string, a2 ...int) {
+	err := vm.Set("x", func(a1 string, a2 ...int) {
 		if a1 != "a" || !reflect.DeepEqual(a2, []int{1}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x("a", [1])`)
+	s, err := vm.Compile("test.js", `x("a", [1])`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -1174,15 +1440,17 @@ func TestNativeCallWithStringIntVariadicArray3(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 string, a2 ...int) {
+	err := vm.Set("x", func(a1 string, a2 ...int) {
 		if a1 != "a" || !reflect.DeepEqual(a2, []int{1, 2, 3}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x("a", [1, 2, 3])`)
+	s, err := vm.Compile("test.js", `x("a", [1, 2, 3])`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -1199,15 +1467,17 @@ func TestNativeCallWithStringIntVariadicArray10(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a1 string, a2 ...int) {
+	err := vm.Set("x", func(a1 string, a2 ...int) {
 		if a1 != "a" || !reflect.DeepEqual(a2, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x("a", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])`)
+	s, err := vm.Compile("test.js", `x("a", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -1224,15 +1494,17 @@ func TestNativeCallWithMap(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a map[string]string) {
+	err := vm.Set("x", func(a map[string]string) {
 		if !reflect.DeepEqual(a, map[string]string{"a": "b", "c": "d"}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x({a: "b", c: "d"})`)
+	s, err := vm.Compile("test.js", `x({a: "b", c: "d"})`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -1249,15 +1521,17 @@ func TestNativeCallWithMapVariadic(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a ...map[string]string) {
+	err := vm.Set("x", func(a ...map[string]string) {
 		if !reflect.DeepEqual(a, []map[string]string{{"a": "b", "c": "d"}, {"w": "x", "y": "z"}}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x({a: "b", c: "d"}, {w: "x", y: "z"})`)
+	s, err := vm.Compile("test.js", `x({a: "b", c: "d"}, {w: "x", y: "z"})`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -1274,15 +1548,17 @@ func TestNativeCallWithMapVariadicArray(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(a ...map[string]string) {
+	err := vm.Set("x", func(a ...map[string]string) {
 		if !reflect.DeepEqual(a, []map[string]string{{"a": "b", "c": "d"}, {"w": "x", "y": "z"}}) {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x([{a: "b", c: "d"}, {w: "x", y: "z"}])`)
+	s, err := vm.Compile("test.js", `x([{a: "b", c: "d"}, {w: "x", y: "z"}])`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -1299,15 +1575,17 @@ func TestNativeCallWithFunctionVoidBool(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(fn func() bool) {
+	err := vm.Set("x", func(fn func() bool) {
 		if !fn() {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x(function() { return true; })`)
+	s, err := vm.Compile("test.js", `x(function() { return true; })`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -1324,15 +1602,17 @@ func TestNativeCallWithFunctionIntInt(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(fn func(int) int) {
+	err := vm.Set("x", func(fn func(int) int) {
 		if fn(5) != 5 {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x(function(n) { return n; })`)
+	s, err := vm.Compile("test.js", `x(function(n) { return n; })`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -1349,15 +1629,17 @@ func TestNativeCallWithFunctionStringString(t *testing.T) {
 
 	called := false
 
-	vm.Set("x", func(fn func(string) string) {
+	err := vm.Set("x", func(fn func(string) string) {
 		if fn("zzz") != "zzz" {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `x(function(n) { return n; })`)
+	s, err := vm.Compile("test.js", `x(function(n) { return n; })`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -1405,18 +1687,20 @@ func TestNativeCallMethodWithStruct(t *testing.T) {
 	vm := New()
 
 	called := false
+	err := vm.Set("x", testNativeCallWithStruct{Prefix: "a"})
+	require.NoError(t, err)
 
-	vm.Set("x", testNativeCallWithStruct{Prefix: "a"})
-
-	vm.Set("t", func(s string) {
+	err = vm.Set("t", func(s string) {
 		if s != testAb {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `t(x.CallWithStruct(x.MakeStruct("b")))`)
+	s, err := vm.Compile("test.js", `t(x.CallWithStruct(x.MakeStruct("b")))`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -1432,18 +1716,20 @@ func TestNativeCallPointerMethodWithStruct(t *testing.T) {
 	vm := New()
 
 	called := false
+	err := vm.Set("x", &testNativeCallWithStruct{Prefix: "a"})
+	require.NoError(t, err)
 
-	vm.Set("x", &testNativeCallWithStruct{Prefix: "a"})
-
-	vm.Set("t", func(s string) {
+	err = vm.Set("t", func(s string) {
 		if s != testAb {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `t(x.CallPointerWithStruct(x.MakeStruct("b")))`)
+	s, err := vm.Compile("test.js", `t(x.CallPointerWithStruct(x.MakeStruct("b")))`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -1459,18 +1745,20 @@ func TestNativeCallMethodWithStructPointer(t *testing.T) {
 	vm := New()
 
 	called := false
+	err := vm.Set("x", testNativeCallWithStruct{Prefix: "a"})
+	require.NoError(t, err)
 
-	vm.Set("x", testNativeCallWithStruct{Prefix: "a"})
-
-	vm.Set("t", func(s string) {
+	err = vm.Set("t", func(s string) {
 		if s != testAb {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `t(x.CallWithStructPointer(x.MakeStructPointer("b")))`)
+	s, err := vm.Compile("test.js", `t(x.CallWithStructPointer(x.MakeStructPointer("b")))`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -1486,18 +1774,20 @@ func TestNativeCallPointerMethodWithStructPointer(t *testing.T) {
 	vm := New()
 
 	called := false
+	err := vm.Set("x", &testNativeCallWithStruct{Prefix: "a"})
+	require.NoError(t, err)
 
-	vm.Set("x", &testNativeCallWithStruct{Prefix: "a"})
-
-	vm.Set("t", func(s string) {
+	err = vm.Set("t", func(s string) {
 		if s != testAb {
 			t.Fail()
 		}
 
 		called = true
 	})
+	require.NoError(t, err)
 
-	s, _ := vm.Compile("test.js", `t(x.CallPointerWithStructPointer(x.MakeStructPointer("b")))`)
+	s, err := vm.Compile("test.js", `t(x.CallPointerWithStructPointer(x.MakeStructPointer("b")))`)
+	require.NoError(t, err)
 
 	if _, err := vm.Run(s); err != nil {
 		t.Logf("err should have been nil; was %s\n", err.Error())
@@ -1511,6 +1801,9 @@ func TestNativeCallPointerMethodWithStructPointer(t *testing.T) {
 
 func TestNativeCallNilInterfaceArg(t *testing.T) {
 	vm := New()
-	vm.Set("f1", func(v interface{}) {})
-	vm.Call("f1", nil, nil)
+	err := vm.Set("f1", func(v interface{}) {})
+	require.NoError(t, err)
+
+	_, err = vm.Call("f1", nil, nil)
+	require.NoError(t, err)
 }

--- a/clone_test.go
+++ b/clone_test.go
@@ -2,17 +2,21 @@ package otto
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCloneGetterSetter(t *testing.T) {
 	vm := New()
 
-	vm.Run(`var x = Object.create(null, {
+	_, err := vm.Run(`var x = Object.create(null, {
     x: {
       get: function() {},
       set: function() {},
     },
   })`)
-
-	vm.Copy()
+	require.NoError(t, err)
+	require.NotPanics(t, func() {
+		vm.Copy()
+	})
 }

--- a/cmpl.go
+++ b/cmpl.go
@@ -5,14 +5,7 @@ import (
 	"github.com/robertkrimen/otto/file"
 )
 
-type _compiler struct {
+type compiler struct {
 	file    *file.File
 	program *ast.Program
-}
-
-func (cmpl *_compiler) parse() *_nodeProgram {
-	if cmpl.program != nil {
-		cmpl.file = cmpl.program.File
-	}
-	return cmpl._parse(cmpl.program)
 }

--- a/cmpl_test.go
+++ b/cmpl_test.go
@@ -14,8 +14,8 @@ func Test_cmpl(t *testing.T) {
 			program, err := parser.ParseFile(nil, "", src, 0)
 			is(err, nil)
 			{
-				program := cmpl_parse(program)
-				value := vm.runtime.cmpl_evaluate_nodeProgram(program, false)
+				program := cmplParse(program)
+				value := vm.runtime.cmplEvaluateNodeProgram(program, false)
 				if len(expect) > 0 {
 					is(value, expect[0])
 				}
@@ -37,7 +37,7 @@ func TestParse_cmpl(t *testing.T) {
 		test := func(src string) {
 			program, err := parser.ParseFile(nil, "", src, 0)
 			is(err, nil)
-			is(cmpl_parse(program), "!=", nil)
+			is(cmplParse(program), "!=", nil)
 		}
 
 		test(``)

--- a/console.go
+++ b/console.go
@@ -14,37 +14,37 @@ func formatForConsole(argumentList []Value) string {
 	return strings.Join(output, " ")
 }
 
-func builtinConsole_log(call FunctionCall) Value {
+func builtinConsoleLog(call FunctionCall) Value {
 	fmt.Fprintln(os.Stdout, formatForConsole(call.ArgumentList))
 	return Value{}
 }
 
-func builtinConsole_error(call FunctionCall) Value {
+func builtinConsoleError(call FunctionCall) Value {
 	fmt.Fprintln(os.Stdout, formatForConsole(call.ArgumentList))
 	return Value{}
 }
 
 // Nothing happens.
-func builtinConsole_dir(call FunctionCall) Value {
+func builtinConsoleDir(call FunctionCall) Value {
 	return Value{}
 }
 
-func builtinConsole_time(call FunctionCall) Value {
+func builtinConsoleTime(call FunctionCall) Value {
 	return Value{}
 }
 
-func builtinConsole_timeEnd(call FunctionCall) Value {
+func builtinConsoleTimeEnd(call FunctionCall) Value {
 	return Value{}
 }
 
-func builtinConsole_trace(call FunctionCall) Value {
+func builtinConsoleTrace(call FunctionCall) Value {
 	return Value{}
 }
 
-func builtinConsole_assert(call FunctionCall) Value {
+func builtinConsoleAssert(call FunctionCall) Value {
 	return Value{}
 }
 
-func (runtime *_runtime) newConsole() *_object {
-	return newConsoleObject(runtime)
+func (rt *runtime) newConsole() *object {
+	return newConsoleObject(rt)
 }

--- a/console.go
+++ b/console.go
@@ -44,7 +44,3 @@ func builtinConsoleTrace(call FunctionCall) Value {
 func builtinConsoleAssert(call FunctionCall) Value {
 	return Value{}
 }
-
-func (rt *runtime) newConsole() *object {
-	return newConsoleObject(rt)
-}

--- a/consts.go
+++ b/consts.go
@@ -2,17 +2,17 @@ package otto
 
 const (
 	// Common classes.
-	classString   = "String"
-	classGoArray  = "GoArray"
-	classGoSlice  = "GoSlice"
-	classNumber   = "Number"
-	classDate     = "Date"
-	classArray    = "Array"
-	classFunction = "Function"
-	classObject   = "Object"
-	classRegExp   = "RegExp"
-	classBoolean  = "Boolean"
-	classError    = "Error"
+	classStringName   = "String"
+	classGoArrayName  = "GoArray"
+	classGoSliceName  = "GoSlice"
+	classNumberName   = "Number"
+	classDateName     = "Date"
+	classArrayName    = "Array"
+	classFunctionName = "Function"
+	classObjectName   = "Object"
+	classRegExpName   = "RegExp"
+	classBooleanName  = "Boolean"
+	classErrorName    = "Error"
 
 	// Common properties.
 	propertyLength = "length"

--- a/consts.go
+++ b/consts.go
@@ -12,8 +12,23 @@ const (
 	classObjectName   = "Object"
 	classRegExpName   = "RegExp"
 	classBooleanName  = "Boolean"
-	classErrorName    = "Error"
+	classMathName     = "Math"
+	classJSONName     = "JSON"
+
+	// Error classes.
+	classErrorName          = "Error"
+	classEvalErrorName      = "EvalError"
+	classTypeErrorName      = "TypeError"
+	classRangeErrorName     = "RangeError"
+	classReferenceErrorName = "ReferenceError"
+	classSyntaxErrorName    = "SyntaxError"
+	classURIErrorName       = "URIError"
 
 	// Common properties.
-	propertyLength = "length"
+	propertyLength      = "length"
+	propertyPrototype   = "prototype"
+	propertyConstructor = "constructor"
+
+	// Common methods.
+	methodToString = "toString"
 )

--- a/date_test.go
+++ b/date_test.go
@@ -14,7 +14,7 @@ func mockTimeLocal(location *time.Location) func() {
 	}
 }
 
-// Passing or failing should not be dependent on what time zone we're in
+// Passing or failing should not be dependent on what time zone we're in.
 func mockUTC() func() {
 	return mockTimeLocal(time.UTC)
 }
@@ -69,8 +69,6 @@ func TestDate(t *testing.T) {
 		format := "Mon, 2 Jan 2006 15:04:05 MST"
 
 		time1 := time.Unix(1256450400, 0)
-		time0 = time.Date(time1.Year(), time1.Month(), time1.Day(), time1.Hour(), time1.Minute(), time1.Second(), time1.Nanosecond(), time1.Location()).In(utcTimeZone)
-
 		time0 = time.Date(time1.Year(), time1.Month(), time1.Day(), time1.Hour(), time1.Minute(), time1.Second(), 2001*1000*1000, time1.Location()).In(utcTimeZone)
 		test(`abc = new Date(12564504e5); abc.setMilliseconds(2001); abc.toUTCString()`, time0.Format(format))
 

--- a/documentation_test.go
+++ b/documentation_test.go
@@ -2,58 +2,105 @@ package otto
 
 import (
 	"fmt"
+	"os"
 )
 
 func ExampleSynopsis() { //nolint: govet
 	vm := New()
-	vm.Run(`
+	_, err := vm.Run(`
         abc = 2 + 2;
         console.log("The value of abc is " + abc); // 4
     `)
-
-	value, _ := vm.Get("abc")
-	{
-		value, _ := value.ToInteger()
-		fmt.Println(value)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
 	}
 
-	vm.Set("def", 11)
-	vm.Run(`
+	value, err := vm.Get("abc")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+
+	iv, err := value.ToInteger()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	fmt.Println(iv)
+
+	err = vm.Set("def", 11)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	_, err = vm.Run(`
         console.log("The value of def is " + def);
     `)
-
-	vm.Set("xyzzy", "Nothing happens.")
-	vm.Run(`
-        console.log(xyzzy.length);
-    `)
-
-	value, _ = vm.Run("xyzzy.length")
-	{
-		value, _ := value.ToInteger()
-		fmt.Println(value)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
 	}
 
-	value, err := vm.Run("abcdefghijlmnopqrstuvwxyz.length")
-	fmt.Println(value)
-	fmt.Println(err)
+	err = vm.Set("xyzzy", "Nothing happens.")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	_, err = vm.Run(`
+        console.log(xyzzy.length);
+    `)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
 
-	vm.Set("sayHello", func(call FunctionCall) Value {
+	value, err = vm.Run("xyzzy.length")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+
+	iv, err = value.ToInteger()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	fmt.Println(iv)
+
+	value, err = vm.Run("abcdefghijlmnopqrstuvwxyz.length")
+	fmt.Println(value)
+	fmt.Println(err) // Expected error.
+
+	err = vm.Set("sayHello", func(call FunctionCall) Value {
 		fmt.Printf("Hello, %s.\n", call.Argument(0).String())
 		return UndefinedValue()
 	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
 
-	vm.Set("twoPlus", func(call FunctionCall) Value {
+	err = vm.Set("twoPlus", func(call FunctionCall) Value {
 		right, _ := call.Argument(0).ToInteger()
 		result, _ := vm.ToValue(2 + right)
 		return result
 	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
 
-	value, _ = vm.Run(`
+	value, err = vm.Run(`
         sayHello("Xyzzy");
         sayHello();
 
         result = twoPlus(2.0);
     `)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
 	fmt.Println(value)
 
 	// Output:

--- a/error.go
+++ b/error.go
@@ -7,49 +7,49 @@ import (
 	"github.com/robertkrimen/otto/file"
 )
 
-type _exception struct {
+type exception struct {
 	value interface{}
 }
 
-func newException(value interface{}) *_exception {
-	return &_exception{
+func newException(value interface{}) *exception {
+	return &exception{
 		value: value,
 	}
 }
 
-func (self *_exception) eject() interface{} {
-	value := self.value
-	self.value = nil // Prevent Go from holding on to the value, whatever it is
+func (e *exception) eject() interface{} {
+	value := e.value
+	e.value = nil // Prevent Go from holding on to the value, whatever it is
 	return value
 }
 
-type _error struct {
+type ottoError struct {
 	name    string
 	message string
-	trace   []_frame
+	trace   []frame
 
 	offset int
 }
 
-func (err _error) format() string {
-	if len(err.name) == 0 {
-		return err.message
+func (e ottoError) format() string {
+	if len(e.name) == 0 {
+		return e.message
 	}
-	if len(err.message) == 0 {
-		return err.name
+	if len(e.message) == 0 {
+		return e.name
 	}
-	return fmt.Sprintf("%s: %s", err.name, err.message)
+	return fmt.Sprintf("%s: %s", e.name, e.message)
 }
 
-func (err _error) formatWithStack() string {
-	str := err.format() + "\n"
-	for _, frame := range err.trace {
-		str += "    at " + frame.location() + "\n"
+func (e ottoError) formatWithStack() string {
+	str := e.format() + "\n"
+	for _, frm := range e.trace {
+		str += "    at " + frm.location() + "\n"
 	}
 	return str
 }
 
-type _frame struct {
+type frame struct {
 	native     bool
 	nativeFile string
 	nativeLine int
@@ -59,13 +59,11 @@ type _frame struct {
 	fn         interface{}
 }
 
-var (
-	nativeFrame = _frame{}
-)
+var nativeFrame = frame{}
 
-type _at int
+type at int
 
-func (fr _frame) location() string {
+func (fr frame) location() string {
 	str := "<unknown>"
 
 	switch {
@@ -95,14 +93,14 @@ func (fr _frame) location() string {
 
 // An Error represents a runtime error, e.g. a TypeError, a ReferenceError, etc.
 type Error struct {
-	_error
+	ottoError
 }
 
 // Error returns a description of the error
 //
 //	TypeError: 'def' is not a function
-func (err Error) Error() string {
-	return err.format()
+func (e Error) Error() string {
+	return e.format()
 }
 
 // String returns a description of the error and a trace of where the
@@ -111,36 +109,36 @@ func (err Error) Error() string {
 //	TypeError: 'def' is not a function
 //	    at xyz (<anonymous>:3:9)
 //	    at <anonymous>:7:1/
-func (err Error) String() string {
-	return err.formatWithStack()
+func (e Error) String() string {
+	return e.formatWithStack()
 }
 
 // GoString returns a description of the error and a trace of where the
 // error occurred. Printing with %#v will trigger this behaviour.
-func (err Error) GoString() string {
-	return err.formatWithStack()
+func (e Error) GoString() string {
+	return e.formatWithStack()
 }
 
-func (err _error) describe(format string, in ...interface{}) string {
+func (e ottoError) describe(format string, in ...interface{}) string {
 	return fmt.Sprintf(format, in...)
 }
 
-func (self _error) messageValue() Value {
-	if self.message == "" {
+func (e ottoError) messageValue() Value {
+	if e.message == "" {
 		return Value{}
 	}
-	return toValue_string(self.message)
+	return stringValue(e.message)
 }
 
-func (rt *_runtime) typeErrorResult(throw bool) bool {
+func (rt *runtime) typeErrorResult(throw bool) bool {
 	if throw {
 		panic(rt.panicTypeError())
 	}
 	return false
 }
 
-func newError(rt *_runtime, name string, stackFramesToPop int, in ...interface{}) _error {
-	err := _error{
+func newError(rt *runtime, name string, stackFramesToPop int, in ...interface{}) ottoError {
+	err := ottoError{
 		name:   name,
 		offset: -1,
 	}
@@ -148,21 +146,21 @@ func newError(rt *_runtime, name string, stackFramesToPop int, in ...interface{}
 	length := len(in)
 
 	if rt != nil && rt.scope != nil {
-		scope := rt.scope
+		curScope := rt.scope
 
 		for i := 0; i < stackFramesToPop; i++ {
-			if scope.outer != nil {
-				scope = scope.outer
+			if curScope.outer != nil {
+				curScope = curScope.outer
 			}
 		}
 
-		frame := scope.frame
+		frm := curScope.frame
 
 		if length > 0 {
-			if at, ok := in[length-1].(_at); ok {
+			if atv, ok := in[length-1].(at); ok {
 				in = in[0 : length-1]
-				if scope != nil {
-					frame.offset = int(at)
+				if curScope != nil {
+					frm.offset = int(atv)
 				}
 				length--
 			}
@@ -173,54 +171,52 @@ func newError(rt *_runtime, name string, stackFramesToPop int, in ...interface{}
 
 		limit := rt.traceLimit
 
-		err.trace = append(err.trace, frame)
-		if scope != nil {
-			for scope = scope.outer; scope != nil; scope = scope.outer {
+		err.trace = append(err.trace, frm)
+		if curScope != nil {
+			for curScope = curScope.outer; curScope != nil; curScope = curScope.outer {
 				if limit--; limit == 0 {
 					break
 				}
 
-				if scope.frame.offset >= 0 {
-					err.trace = append(err.trace, scope.frame)
+				if curScope.frame.offset >= 0 {
+					err.trace = append(err.trace, curScope.frame)
 				}
 			}
 		}
-	} else {
-		if length > 0 {
-			description, in = in[0].(string), in[1:]
-		}
+	} else if length > 0 {
+		description, in = in[0].(string), in[1:]
 	}
 	err.message = err.describe(description, in...)
 
 	return err
 }
 
-func (rt *_runtime) panicTypeError(argumentList ...interface{}) *_exception {
-	return &_exception{
+func (rt *runtime) panicTypeError(argumentList ...interface{}) *exception {
+	return &exception{
 		value: newError(rt, "TypeError", 0, argumentList...),
 	}
 }
 
-func (rt *_runtime) panicReferenceError(argumentList ...interface{}) *_exception {
-	return &_exception{
+func (rt *runtime) panicReferenceError(argumentList ...interface{}) *exception {
+	return &exception{
 		value: newError(rt, "ReferenceError", 0, argumentList...),
 	}
 }
 
-func (rt *_runtime) panicURIError(argumentList ...interface{}) *_exception {
-	return &_exception{
+func (rt *runtime) panicURIError(argumentList ...interface{}) *exception {
+	return &exception{
 		value: newError(rt, "URIError", 0, argumentList...),
 	}
 }
 
-func (rt *_runtime) panicSyntaxError(argumentList ...interface{}) *_exception {
-	return &_exception{
+func (rt *runtime) panicSyntaxError(argumentList ...interface{}) *exception {
+	return &exception{
 		value: newError(rt, "SyntaxError", 0, argumentList...),
 	}
 }
 
-func (rt *_runtime) panicRangeError(argumentList ...interface{}) *_exception {
-	return &_exception{
+func (rt *runtime) panicRangeError(argumentList ...interface{}) *exception {
+	return &exception{
 		value: newError(rt, "RangeError", 0, argumentList...),
 	}
 }
@@ -228,20 +224,19 @@ func (rt *_runtime) panicRangeError(argumentList ...interface{}) *_exception {
 func catchPanic(function func()) (err error) {
 	defer func() {
 		if caught := recover(); caught != nil {
-			if exception, ok := caught.(*_exception); ok {
-				caught = exception.eject()
+			if excep, ok := caught.(*exception); ok {
+				caught = excep.eject()
 			}
 			switch caught := caught.(type) {
 			case *Error:
 				err = caught
 				return
-			case _error:
+			case ottoError:
 				err = &Error{caught}
 				return
 			case Value:
-				if vl := caught._object(); vl != nil {
-					switch vl := vl.value.(type) {
-					case _error:
+				if vl := caught.object(); vl != nil {
+					if vl, ok := vl.value.(ottoError); ok {
 						err = &Error{vl}
 						return
 					}

--- a/error_native_test.go
+++ b/error_native_test.go
@@ -2,6 +2,8 @@ package otto
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // this is its own file because the tests in it rely on the line numbers of
@@ -12,28 +14,33 @@ func TestErrorContextNative(t *testing.T) {
 	tt(t, func() {
 		vm := New()
 
-		vm.Set("N", func(c FunctionCall) Value {
+		err := vm.Set("N", func(c FunctionCall) Value {
 			v, err := c.Argument(0).Call(NullValue())
 			if err != nil {
 				panic(err)
 			}
 			return v
 		})
+		require.NoError(t, err)
 
-		s, _ := vm.Compile("test.js", `
+		s, err := vm.Compile("test.js", `
 			function F() { throw new Error('wow'); }
 			function G() { return N(F); }
 		`)
+		require.NoError(t, err)
 
-		vm.Run(s)
+		_, err = vm.Run(s)
+		require.NoError(t, err)
 
-		f1, _ := vm.Get("G")
-		_, err := f1.Call(NullValue())
-		err1 := err.(*Error)
+		f1, err := vm.Get("G")
+		require.NoError(t, err)
+		_, err = f1.Call(NullValue())
+		require.Error(t, err)
+		err1 := asError(t, err)
 		is(err1.message, "wow")
 		is(len(err1.trace), 3)
 		is(err1.trace[0].location(), "F (test.js:2:29)")
-		is(err1.trace[1].location(), "github.com/robertkrimen/otto.TestErrorContextNative.func1.1 (error_native_test.go:15)")
+		is(err1.trace[1].location(), "github.com/robertkrimen/otto.TestErrorContextNative.func1.1 (error_native_test.go:17)")
 		is(err1.trace[2].location(), "G (test.js:3:26)")
 	})
 }

--- a/function_test.go
+++ b/function_test.go
@@ -28,7 +28,7 @@ func TestFunction_new(t *testing.T) {
 
 		test(`raise:
             new Function({});
-        `, "SyntaxError: Unexpected identifier")
+        `, "SyntaxError: (anonymous): Line 2:9 Unexpected identifier")
 
 		test(`
             var abc = Function("def, ghi", "jkl", "return def+ghi+jkl");
@@ -54,14 +54,14 @@ func TestFunction_new(t *testing.T) {
             var def = "return this";
             var ghi = new Function(abc, def);
             ghi;
-        `, "SyntaxError: Unexpected token ;")
+        `, "SyntaxError: (anonymous): Line 1:12 Unexpected token ;")
 
 		test(`raise:
             var abc;
             var def = "return true";
             var ghi = new Function(null, def);
             ghi;
-        `, "SyntaxError: Unexpected token null")
+        `, "SyntaxError: (anonymous): Line 1:11 Unexpected token null")
 	})
 }
 

--- a/functional_benchmark_test.go
+++ b/functional_benchmark_test.go
@@ -5,6 +5,8 @@ import (
 	"math/rand"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGoSliceQuickSort(t *testing.T) {
@@ -62,7 +64,8 @@ func BenchmarkCryptoAES(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		vm.Run(jsCryptoAES)
+		_, err := vm.Run(jsCryptoAES)
+		require.NoError(b, err)
 	}
 }
 
@@ -100,11 +103,13 @@ func testJsArraySort(t *testing.T, sortFuncCall string, sortCode string) {
 		test, vm := test()
 
 		// inject quicksort code
-		vm.Run(sortCode)
+		_, err := vm.Run(sortCode)
+		require.NoError(t, err)
 
-		vm.Run("var testSlice = [5, 3, 2, 4, 1];")
-		_, err := vm.Run(sortFuncCall)
-		is(err, nil)
+		_, err = vm.Run("var testSlice = [5, 3, 2, 4, 1];")
+		require.NoError(t, err)
+		_, err = vm.Run(sortFuncCall)
+		require.NoError(t, err)
 
 		is(test(`testSlice[0]`).export(), 1)
 		is(test(`testSlice[1]`).export(), 2)
@@ -119,19 +124,21 @@ func benchmarkGoSliceSort(b *testing.B, size int, sortFuncCall string, sortCode 
 	// generate arbitrary slice of 'size'
 	testSlice := make([]int, size)
 	for i := 0; i < size; i++ {
-		testSlice[i] = rand.Int()
+		testSlice[i] = rand.Int() //nolint: gosec
 	}
 
 	vm := New()
 
 	// inject the sorting code
-	vm.Run(sortCode)
+	_, err := vm.Run(sortCode)
+	require.NoError(b, err)
 
 	// Reset timer - everything until this point may have taken a long time
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		vm.Run(sortFuncCall)
+		_, err = vm.Run(sortFuncCall)
+		require.NoError(b, err)
 	}
 }
 
@@ -139,8 +146,8 @@ func benchmarkJsArraySort(b *testing.B, size int, sortFuncCall string, sortCode 
 	b.Helper()
 	// generate arbitrary slice of 'size'
 	testSlice := make([]string, size)
-	for i, _ := range testSlice {
-		testSlice[i] = fmt.Sprintf("%d", rand.Int())
+	for i := range testSlice {
+		testSlice[i] = fmt.Sprintf("%d", rand.Int()) //nolint: gosec
 	}
 
 	jsArrayString := "[" + strings.Join(testSlice, ",") + "]"
@@ -148,16 +155,19 @@ func benchmarkJsArraySort(b *testing.B, size int, sortFuncCall string, sortCode 
 	vm := New()
 
 	// inject the test array
-	vm.Run("testSlice = " + jsArrayString)
+	_, err := vm.Run("testSlice = " + jsArrayString)
+	require.NoError(b, err)
 
 	// inject the sorting code
-	vm.Run(sortCode)
+	_, err = vm.Run(sortCode)
+	require.NoError(b, err)
 
 	// Reset timer - everything until this point may have taken a long time
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		vm.Run(sortFuncCall)
+		_, err = vm.Run(sortFuncCall)
+		require.NoError(b, err)
 	}
 }
 

--- a/global_test.go
+++ b/global_test.go
@@ -14,15 +14,15 @@ func TestGlobal(t *testing.T) {
 		runtime := vm.vm.runtime
 
 		{
-			call := func(object interface{}, src string, argumentList ...interface{}) Value {
+			call := func(obj interface{}, src string, argumentList ...interface{}) Value {
 				var tgt *Object
-				switch object := object.(type) {
+				switch obj := obj.(type) {
 				case Value:
-					tgt = object.Object()
+					tgt = obj.Object()
 				case *Object:
-					tgt = object
-				case *_object:
-					tgt = toValue_object(object).Object()
+					tgt = obj
+				case *object:
+					tgt = objectValue(obj).Object()
 				default:
 					panic("Here be dragons.")
 				}
@@ -33,35 +33,32 @@ func TestGlobal(t *testing.T) {
 
 			// FIXME enterGlobalScope
 			if false {
-				value := runtime.scope.lexical.getBinding(classObject, false)._object().call(UndefinedValue(), []Value{toValue(runtime.newObject())}, false, nativeFrame)
+				value := runtime.scope.lexical.getBinding(classObjectName, false).object().call(UndefinedValue(), []Value{toValue(runtime.newObject())}, false, nativeFrame)
 				is(value.IsObject(), true)
 				is(value, "[object Object]")
-				is(value._object().prototype == runtime.global.ObjectPrototype, true)
-				is(value._object().prototype == runtime.global.Object.get("prototype")._object(), true)
-				is(value._object().get("toString"), "function toString() { [native code] }")
+				is(value.object().prototype == runtime.global.ObjectPrototype, true)
+				is(value.object().prototype == runtime.global.Object.get("prototype").object(), true)
+				is(value.object().get("toString"), "function toString() { [native code] }")
 				is(call(value.Object(), "hasOwnProperty", "hasOwnProperty"), false)
 
-				is(call(value._object().get("toString")._object().prototype, "toString"), "function () { [native code] }") // TODO Is this right?
-				is(value._object().get("toString")._object().get("toString"), "function toString() { [native code] }")
-				is(value._object().get("toString")._object().get("toString")._object(), "function toString() { [native code] }")
+				is(call(value.object().get("toString").object().prototype, "toString"), "function () { [native code] }") // TODO Is this right?
+				is(value.object().get("toString").object().get("toString"), "function toString() { [native code] }")
+				is(value.object().get("toString").object().get("toString").object(), "function toString() { [native code] }")
 
-				is(call(value._object(), "propertyIsEnumerable", "isPrototypeOf"), false)
-				value._object().put("xyzzy", toValue_string("Nothing happens."), false)
+				is(call(value.object(), "propertyIsEnumerable", "isPrototypeOf"), false)
+				value.object().put("xyzzy", stringValue("Nothing happens."), false)
 				is(call(value, "propertyIsEnumerable", "isPrototypeOf"), false)
 				is(call(value, "propertyIsEnumerable", "xyzzy"), true)
-				is(value._object().get("xyzzy"), "Nothing happens.")
+				is(value.object().get("xyzzy"), "Nothing happens.")
 
-				is(call(runtime.scope.lexical.getBinding(classObject, false), "isPrototypeOf", value), false)
-				is(call(runtime.scope.lexical.getBinding(classObject, false)._object().get("prototype"), "isPrototypeOf", value), true)
-				is(call(runtime.scope.lexical.getBinding(classFunction, false), "isPrototypeOf", value), false)
+				is(call(runtime.scope.lexical.getBinding(classObjectName, false), "isPrototypeOf", value), false)
+				is(call(runtime.scope.lexical.getBinding(classObjectName, false).object().get("prototype"), "isPrototypeOf", value), true)
+				is(call(runtime.scope.lexical.getBinding(classFunctionName, false), "isPrototypeOf", value), false)
 
-				is(runtime.newObject().prototype == runtime.global.Object.get("prototype")._object(), true)
+				is(runtime.newObject().prototype == runtime.global.Object.get("prototype").object(), true)
 
-				abc := runtime.newBoolean(toValue_bool(true))
-				is(toValue_object(abc), "true") // TODO Call primitive?
-
-				//def := runtime.localGet(classBoolean)._object().Construct(UndefinedValue(), []Value{})
-				//is(def, "false") // TODO Call primitive?
+				abc := runtime.newBoolean(boolValue(true))
+				is(objectValue(abc), "true") // TODO Call primitive?
 			}
 		}
 
@@ -208,7 +205,7 @@ func Test_parseInt(t *testing.T) {
 		test(`parseInt(" 11\n")`, 11)
 		test(`parseInt(" 11\n", 16)`, 17)
 
-		test(`parseInt("Xyzzy")`, _NaN)
+		test(`parseInt("Xyzzy")`, naN)
 
 		test(`parseInt(" 0x11\n", 16)`, 17)
 		test(`parseInt("0x0aXyzzy", 16)`, 10)
@@ -233,16 +230,16 @@ func Test_parseFloat(t *testing.T) {
 		test(`parseFloat(" 11\n", 16)`, 11)
 		test(`parseFloat("11.1")`, 11.1)
 
-		test(`parseFloat("Xyzzy")`, _NaN)
+		test(`parseFloat("Xyzzy")`, naN)
 
 		test(`parseFloat(" 0x11\n", 16)`, 0)
 		test(`parseFloat("0x0a")`, 0)
 		test(`parseFloat("0x0aXyzzy")`, 0)
-		test(`parseFloat("Infinity")`, _Infinity)
-		test(`parseFloat("infinity")`, _NaN)
+		test(`parseFloat("Infinity")`, infinity)
+		test(`parseFloat("infinity")`, naN)
 		test(`parseFloat("0x")`, 0)
 		test(`parseFloat("11x")`, 11)
-		test(`parseFloat("Infinity1")`, _Infinity)
+		test(`parseFloat("Infinity1")`, infinity)
 
 		test(`parseFloat.length === 1`, true)
 		test(`parseFloat.prototype === undefined`, true)

--- a/inline.go
+++ b/inline.go
@@ -4,36 +4,34 @@ import (
 	"math"
 )
 
-func _newContext(runtime *_runtime) {
+func (rt *runtime) newContext() {
 	{
-		runtime.global.ObjectPrototype = &_object{
-			runtime:     runtime,
-			class:       classObject,
-			objectClass: _classObject,
+		rt.global.ObjectPrototype = &object{
+			runtime:     rt,
+			class:       classObjectName,
+			objectClass: classObject,
 			prototype:   nil,
 			extensible:  true,
 			value:       prototypeValueObject,
 		}
-	}
-	{
-		runtime.global.FunctionPrototype = &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.ObjectPrototype,
+
+		rt.global.FunctionPrototype = &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.ObjectPrototype,
 			extensible:  true,
 			value:       prototypeValueFunction,
 		}
-	}
-	{
-		valueOf_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+
+		valueOf := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -44,19 +42,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "valueOf",
-				call: builtinObject_valueOf,
+				call: builtinObjectValueOf,
 			},
 		}
-		toString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -67,19 +65,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toString",
-				call: builtinObject_toString,
+				call: builtinObjectToString,
 			},
 		}
-		toLocaleString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toLocaleString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -90,19 +88,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toLocaleString",
-				call: builtinObject_toLocaleString,
+				call: builtinObjectToLocaleString,
 			},
 		}
-		hasOwnProperty_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		hasOwnProperty := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -113,19 +111,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "hasOwnProperty",
-				call: builtinObject_hasOwnProperty,
+				call: builtinObjectHasOwnProperty,
 			},
 		}
-		isPrototypeOf_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		isPrototypeOf := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -136,19 +134,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "isPrototypeOf",
-				call: builtinObject_isPrototypeOf,
+				call: builtinObjectIsPrototypeOf,
 			},
 		}
-		propertyIsEnumerable_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		propertyIsEnumerable := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -159,60 +157,60 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "propertyIsEnumerable",
-				call: builtinObject_propertyIsEnumerable,
+				call: builtinObjectPropertyIsEnumerable,
 			},
 		}
-		runtime.global.ObjectPrototype.property = map[string]_property{
-			"valueOf": _property{
-				mode: 0101,
+		rt.global.ObjectPrototype.property = map[string]property{
+			"valueOf": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: valueOf_function,
+					value: valueOf,
 				},
 			},
-			"toString": _property{
-				mode: 0101,
+			"toString": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: toString_function,
+					value: toString,
 				},
 			},
-			"toLocaleString": _property{
-				mode: 0101,
+			"toLocaleString": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: toLocaleString_function,
+					value: toLocaleString,
 				},
 			},
-			"hasOwnProperty": _property{
-				mode: 0101,
+			"hasOwnProperty": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: hasOwnProperty_function,
+					value: hasOwnProperty,
 				},
 			},
-			"isPrototypeOf": _property{
-				mode: 0101,
+			"isPrototypeOf": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: isPrototypeOf_function,
+					value: isPrototypeOf,
 				},
 			},
-			"propertyIsEnumerable": _property{
-				mode: 0101,
+			"propertyIsEnumerable": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: propertyIsEnumerable_function,
+					value: propertyIsEnumerable,
 				},
 			},
-			"constructor": _property{
-				mode:  0101,
+			"constructor": {
+				mode:  0o101,
 				value: Value{},
 			},
 		}
-		runtime.global.ObjectPrototype.propertyOrder = []string{
+		rt.global.ObjectPrototype.propertyOrder = []string{
 			"valueOf",
 			"toString",
 			"toLocaleString",
@@ -223,14 +221,14 @@ func _newContext(runtime *_runtime) {
 		}
 	}
 	{
-		toString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -241,19 +239,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toString",
-				call: builtinFunction_toString,
+				call: builtinFunctionToString,
 			},
 		}
-		apply_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		apply := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -264,19 +262,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "apply",
-				call: builtinFunction_apply,
+				call: builtinFunctionApply,
 			},
 		}
-		call_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		call := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -287,19 +285,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "call",
-				call: builtinFunction_call,
+				call: builtinFunctionCall,
 			},
 		}
-		bind_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		bind := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -310,45 +308,45 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "bind",
-				call: builtinFunction_bind,
+				call: builtinFunctionBind,
 			},
 		}
-		runtime.global.FunctionPrototype.property = map[string]_property{
-			"toString": _property{
-				mode: 0101,
+		rt.global.FunctionPrototype.property = map[string]property{
+			"toString": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: toString_function,
+					value: toString,
 				},
 			},
-			"apply": _property{
-				mode: 0101,
+			"apply": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: apply_function,
+					value: apply,
 				},
 			},
-			"call": _property{
-				mode: 0101,
+			"call": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: call_function,
+					value: call,
 				},
 			},
-			"bind": _property{
-				mode: 0101,
+			"bind": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: bind_function,
+					value: bind,
 				},
 			},
-			"constructor": _property{
-				mode:  0101,
+			"constructor": {
+				mode:  0o101,
 				value: Value{},
 			},
-			propertyLength: _property{
+			propertyLength: {
 				mode: 0,
 				value: Value{
 					kind:  valueNumber,
@@ -356,7 +354,7 @@ func _newContext(runtime *_runtime) {
 				},
 			},
 		}
-		runtime.global.FunctionPrototype.propertyOrder = []string{
+		rt.global.FunctionPrototype.propertyOrder = []string{
 			"toString",
 			"apply",
 			"call",
@@ -366,14 +364,14 @@ func _newContext(runtime *_runtime) {
 		}
 	}
 	{
-		getPrototypeOf_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getPrototypeOf := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -384,19 +382,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getPrototypeOf",
-				call: builtinObject_getPrototypeOf,
+				call: builtinObjectGetPrototypeOf,
 			},
 		}
-		getOwnPropertyDescriptor_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getOwnPropertyDescriptor := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -407,19 +405,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getOwnPropertyDescriptor",
-				call: builtinObject_getOwnPropertyDescriptor,
+				call: builtinObjectGetOwnPropertyDescriptor,
 			},
 		}
-		defineProperty_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		defineProperty := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -430,19 +428,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "defineProperty",
-				call: builtinObject_defineProperty,
+				call: builtinObjectDefineProperty,
 			},
 		}
-		defineProperties_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		defineProperties := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -453,19 +451,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "defineProperties",
-				call: builtinObject_defineProperties,
+				call: builtinObjectDefineProperties,
 			},
 		}
-		create_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		create := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -476,19 +474,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "create",
-				call: builtinObject_create,
+				call: builtinObjectCreate,
 			},
 		}
-		isExtensible_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		isExtensible := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -499,19 +497,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "isExtensible",
-				call: builtinObject_isExtensible,
+				call: builtinObjectIsExtensible,
 			},
 		}
-		preventExtensions_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		preventExtensions := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -522,19 +520,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "preventExtensions",
-				call: builtinObject_preventExtensions,
+				call: builtinObjectPreventExtensions,
 			},
 		}
-		isSealed_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		isSealed := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -545,19 +543,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "isSealed",
-				call: builtinObject_isSealed,
+				call: builtinObjectIsSealed,
 			},
 		}
-		seal_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		seal := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -568,19 +566,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "seal",
-				call: builtinObject_seal,
+				call: builtinObjectSeal,
 			},
 		}
-		isFrozen_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		isFrozen := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -591,19 +589,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "isFrozen",
-				call: builtinObject_isFrozen,
+				call: builtinObjectIsFrozen,
 			},
 		}
-		freeze_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		freeze := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -614,19 +612,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "freeze",
-				call: builtinObject_freeze,
+				call: builtinObjectFreeze,
 			},
 		}
-		keys_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		keys := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -637,19 +635,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "keys",
-				call: builtinObject_keys,
+				call: builtinObjectKeys,
 			},
 		}
-		getOwnPropertyNames_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getOwnPropertyNames := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -660,126 +658,126 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getOwnPropertyNames",
-				call: builtinObject_getOwnPropertyNames,
+				call: builtinObjectGetOwnPropertyNames,
 			},
 		}
-		runtime.global.Object = &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		rt.global.Object = &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			value: _nativeFunctionObject{
-				name:      classObject,
+			value: nativeFunctionObject{
+				name:      classObjectName,
 				call:      builtinObject,
 				construct: builtinNewObject,
 			},
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: 1,
 					},
 				},
-				"prototype": _property{
+				"prototype": {
 					mode: 0,
 					value: Value{
 						kind:  valueObject,
-						value: runtime.global.ObjectPrototype,
+						value: rt.global.ObjectPrototype,
 					},
 				},
-				"getPrototypeOf": _property{
-					mode: 0101,
+				"getPrototypeOf": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getPrototypeOf_function,
+						value: getPrototypeOf,
 					},
 				},
-				"getOwnPropertyDescriptor": _property{
-					mode: 0101,
+				"getOwnPropertyDescriptor": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getOwnPropertyDescriptor_function,
+						value: getOwnPropertyDescriptor,
 					},
 				},
-				"defineProperty": _property{
-					mode: 0101,
+				"defineProperty": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: defineProperty_function,
+						value: defineProperty,
 					},
 				},
-				"defineProperties": _property{
-					mode: 0101,
+				"defineProperties": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: defineProperties_function,
+						value: defineProperties,
 					},
 				},
-				"create": _property{
-					mode: 0101,
+				"create": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: create_function,
+						value: create,
 					},
 				},
-				"isExtensible": _property{
-					mode: 0101,
+				"isExtensible": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: isExtensible_function,
+						value: isExtensible,
 					},
 				},
-				"preventExtensions": _property{
-					mode: 0101,
+				"preventExtensions": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: preventExtensions_function,
+						value: preventExtensions,
 					},
 				},
-				"isSealed": _property{
-					mode: 0101,
+				"isSealed": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: isSealed_function,
+						value: isSealed,
 					},
 				},
-				"seal": _property{
-					mode: 0101,
+				"seal": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: seal_function,
+						value: seal,
 					},
 				},
-				"isFrozen": _property{
-					mode: 0101,
+				"isFrozen": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: isFrozen_function,
+						value: isFrozen,
 					},
 				},
-				"freeze": _property{
-					mode: 0101,
+				"freeze": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: freeze_function,
+						value: freeze,
 					},
 				},
-				"keys": _property{
-					mode: 0101,
+				"keys": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: keys_function,
+						value: keys,
 					},
 				},
-				"getOwnPropertyNames": _property{
-					mode: 0101,
+				"getOwnPropertyNames": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getOwnPropertyNames_function,
+						value: getOwnPropertyNames,
 					},
 				},
 			},
@@ -801,40 +799,39 @@ func _newContext(runtime *_runtime) {
 				"getOwnPropertyNames",
 			},
 		}
-		runtime.global.ObjectPrototype.property["constructor"] =
-			_property{
-				mode: 0101,
-				value: Value{
-					kind:  valueObject,
-					value: runtime.global.Object,
-				},
-			}
+		rt.global.ObjectPrototype.property["constructor"] = property{
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.Object,
+			},
+		}
 	}
 	{
-		Function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		Function := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			value: _nativeFunctionObject{
-				name:      classFunction,
+			value: nativeFunctionObject{
+				name:      classFunctionName,
 				call:      builtinFunction,
 				construct: builtinNewFunction,
 			},
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: 1,
 					},
 				},
-				"prototype": _property{
+				"prototype": {
 					mode: 0,
 					value: Value{
 						kind:  valueObject,
-						value: runtime.global.FunctionPrototype,
+						value: rt.global.FunctionPrototype,
 					},
 				},
 			},
@@ -843,25 +840,24 @@ func _newContext(runtime *_runtime) {
 				"prototype",
 			},
 		}
-		runtime.global.Function = Function
-		runtime.global.FunctionPrototype.property["constructor"] =
-			_property{
-				mode: 0101,
-				value: Value{
-					kind:  valueObject,
-					value: runtime.global.Function,
-				},
-			}
+		rt.global.Function = Function
+		rt.global.FunctionPrototype.property["constructor"] = property{
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.Function,
+			},
+		}
 	}
 	{
-		toString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -872,19 +868,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toString",
-				call: builtinArray_toString,
+				call: builtinArrayToString,
 			},
 		}
-		toLocaleString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toLocaleString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -895,19 +891,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toLocaleString",
-				call: builtinArray_toLocaleString,
+				call: builtinArrayToLocaleString,
 			},
 		}
-		concat_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		concat := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -918,19 +914,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "concat",
-				call: builtinArray_concat,
+				call: builtinArrayConcat,
 			},
 		}
-		join_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		join := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -941,19 +937,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "join",
-				call: builtinArray_join,
+				call: builtinArrayJoin,
 			},
 		}
-		splice_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		splice := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -964,19 +960,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "splice",
-				call: builtinArray_splice,
+				call: builtinArraySplice,
 			},
 		}
-		shift_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		shift := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -987,19 +983,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "shift",
-				call: builtinArray_shift,
+				call: builtinArrayShift,
 			},
 		}
-		pop_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		pop := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1010,19 +1006,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "pop",
-				call: builtinArray_pop,
+				call: builtinArrayPop,
 			},
 		}
-		push_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		push := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1033,19 +1029,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "push",
-				call: builtinArray_push,
+				call: builtinArrayPush,
 			},
 		}
-		slice_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		slice := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1056,19 +1052,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "slice",
-				call: builtinArray_slice,
+				call: builtinArraySlice,
 			},
 		}
-		unshift_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		unshift := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1079,19 +1075,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "unshift",
-				call: builtinArray_unshift,
+				call: builtinArrayUnshift,
 			},
 		}
-		reverse_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		reverse := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1102,19 +1098,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "reverse",
-				call: builtinArray_reverse,
+				call: builtinArrayReverse,
 			},
 		}
-		sort_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		sort := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1125,19 +1121,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "sort",
-				call: builtinArray_sort,
+				call: builtinArraySort,
 			},
 		}
-		indexOf_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		indexOf := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1148,19 +1144,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "indexOf",
-				call: builtinArray_indexOf,
+				call: builtinArrayIndexOf,
 			},
 		}
-		lastIndexOf_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		lastIndexOf := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1171,19 +1167,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "lastIndexOf",
-				call: builtinArray_lastIndexOf,
+				call: builtinArrayLastIndexOf,
 			},
 		}
-		every_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		every := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1194,19 +1190,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "every",
-				call: builtinArray_every,
+				call: builtinArrayEvery,
 			},
 		}
-		some_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		some := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1217,19 +1213,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "some",
-				call: builtinArray_some,
+				call: builtinArraySome,
 			},
 		}
-		forEach_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		forEach := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1240,19 +1236,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "forEach",
-				call: builtinArray_forEach,
+				call: builtinArrayForEach,
 			},
 		}
-		map_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		mapObj := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1263,19 +1259,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "map",
-				call: builtinArray_map,
+				call: builtinArrayMap,
 			},
 		}
-		filter_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		filter := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1286,19 +1282,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "filter",
-				call: builtinArray_filter,
+				call: builtinArrayFilter,
 			},
 		}
-		reduce_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		reduce := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1309,19 +1305,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "reduce",
-				call: builtinArray_reduce,
+				call: builtinArrayReduce,
 			},
 		}
-		reduceRight_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		reduceRight := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1332,19 +1328,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "reduceRight",
-				call: builtinArray_reduceRight,
+				call: builtinArrayReduceRight,
 			},
 		}
-		isArray_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		isArray := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1355,171 +1351,171 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "isArray",
-				call: builtinArray_isArray,
+				call: builtinArrayIsArray,
 			},
 		}
-		runtime.global.ArrayPrototype = &_object{
-			runtime:     runtime,
-			class:       classArray,
-			objectClass: _classArray,
-			prototype:   runtime.global.ObjectPrototype,
+		rt.global.ArrayPrototype = &object{
+			runtime:     rt,
+			class:       classArrayName,
+			objectClass: classArray,
+			prototype:   rt.global.ObjectPrototype,
 			extensible:  true,
 			value:       nil,
-			property: map[string]_property{
-				propertyLength: _property{
-					mode: 0100,
+			property: map[string]property{
+				propertyLength: {
+					mode: 0o100,
 					value: Value{
 						kind:  valueNumber,
 						value: uint32(0),
 					},
 				},
-				"toString": _property{
-					mode: 0101,
+				"toString": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toString_function,
+						value: toString,
 					},
 				},
-				"toLocaleString": _property{
-					mode: 0101,
+				"toLocaleString": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toLocaleString_function,
+						value: toLocaleString,
 					},
 				},
-				"concat": _property{
-					mode: 0101,
+				"concat": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: concat_function,
+						value: concat,
 					},
 				},
-				"join": _property{
-					mode: 0101,
+				"join": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: join_function,
+						value: join,
 					},
 				},
-				"splice": _property{
-					mode: 0101,
+				"splice": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: splice_function,
+						value: splice,
 					},
 				},
-				"shift": _property{
-					mode: 0101,
+				"shift": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: shift_function,
+						value: shift,
 					},
 				},
-				"pop": _property{
-					mode: 0101,
+				"pop": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: pop_function,
+						value: pop,
 					},
 				},
-				"push": _property{
-					mode: 0101,
+				"push": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: push_function,
+						value: push,
 					},
 				},
-				"slice": _property{
-					mode: 0101,
+				"slice": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: slice_function,
+						value: slice,
 					},
 				},
-				"unshift": _property{
-					mode: 0101,
+				"unshift": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: unshift_function,
+						value: unshift,
 					},
 				},
-				"reverse": _property{
-					mode: 0101,
+				"reverse": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: reverse_function,
+						value: reverse,
 					},
 				},
-				"sort": _property{
-					mode: 0101,
+				"sort": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: sort_function,
+						value: sort,
 					},
 				},
-				"indexOf": _property{
-					mode: 0101,
+				"indexOf": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: indexOf_function,
+						value: indexOf,
 					},
 				},
-				"lastIndexOf": _property{
-					mode: 0101,
+				"lastIndexOf": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: lastIndexOf_function,
+						value: lastIndexOf,
 					},
 				},
-				"every": _property{
-					mode: 0101,
+				"every": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: every_function,
+						value: every,
 					},
 				},
-				"some": _property{
-					mode: 0101,
+				"some": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: some_function,
+						value: some,
 					},
 				},
-				"forEach": _property{
-					mode: 0101,
+				"forEach": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: forEach_function,
+						value: forEach,
 					},
 				},
-				"map": _property{
-					mode: 0101,
+				"map": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: map_function,
+						value: mapObj,
 					},
 				},
-				"filter": _property{
-					mode: 0101,
+				"filter": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: filter_function,
+						value: filter,
 					},
 				},
-				"reduce": _property{
-					mode: 0101,
+				"reduce": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: reduce_function,
+						value: reduce,
 					},
 				},
-				"reduceRight": _property{
-					mode: 0101,
+				"reduceRight": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: reduceRight_function,
+						value: reduceRight,
 					},
 				},
 			},
@@ -1548,37 +1544,37 @@ func _newContext(runtime *_runtime) {
 				"reduceRight",
 			},
 		}
-		runtime.global.Array = &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		rt.global.Array = &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			value: _nativeFunctionObject{
-				name:      classArray,
+			value: nativeFunctionObject{
+				name:      classArrayName,
 				call:      builtinArray,
 				construct: builtinNewArray,
 			},
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: 1,
 					},
 				},
-				"prototype": _property{
+				"prototype": {
 					mode: 0,
 					value: Value{
 						kind:  valueObject,
-						value: runtime.global.ArrayPrototype,
+						value: rt.global.ArrayPrototype,
 					},
 				},
-				"isArray": _property{
-					mode: 0101,
+				"isArray": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: isArray_function,
+						value: isArray,
 					},
 				},
 			},
@@ -1588,24 +1584,23 @@ func _newContext(runtime *_runtime) {
 				"isArray",
 			},
 		}
-		runtime.global.ArrayPrototype.property["constructor"] =
-			_property{
-				mode: 0101,
-				value: Value{
-					kind:  valueObject,
-					value: runtime.global.Array,
-				},
-			}
+		rt.global.ArrayPrototype.property["constructor"] = property{
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.Array,
+			},
+		}
 	}
 	{
-		toString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1616,19 +1611,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toString",
-				call: builtinString_toString,
+				call: builtinStringToString,
 			},
 		}
-		valueOf_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		valueOf := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1639,19 +1634,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "valueOf",
-				call: builtinString_valueOf,
+				call: builtinStringValueOf,
 			},
 		}
-		charAt_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		charAt := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1662,19 +1657,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "charAt",
-				call: builtinString_charAt,
+				call: builtinStringCharAt,
 			},
 		}
-		charCodeAt_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		charCodeAt := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1685,19 +1680,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "charCodeAt",
-				call: builtinString_charCodeAt,
+				call: builtinStringCharCodeAt,
 			},
 		}
-		concat_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		concat := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1708,19 +1703,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "concat",
-				call: builtinString_concat,
+				call: builtinStringConcat,
 			},
 		}
-		indexOf_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		indexOf := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1731,19 +1726,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "indexOf",
-				call: builtinString_indexOf,
+				call: builtinStringIndexOf,
 			},
 		}
-		lastIndexOf_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		lastIndexOf := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1754,19 +1749,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "lastIndexOf",
-				call: builtinString_lastIndexOf,
+				call: builtinStringLastIndexOf,
 			},
 		}
-		match_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		match := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1777,19 +1772,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "match",
-				call: builtinString_match,
+				call: builtinStringMatch,
 			},
 		}
-		replace_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		replace := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1800,19 +1795,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "replace",
-				call: builtinString_replace,
+				call: builtinStringReplace,
 			},
 		}
-		search_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		search := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1823,19 +1818,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "search",
-				call: builtinString_search,
+				call: builtinStringSearch,
 			},
 		}
-		split_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		split := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1846,19 +1841,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "split",
-				call: builtinString_split,
+				call: builtinStringSplit,
 			},
 		}
-		slice_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		slice := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1869,19 +1864,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "slice",
-				call: builtinString_slice,
+				call: builtinStringSlice,
 			},
 		}
-		substring_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		substring := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1892,19 +1887,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "substring",
-				call: builtinString_substring,
+				call: builtinStringSubstring,
 			},
 		}
-		toLowerCase_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toLowerCase := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1915,19 +1910,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toLowerCase",
-				call: builtinString_toLowerCase,
+				call: builtinStringToLowerCase,
 			},
 		}
-		toUpperCase_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toUpperCase := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1938,19 +1933,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toUpperCase",
-				call: builtinString_toUpperCase,
+				call: builtinStringToUpperCase,
 			},
 		}
-		substr_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		substr := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1961,19 +1956,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "substr",
-				call: builtinString_substr,
+				call: builtinStringSubstr,
 			},
 		}
-		trim_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		trim := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -1984,19 +1979,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "trim",
-				call: builtinString_trim,
+				call: builtinStringTrim,
 			},
 		}
-		trimLeft_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		trimLeft := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2007,19 +2002,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "trimLeft",
-				call: builtinString_trimLeft,
+				call: builtinStringTrimLeft,
 			},
 		}
-		trimRight_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		trimRight := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2030,19 +2025,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "trimRight",
-				call: builtinString_trimRight,
+				call: builtinStringTrimRight,
 			},
 		}
-		localeCompare_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		localeCompare := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2053,19 +2048,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "localeCompare",
-				call: builtinString_localeCompare,
+				call: builtinStringLocaleCompare,
 			},
 		}
-		toLocaleLowerCase_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toLocaleLowerCase := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2076,19 +2071,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toLocaleLowerCase",
-				call: builtinString_toLocaleLowerCase,
+				call: builtinStringToLocaleLowerCase,
 			},
 		}
-		toLocaleUpperCase_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toLocaleUpperCase := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2099,19 +2094,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toLocaleUpperCase",
-				call: builtinString_toLocaleUpperCase,
+				call: builtinStringToLocaleUpperCase,
 			},
 		}
-		fromCharCode_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		fromCharCode := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2122,178 +2117,178 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "fromCharCode",
-				call: builtinString_fromCharCode,
+				call: builtinStringFromCharCode,
 			},
 		}
-		runtime.global.StringPrototype = &_object{
-			runtime:     runtime,
-			class:       classString,
-			objectClass: _classString,
-			prototype:   runtime.global.ObjectPrototype,
+		rt.global.StringPrototype = &object{
+			runtime:     rt,
+			class:       classStringName,
+			objectClass: classString,
+			prototype:   rt.global.ObjectPrototype,
 			extensible:  true,
 			value:       prototypeValueString,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: int(0),
 					},
 				},
-				"toString": _property{
-					mode: 0101,
+				"toString": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toString_function,
+						value: toString,
 					},
 				},
-				"valueOf": _property{
-					mode: 0101,
+				"valueOf": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: valueOf_function,
+						value: valueOf,
 					},
 				},
-				"charAt": _property{
-					mode: 0101,
+				"charAt": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: charAt_function,
+						value: charAt,
 					},
 				},
-				"charCodeAt": _property{
-					mode: 0101,
+				"charCodeAt": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: charCodeAt_function,
+						value: charCodeAt,
 					},
 				},
-				"concat": _property{
-					mode: 0101,
+				"concat": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: concat_function,
+						value: concat,
 					},
 				},
-				"indexOf": _property{
-					mode: 0101,
+				"indexOf": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: indexOf_function,
+						value: indexOf,
 					},
 				},
-				"lastIndexOf": _property{
-					mode: 0101,
+				"lastIndexOf": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: lastIndexOf_function,
+						value: lastIndexOf,
 					},
 				},
-				"match": _property{
-					mode: 0101,
+				"match": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: match_function,
+						value: match,
 					},
 				},
-				"replace": _property{
-					mode: 0101,
+				"replace": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: replace_function,
+						value: replace,
 					},
 				},
-				"search": _property{
-					mode: 0101,
+				"search": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: search_function,
+						value: search,
 					},
 				},
-				"split": _property{
-					mode: 0101,
+				"split": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: split_function,
+						value: split,
 					},
 				},
-				"slice": _property{
-					mode: 0101,
+				"slice": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: slice_function,
+						value: slice,
 					},
 				},
-				"substring": _property{
-					mode: 0101,
+				"substring": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: substring_function,
+						value: substring,
 					},
 				},
-				"toLowerCase": _property{
-					mode: 0101,
+				"toLowerCase": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toLowerCase_function,
+						value: toLowerCase,
 					},
 				},
-				"toUpperCase": _property{
-					mode: 0101,
+				"toUpperCase": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toUpperCase_function,
+						value: toUpperCase,
 					},
 				},
-				"substr": _property{
-					mode: 0101,
+				"substr": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: substr_function,
+						value: substr,
 					},
 				},
-				"trim": _property{
-					mode: 0101,
+				"trim": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: trim_function,
+						value: trim,
 					},
 				},
-				"trimLeft": _property{
-					mode: 0101,
+				"trimLeft": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: trimLeft_function,
+						value: trimLeft,
 					},
 				},
-				"trimRight": _property{
-					mode: 0101,
+				"trimRight": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: trimRight_function,
+						value: trimRight,
 					},
 				},
-				"localeCompare": _property{
-					mode: 0101,
+				"localeCompare": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: localeCompare_function,
+						value: localeCompare,
 					},
 				},
-				"toLocaleLowerCase": _property{
-					mode: 0101,
+				"toLocaleLowerCase": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toLocaleLowerCase_function,
+						value: toLocaleLowerCase,
 					},
 				},
-				"toLocaleUpperCase": _property{
-					mode: 0101,
+				"toLocaleUpperCase": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toLocaleUpperCase_function,
+						value: toLocaleUpperCase,
 					},
 				},
 			},
@@ -2323,37 +2318,37 @@ func _newContext(runtime *_runtime) {
 				"toLocaleUpperCase",
 			},
 		}
-		runtime.global.String = &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		rt.global.String = &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			value: _nativeFunctionObject{
-				name:      classString,
+			value: nativeFunctionObject{
+				name:      classStringName,
 				call:      builtinString,
 				construct: builtinNewString,
 			},
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: 1,
 					},
 				},
-				"prototype": _property{
+				"prototype": {
 					mode: 0,
 					value: Value{
 						kind:  valueObject,
-						value: runtime.global.StringPrototype,
+						value: rt.global.StringPrototype,
 					},
 				},
-				"fromCharCode": _property{
-					mode: 0101,
+				"fromCharCode": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: fromCharCode_function,
+						value: fromCharCode,
 					},
 				},
 			},
@@ -2363,24 +2358,23 @@ func _newContext(runtime *_runtime) {
 				"fromCharCode",
 			},
 		}
-		runtime.global.StringPrototype.property["constructor"] =
-			_property{
-				mode: 0101,
-				value: Value{
-					kind:  valueObject,
-					value: runtime.global.String,
-				},
-			}
+		rt.global.StringPrototype.property["constructor"] = property{
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.String,
+			},
+		}
 	}
 	{
-		toString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2391,19 +2385,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toString",
-				call: builtinBoolean_toString,
+				call: builtinBooleanToString,
 			},
 		}
-		valueOf_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		valueOf := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2414,31 +2408,31 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "valueOf",
-				call: builtinBoolean_valueOf,
+				call: builtinBooleanValueOf,
 			},
 		}
-		runtime.global.BooleanPrototype = &_object{
-			runtime:     runtime,
-			class:       classBoolean,
-			objectClass: _classObject,
-			prototype:   runtime.global.ObjectPrototype,
+		rt.global.BooleanPrototype = &object{
+			runtime:     rt,
+			class:       classBooleanName,
+			objectClass: classObject,
+			prototype:   rt.global.ObjectPrototype,
 			extensible:  true,
 			value:       prototypeValueBoolean,
-			property: map[string]_property{
-				"toString": _property{
-					mode: 0101,
+			property: map[string]property{
+				"toString": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toString_function,
+						value: toString,
 					},
 				},
-				"valueOf": _property{
-					mode: 0101,
+				"valueOf": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: valueOf_function,
+						value: valueOf,
 					},
 				},
 			},
@@ -2447,30 +2441,30 @@ func _newContext(runtime *_runtime) {
 				"valueOf",
 			},
 		}
-		runtime.global.Boolean = &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		rt.global.Boolean = &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			value: _nativeFunctionObject{
-				name:      classBoolean,
+			value: nativeFunctionObject{
+				name:      classBooleanName,
 				call:      builtinBoolean,
 				construct: builtinNewBoolean,
 			},
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: 1,
 					},
 				},
-				"prototype": _property{
+				"prototype": {
 					mode: 0,
 					value: Value{
 						kind:  valueObject,
-						value: runtime.global.BooleanPrototype,
+						value: rt.global.BooleanPrototype,
 					},
 				},
 			},
@@ -2479,24 +2473,23 @@ func _newContext(runtime *_runtime) {
 				"prototype",
 			},
 		}
-		runtime.global.BooleanPrototype.property["constructor"] =
-			_property{
-				mode: 0101,
-				value: Value{
-					kind:  valueObject,
-					value: runtime.global.Boolean,
-				},
-			}
+		rt.global.BooleanPrototype.property["constructor"] = property{
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.Boolean,
+			},
+		}
 	}
 	{
-		toString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2507,19 +2500,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toString",
-				call: builtinNumber_toString,
+				call: builtinNumberToString,
 			},
 		}
-		valueOf_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		valueOf := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2530,19 +2523,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "valueOf",
-				call: builtinNumber_valueOf,
+				call: builtinNumberValueOf,
 			},
 		}
-		toFixed_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toFixed := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2553,19 +2546,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toFixed",
-				call: builtinNumber_toFixed,
+				call: builtinNumberToFixed,
 			},
 		}
-		toExponential_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toExponential := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2576,19 +2569,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toExponential",
-				call: builtinNumber_toExponential,
+				call: builtinNumberToExponential,
 			},
 		}
-		toPrecision_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toPrecision := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2599,19 +2592,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toPrecision",
-				call: builtinNumber_toPrecision,
+				call: builtinNumberToPrecision,
 			},
 		}
-		toLocaleString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toLocaleString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2622,19 +2615,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toLocaleString",
-				call: builtinNumber_toLocaleString,
+				call: builtinNumberToLocaleString,
 			},
 		}
-		isNaN_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		isNaN := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2645,59 +2638,59 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "isNaN",
-				call: builtinNumber_isNaN,
+				call: builtinNumberIsNaN,
 			},
 		}
-		runtime.global.NumberPrototype = &_object{
-			runtime:     runtime,
-			class:       classNumber,
-			objectClass: _classObject,
-			prototype:   runtime.global.ObjectPrototype,
+		rt.global.NumberPrototype = &object{
+			runtime:     rt,
+			class:       classNumberName,
+			objectClass: classObject,
+			prototype:   rt.global.ObjectPrototype,
 			extensible:  true,
 			value:       prototypeValueNumber,
-			property: map[string]_property{
-				"toString": _property{
-					mode: 0101,
+			property: map[string]property{
+				"toString": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toString_function,
+						value: toString,
 					},
 				},
-				"valueOf": _property{
-					mode: 0101,
+				"valueOf": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: valueOf_function,
+						value: valueOf,
 					},
 				},
-				"toFixed": _property{
-					mode: 0101,
+				"toFixed": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toFixed_function,
+						value: toFixed,
 					},
 				},
-				"toExponential": _property{
-					mode: 0101,
+				"toExponential": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toExponential_function,
+						value: toExponential,
 					},
 				},
-				"toPrecision": _property{
-					mode: 0101,
+				"toPrecision": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toPrecision_function,
+						value: toPrecision,
 					},
 				},
-				"toLocaleString": _property{
-					mode: 0101,
+				"toLocaleString": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toLocaleString_function,
+						value: toLocaleString,
 					},
 				},
 			},
@@ -2710,68 +2703,68 @@ func _newContext(runtime *_runtime) {
 				"toLocaleString",
 			},
 		}
-		runtime.global.Number = &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		rt.global.Number = &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			value: _nativeFunctionObject{
-				name:      classNumber,
+			value: nativeFunctionObject{
+				name:      classNumberName,
 				call:      builtinNumber,
 				construct: builtinNewNumber,
 			},
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: 1,
 					},
 				},
-				"prototype": _property{
+				"prototype": {
 					mode: 0,
 					value: Value{
 						kind:  valueObject,
-						value: runtime.global.NumberPrototype,
+						value: rt.global.NumberPrototype,
 					},
 				},
-				"isNaN": _property{
-					mode: 0101,
+				"isNaN": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: isNaN_function,
+						value: isNaN,
 					},
 				},
-				"MAX_VALUE": _property{
+				"MAX_VALUE": {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: math.MaxFloat64,
 					},
 				},
-				"MIN_VALUE": _property{
+				"MIN_VALUE": {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: math.SmallestNonzeroFloat64,
 					},
 				},
-				"NaN": _property{
+				"NaN": {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: math.NaN(),
 					},
 				},
-				"NEGATIVE_INFINITY": _property{
+				"NEGATIVE_INFINITY": {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: math.Inf(-1),
 					},
 				},
-				"POSITIVE_INFINITY": _property{
+				"POSITIVE_INFINITY": {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2790,24 +2783,23 @@ func _newContext(runtime *_runtime) {
 				"POSITIVE_INFINITY",
 			},
 		}
-		runtime.global.NumberPrototype.property["constructor"] =
-			_property{
-				mode: 0101,
-				value: Value{
-					kind:  valueObject,
-					value: runtime.global.Number,
-				},
-			}
+		rt.global.NumberPrototype.property["constructor"] = property{
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.Number,
+			},
+		}
 	}
 	{
-		abs_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		abs := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2818,19 +2810,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "abs",
-				call: builtinMath_abs,
+				call: builtinMathAbs,
 			},
 		}
-		acos_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		acos := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2841,19 +2833,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "acos",
-				call: builtinMath_acos,
+				call: builtinMathAcos,
 			},
 		}
-		asin_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		asin := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2864,19 +2856,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "asin",
-				call: builtinMath_asin,
+				call: builtinMathAsin,
 			},
 		}
-		atan_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		atan := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2887,19 +2879,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "atan",
-				call: builtinMath_atan,
+				call: builtinMathAtan,
 			},
 		}
-		atan2_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		atan2 := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2910,19 +2902,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "atan2",
-				call: builtinMath_atan2,
+				call: builtinMathAtan2,
 			},
 		}
-		ceil_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		ceil := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2933,19 +2925,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "ceil",
-				call: builtinMath_ceil,
+				call: builtinMathCeil,
 			},
 		}
-		cos_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		cos := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2956,19 +2948,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "cos",
-				call: builtinMath_cos,
+				call: builtinMathCos,
 			},
 		}
-		exp_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		exp := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -2979,19 +2971,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "exp",
-				call: builtinMath_exp,
+				call: builtinMathExp,
 			},
 		}
-		floor_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		floor := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3002,19 +2994,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "floor",
-				call: builtinMath_floor,
+				call: builtinMathFloor,
 			},
 		}
-		log_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		log := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3025,19 +3017,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "log",
-				call: builtinMath_log,
+				call: builtinMathLog,
 			},
 		}
-		max_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		max := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3048,19 +3040,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "max",
-				call: builtinMath_max,
+				call: builtinMathMax,
 			},
 		}
-		min_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		min := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3071,19 +3063,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "min",
-				call: builtinMath_min,
+				call: builtinMathMin,
 			},
 		}
-		pow_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		pow := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3094,19 +3086,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "pow",
-				call: builtinMath_pow,
+				call: builtinMathPow,
 			},
 		}
-		random_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		random := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3117,19 +3109,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "random",
-				call: builtinMath_random,
+				call: builtinMathRandom,
 			},
 		}
-		round_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		round := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3140,19 +3132,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "round",
-				call: builtinMath_round,
+				call: builtinMathRound,
 			},
 		}
-		sin_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		sin := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3163,19 +3155,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "sin",
-				call: builtinMath_sin,
+				call: builtinMathSin,
 			},
 		}
-		sqrt_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		sqrt := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3186,19 +3178,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "sqrt",
-				call: builtinMath_sqrt,
+				call: builtinMathSqrt,
 			},
 		}
-		tan_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		tan := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3209,194 +3201,194 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "tan",
-				call: builtinMath_tan,
+				call: builtinMathTan,
 			},
 		}
-		runtime.global.Math = &_object{
-			runtime:     runtime,
+		rt.global.Math = &object{
+			runtime:     rt,
 			class:       "Math",
-			objectClass: _classObject,
-			prototype:   runtime.global.ObjectPrototype,
+			objectClass: classObject,
+			prototype:   rt.global.ObjectPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				"abs": _property{
-					mode: 0101,
+			property: map[string]property{
+				"abs": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: abs_function,
+						value: abs,
 					},
 				},
-				"acos": _property{
-					mode: 0101,
+				"acos": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: acos_function,
+						value: acos,
 					},
 				},
-				"asin": _property{
-					mode: 0101,
+				"asin": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: asin_function,
+						value: asin,
 					},
 				},
-				"atan": _property{
-					mode: 0101,
+				"atan": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: atan_function,
+						value: atan,
 					},
 				},
-				"atan2": _property{
-					mode: 0101,
+				"atan2": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: atan2_function,
+						value: atan2,
 					},
 				},
-				"ceil": _property{
-					mode: 0101,
+				"ceil": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: ceil_function,
+						value: ceil,
 					},
 				},
-				"cos": _property{
-					mode: 0101,
+				"cos": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: cos_function,
+						value: cos,
 					},
 				},
-				"exp": _property{
-					mode: 0101,
+				"exp": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: exp_function,
+						value: exp,
 					},
 				},
-				"floor": _property{
-					mode: 0101,
+				"floor": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: floor_function,
+						value: floor,
 					},
 				},
-				"log": _property{
-					mode: 0101,
+				"log": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: log_function,
+						value: log,
 					},
 				},
-				"max": _property{
-					mode: 0101,
+				"max": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: max_function,
+						value: max,
 					},
 				},
-				"min": _property{
-					mode: 0101,
+				"min": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: min_function,
+						value: min,
 					},
 				},
-				"pow": _property{
-					mode: 0101,
+				"pow": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: pow_function,
+						value: pow,
 					},
 				},
-				"random": _property{
-					mode: 0101,
+				"random": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: random_function,
+						value: random,
 					},
 				},
-				"round": _property{
-					mode: 0101,
+				"round": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: round_function,
+						value: round,
 					},
 				},
-				"sin": _property{
-					mode: 0101,
+				"sin": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: sin_function,
+						value: sin,
 					},
 				},
-				"sqrt": _property{
-					mode: 0101,
+				"sqrt": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: sqrt_function,
+						value: sqrt,
 					},
 				},
-				"tan": _property{
-					mode: 0101,
+				"tan": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: tan_function,
+						value: tan,
 					},
 				},
-				"E": _property{
+				"E": {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: math.E,
 					},
 				},
-				"LN10": _property{
+				"LN10": {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: math.Ln10,
 					},
 				},
-				"LN2": _property{
+				"LN2": {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: math.Ln2,
 					},
 				},
-				"LOG2E": _property{
+				"LOG2E": {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: math.Log2E,
 					},
 				},
-				"LOG10E": _property{
+				"LOG10E": {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: math.Log10E,
 					},
 				},
-				"PI": _property{
+				"PI": {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: math.Pi,
 					},
 				},
-				"SQRT1_2": _property{
+				"SQRT1_2": {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: sqrt1_2,
 					},
 				},
-				"SQRT2": _property{
+				"SQRT2": {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3435,14 +3427,14 @@ func _newContext(runtime *_runtime) {
 		}
 	}
 	{
-		toString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3453,19 +3445,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toString",
-				call: builtinDate_toString,
+				call: builtinDateToString,
 			},
 		}
-		toDateString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toDateString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3476,19 +3468,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toDateString",
-				call: builtinDate_toDateString,
+				call: builtinDateToDateString,
 			},
 		}
-		toTimeString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toTimeString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3499,19 +3491,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toTimeString",
-				call: builtinDate_toTimeString,
+				call: builtinDateToTimeString,
 			},
 		}
-		toUTCString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toUTCString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3522,19 +3514,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toUTCString",
-				call: builtinDate_toUTCString,
+				call: builtinDateToUTCString,
 			},
 		}
-		toISOString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toISOString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3545,19 +3537,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toISOString",
-				call: builtinDate_toISOString,
+				call: builtinDateToISOString,
 			},
 		}
-		toJSON_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toJSON := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3568,19 +3560,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toJSON",
-				call: builtinDate_toJSON,
+				call: builtinDateToJSON,
 			},
 		}
-		toGMTString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toGMTString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3591,19 +3583,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toGMTString",
-				call: builtinDate_toGMTString,
+				call: builtinDateToGMTString,
 			},
 		}
-		toLocaleString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toLocaleString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3614,19 +3606,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toLocaleString",
-				call: builtinDate_toLocaleString,
+				call: builtinDateToLocaleString,
 			},
 		}
-		toLocaleDateString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toLocaleDateString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3637,19 +3629,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toLocaleDateString",
-				call: builtinDate_toLocaleDateString,
+				call: builtinDateToLocaleDateString,
 			},
 		}
-		toLocaleTimeString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toLocaleTimeString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3660,19 +3652,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toLocaleTimeString",
-				call: builtinDate_toLocaleTimeString,
+				call: builtinDateToLocaleTimeString,
 			},
 		}
-		valueOf_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		valueOf := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3683,19 +3675,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "valueOf",
-				call: builtinDate_valueOf,
+				call: builtinDateValueOf,
 			},
 		}
-		getTime_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getTime := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3706,19 +3698,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getTime",
-				call: builtinDate_getTime,
+				call: builtinDateGetTime,
 			},
 		}
-		getYear_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getYear := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3729,19 +3721,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getYear",
-				call: builtinDate_getYear,
+				call: builtinDateGetYear,
 			},
 		}
-		getFullYear_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getFullYear := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3752,19 +3744,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getFullYear",
-				call: builtinDate_getFullYear,
+				call: builtinDateGetFullYear,
 			},
 		}
-		getUTCFullYear_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getUTCFullYear := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3775,19 +3767,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getUTCFullYear",
-				call: builtinDate_getUTCFullYear,
+				call: builtinDateGetUTCFullYear,
 			},
 		}
-		getMonth_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getMonth := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3798,19 +3790,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getMonth",
-				call: builtinDate_getMonth,
+				call: builtinDateGetMonth,
 			},
 		}
-		getUTCMonth_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getUTCMonth := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3821,19 +3813,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getUTCMonth",
-				call: builtinDate_getUTCMonth,
+				call: builtinDateGetUTCMonth,
 			},
 		}
-		getDate_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getDate := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3844,19 +3836,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getDate",
-				call: builtinDate_getDate,
+				call: builtinDateGetDate,
 			},
 		}
-		getUTCDate_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getUTCDate := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3867,19 +3859,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getUTCDate",
-				call: builtinDate_getUTCDate,
+				call: builtinDateGetUTCDate,
 			},
 		}
-		getDay_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getDay := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3890,19 +3882,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getDay",
-				call: builtinDate_getDay,
+				call: builtinDateGetDay,
 			},
 		}
-		getUTCDay_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getUTCDay := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3913,19 +3905,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getUTCDay",
-				call: builtinDate_getUTCDay,
+				call: builtinDateGetUTCDay,
 			},
 		}
-		getHours_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getHours := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3936,19 +3928,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getHours",
-				call: builtinDate_getHours,
+				call: builtinDateGetHours,
 			},
 		}
-		getUTCHours_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getUTCHours := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3959,19 +3951,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getUTCHours",
-				call: builtinDate_getUTCHours,
+				call: builtinDateGetUTCHours,
 			},
 		}
-		getMinutes_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getMinutes := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -3982,19 +3974,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getMinutes",
-				call: builtinDate_getMinutes,
+				call: builtinDateGetMinutes,
 			},
 		}
-		getUTCMinutes_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getUTCMinutes := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4005,19 +3997,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getUTCMinutes",
-				call: builtinDate_getUTCMinutes,
+				call: builtinDateGetUTCMinutes,
 			},
 		}
-		getSeconds_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getSeconds := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4028,19 +4020,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getSeconds",
-				call: builtinDate_getSeconds,
+				call: builtinDateGetSeconds,
 			},
 		}
-		getUTCSeconds_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getUTCSeconds := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4051,19 +4043,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getUTCSeconds",
-				call: builtinDate_getUTCSeconds,
+				call: builtinDateGetUTCSeconds,
 			},
 		}
-		getMilliseconds_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getMilliseconds := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4074,19 +4066,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getMilliseconds",
-				call: builtinDate_getMilliseconds,
+				call: builtinDateGetMilliseconds,
 			},
 		}
-		getUTCMilliseconds_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getUTCMilliseconds := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4097,19 +4089,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getUTCMilliseconds",
-				call: builtinDate_getUTCMilliseconds,
+				call: builtinDateGetUTCMilliseconds,
 			},
 		}
-		getTimezoneOffset_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		getTimezoneOffset := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4120,19 +4112,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "getTimezoneOffset",
-				call: builtinDate_getTimezoneOffset,
+				call: builtinDateGetTimezoneOffset,
 			},
 		}
-		setTime_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		setTime := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4143,19 +4135,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "setTime",
-				call: builtinDate_setTime,
+				call: builtinDateSetTime,
 			},
 		}
-		setMilliseconds_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		setMilliseconds := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4166,19 +4158,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "setMilliseconds",
-				call: builtinDate_setMilliseconds,
+				call: builtinDateSetMilliseconds,
 			},
 		}
-		setUTCMilliseconds_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		setUTCMilliseconds := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4189,19 +4181,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "setUTCMilliseconds",
-				call: builtinDate_setUTCMilliseconds,
+				call: builtinDateSetUTCMilliseconds,
 			},
 		}
-		setSeconds_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		setSeconds := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4212,19 +4204,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "setSeconds",
-				call: builtinDate_setSeconds,
+				call: builtinDateSetSeconds,
 			},
 		}
-		setUTCSeconds_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		setUTCSeconds := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4235,19 +4227,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "setUTCSeconds",
-				call: builtinDate_setUTCSeconds,
+				call: builtinDateSetUTCSeconds,
 			},
 		}
-		setMinutes_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		setMinutes := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4258,19 +4250,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "setMinutes",
-				call: builtinDate_setMinutes,
+				call: builtinDateSetMinutes,
 			},
 		}
-		setUTCMinutes_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		setUTCMinutes := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4281,19 +4273,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "setUTCMinutes",
-				call: builtinDate_setUTCMinutes,
+				call: builtinDateSetUTCMinutes,
 			},
 		}
-		setHours_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		setHours := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4304,19 +4296,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "setHours",
-				call: builtinDate_setHours,
+				call: builtinDateSetHours,
 			},
 		}
-		setUTCHours_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		setUTCHours := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4327,19 +4319,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "setUTCHours",
-				call: builtinDate_setUTCHours,
+				call: builtinDateSetUTCHours,
 			},
 		}
-		setDate_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		setDate := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4350,19 +4342,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "setDate",
-				call: builtinDate_setDate,
+				call: builtinDateSetDate,
 			},
 		}
-		setUTCDate_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		setUTCDate := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4373,19 +4365,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "setUTCDate",
-				call: builtinDate_setUTCDate,
+				call: builtinDateSetUTCDate,
 			},
 		}
-		setMonth_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		setMonth := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4396,19 +4388,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "setMonth",
-				call: builtinDate_setMonth,
+				call: builtinDateSetMonth,
 			},
 		}
-		setUTCMonth_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		setUTCMonth := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4419,19 +4411,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "setUTCMonth",
-				call: builtinDate_setUTCMonth,
+				call: builtinDateSetUTCMonth,
 			},
 		}
-		setYear_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		setYear := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4442,19 +4434,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "setYear",
-				call: builtinDate_setYear,
+				call: builtinDateSetYear,
 			},
 		}
-		setFullYear_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		setFullYear := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4465,19 +4457,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "setFullYear",
-				call: builtinDate_setFullYear,
+				call: builtinDateSetFullYear,
 			},
 		}
-		setUTCFullYear_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		setUTCFullYear := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4488,19 +4480,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "setUTCFullYear",
-				call: builtinDate_setUTCFullYear,
+				call: builtinDateSetUTCFullYear,
 			},
 		}
-		parse_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		parse := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4511,19 +4503,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "parse",
-				call: builtinDate_parse,
+				call: builtinDateParse,
 			},
 		}
-		UTC_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		UTC := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4534,19 +4526,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "UTC",
-				call: builtinDate_UTC,
+				call: builtinDateUTC,
 			},
 		}
-		now_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		now := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -4557,339 +4549,339 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "now",
-				call: builtinDate_now,
+				call: builtinDateNow,
 			},
 		}
-		runtime.global.DatePrototype = &_object{
-			runtime:     runtime,
-			class:       classDate,
-			objectClass: _classObject,
-			prototype:   runtime.global.ObjectPrototype,
+		rt.global.DatePrototype = &object{
+			runtime:     rt,
+			class:       classDateName,
+			objectClass: classObject,
+			prototype:   rt.global.ObjectPrototype,
 			extensible:  true,
 			value:       prototypeValueDate,
-			property: map[string]_property{
-				"toString": _property{
-					mode: 0101,
+			property: map[string]property{
+				"toString": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toString_function,
+						value: toString,
 					},
 				},
-				"toDateString": _property{
-					mode: 0101,
+				"toDateString": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toDateString_function,
+						value: toDateString,
 					},
 				},
-				"toTimeString": _property{
-					mode: 0101,
+				"toTimeString": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toTimeString_function,
+						value: toTimeString,
 					},
 				},
-				"toUTCString": _property{
-					mode: 0101,
+				"toUTCString": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toUTCString_function,
+						value: toUTCString,
 					},
 				},
-				"toISOString": _property{
-					mode: 0101,
+				"toISOString": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toISOString_function,
+						value: toISOString,
 					},
 				},
-				"toJSON": _property{
-					mode: 0101,
+				"toJSON": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toJSON_function,
+						value: toJSON,
 					},
 				},
-				"toGMTString": _property{
-					mode: 0101,
+				"toGMTString": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toGMTString_function,
+						value: toGMTString,
 					},
 				},
-				"toLocaleString": _property{
-					mode: 0101,
+				"toLocaleString": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toLocaleString_function,
+						value: toLocaleString,
 					},
 				},
-				"toLocaleDateString": _property{
-					mode: 0101,
+				"toLocaleDateString": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toLocaleDateString_function,
+						value: toLocaleDateString,
 					},
 				},
-				"toLocaleTimeString": _property{
-					mode: 0101,
+				"toLocaleTimeString": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toLocaleTimeString_function,
+						value: toLocaleTimeString,
 					},
 				},
-				"valueOf": _property{
-					mode: 0101,
+				"valueOf": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: valueOf_function,
+						value: valueOf,
 					},
 				},
-				"getTime": _property{
-					mode: 0101,
+				"getTime": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getTime_function,
+						value: getTime,
 					},
 				},
-				"getYear": _property{
-					mode: 0101,
+				"getYear": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getYear_function,
+						value: getYear,
 					},
 				},
-				"getFullYear": _property{
-					mode: 0101,
+				"getFullYear": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getFullYear_function,
+						value: getFullYear,
 					},
 				},
-				"getUTCFullYear": _property{
-					mode: 0101,
+				"getUTCFullYear": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getUTCFullYear_function,
+						value: getUTCFullYear,
 					},
 				},
-				"getMonth": _property{
-					mode: 0101,
+				"getMonth": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getMonth_function,
+						value: getMonth,
 					},
 				},
-				"getUTCMonth": _property{
-					mode: 0101,
+				"getUTCMonth": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getUTCMonth_function,
+						value: getUTCMonth,
 					},
 				},
-				"getDate": _property{
-					mode: 0101,
+				"getDate": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getDate_function,
+						value: getDate,
 					},
 				},
-				"getUTCDate": _property{
-					mode: 0101,
+				"getUTCDate": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getUTCDate_function,
+						value: getUTCDate,
 					},
 				},
-				"getDay": _property{
-					mode: 0101,
+				"getDay": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getDay_function,
+						value: getDay,
 					},
 				},
-				"getUTCDay": _property{
-					mode: 0101,
+				"getUTCDay": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getUTCDay_function,
+						value: getUTCDay,
 					},
 				},
-				"getHours": _property{
-					mode: 0101,
+				"getHours": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getHours_function,
+						value: getHours,
 					},
 				},
-				"getUTCHours": _property{
-					mode: 0101,
+				"getUTCHours": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getUTCHours_function,
+						value: getUTCHours,
 					},
 				},
-				"getMinutes": _property{
-					mode: 0101,
+				"getMinutes": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getMinutes_function,
+						value: getMinutes,
 					},
 				},
-				"getUTCMinutes": _property{
-					mode: 0101,
+				"getUTCMinutes": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getUTCMinutes_function,
+						value: getUTCMinutes,
 					},
 				},
-				"getSeconds": _property{
-					mode: 0101,
+				"getSeconds": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getSeconds_function,
+						value: getSeconds,
 					},
 				},
-				"getUTCSeconds": _property{
-					mode: 0101,
+				"getUTCSeconds": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getUTCSeconds_function,
+						value: getUTCSeconds,
 					},
 				},
-				"getMilliseconds": _property{
-					mode: 0101,
+				"getMilliseconds": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getMilliseconds_function,
+						value: getMilliseconds,
 					},
 				},
-				"getUTCMilliseconds": _property{
-					mode: 0101,
+				"getUTCMilliseconds": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getUTCMilliseconds_function,
+						value: getUTCMilliseconds,
 					},
 				},
-				"getTimezoneOffset": _property{
-					mode: 0101,
+				"getTimezoneOffset": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: getTimezoneOffset_function,
+						value: getTimezoneOffset,
 					},
 				},
-				"setTime": _property{
-					mode: 0101,
+				"setTime": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: setTime_function,
+						value: setTime,
 					},
 				},
-				"setMilliseconds": _property{
-					mode: 0101,
+				"setMilliseconds": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: setMilliseconds_function,
+						value: setMilliseconds,
 					},
 				},
-				"setUTCMilliseconds": _property{
-					mode: 0101,
+				"setUTCMilliseconds": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: setUTCMilliseconds_function,
+						value: setUTCMilliseconds,
 					},
 				},
-				"setSeconds": _property{
-					mode: 0101,
+				"setSeconds": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: setSeconds_function,
+						value: setSeconds,
 					},
 				},
-				"setUTCSeconds": _property{
-					mode: 0101,
+				"setUTCSeconds": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: setUTCSeconds_function,
+						value: setUTCSeconds,
 					},
 				},
-				"setMinutes": _property{
-					mode: 0101,
+				"setMinutes": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: setMinutes_function,
+						value: setMinutes,
 					},
 				},
-				"setUTCMinutes": _property{
-					mode: 0101,
+				"setUTCMinutes": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: setUTCMinutes_function,
+						value: setUTCMinutes,
 					},
 				},
-				"setHours": _property{
-					mode: 0101,
+				"setHours": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: setHours_function,
+						value: setHours,
 					},
 				},
-				"setUTCHours": _property{
-					mode: 0101,
+				"setUTCHours": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: setUTCHours_function,
+						value: setUTCHours,
 					},
 				},
-				"setDate": _property{
-					mode: 0101,
+				"setDate": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: setDate_function,
+						value: setDate,
 					},
 				},
-				"setUTCDate": _property{
-					mode: 0101,
+				"setUTCDate": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: setUTCDate_function,
+						value: setUTCDate,
 					},
 				},
-				"setMonth": _property{
-					mode: 0101,
+				"setMonth": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: setMonth_function,
+						value: setMonth,
 					},
 				},
-				"setUTCMonth": _property{
-					mode: 0101,
+				"setUTCMonth": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: setUTCMonth_function,
+						value: setUTCMonth,
 					},
 				},
-				"setYear": _property{
-					mode: 0101,
+				"setYear": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: setYear_function,
+						value: setYear,
 					},
 				},
-				"setFullYear": _property{
-					mode: 0101,
+				"setFullYear": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: setFullYear_function,
+						value: setFullYear,
 					},
 				},
-				"setUTCFullYear": _property{
-					mode: 0101,
+				"setUTCFullYear": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: setUTCFullYear_function,
+						value: setUTCFullYear,
 					},
 				},
 			},
@@ -4942,51 +4934,51 @@ func _newContext(runtime *_runtime) {
 				"setUTCFullYear",
 			},
 		}
-		runtime.global.Date = &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		rt.global.Date = &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			value: _nativeFunctionObject{
-				name:      classDate,
+			value: nativeFunctionObject{
+				name:      classDateName,
 				call:      builtinDate,
 				construct: builtinNewDate,
 			},
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: 7,
 					},
 				},
-				"prototype": _property{
+				"prototype": {
 					mode: 0,
 					value: Value{
 						kind:  valueObject,
-						value: runtime.global.DatePrototype,
+						value: rt.global.DatePrototype,
 					},
 				},
-				"parse": _property{
-					mode: 0101,
+				"parse": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: parse_function,
+						value: parse,
 					},
 				},
-				"UTC": _property{
-					mode: 0101,
+				"UTC": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: UTC_function,
+						value: UTC,
 					},
 				},
-				"now": _property{
-					mode: 0101,
+				"now": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: now_function,
+						value: now,
 					},
 				},
 			},
@@ -4998,24 +4990,23 @@ func _newContext(runtime *_runtime) {
 				"now",
 			},
 		}
-		runtime.global.DatePrototype.property["constructor"] =
-			_property{
-				mode: 0101,
-				value: Value{
-					kind:  valueObject,
-					value: runtime.global.Date,
-				},
-			}
+		rt.global.DatePrototype.property["constructor"] = property{
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.Date,
+			},
+		}
 	}
 	{
-		toString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -5026,19 +5017,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toString",
-				call: builtinRegExp_toString,
+				call: builtinRegExpToString,
 			},
 		}
-		exec_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		exec := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -5049,19 +5040,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "exec",
-				call: builtinRegExp_exec,
+				call: builtinRegExpExec,
 			},
 		}
-		test_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		test := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -5072,19 +5063,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "test",
-				call: builtinRegExp_test,
+				call: builtinRegExpTest,
 			},
 		}
-		compile_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		compile := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -5095,45 +5086,45 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "compile",
-				call: builtinRegExp_compile,
+				call: builtinRegExpCompile,
 			},
 		}
-		runtime.global.RegExpPrototype = &_object{
-			runtime:     runtime,
-			class:       classRegExp,
-			objectClass: _classObject,
-			prototype:   runtime.global.ObjectPrototype,
+		rt.global.RegExpPrototype = &object{
+			runtime:     rt,
+			class:       classRegExpName,
+			objectClass: classObject,
+			prototype:   rt.global.ObjectPrototype,
 			extensible:  true,
 			value:       prototypeValueRegExp,
-			property: map[string]_property{
-				"toString": _property{
-					mode: 0101,
+			property: map[string]property{
+				"toString": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toString_function,
+						value: toString,
 					},
 				},
-				"exec": _property{
-					mode: 0101,
+				"exec": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: exec_function,
+						value: exec,
 					},
 				},
-				"test": _property{
-					mode: 0101,
+				"test": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: test_function,
+						value: test,
 					},
 				},
-				"compile": _property{
-					mode: 0101,
+				"compile": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: compile_function,
+						value: compile,
 					},
 				},
 			},
@@ -5144,30 +5135,30 @@ func _newContext(runtime *_runtime) {
 				"compile",
 			},
 		}
-		runtime.global.RegExp = &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		rt.global.RegExp = &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			value: _nativeFunctionObject{
-				name:      classRegExp,
+			value: nativeFunctionObject{
+				name:      classRegExpName,
 				call:      builtinRegExp,
 				construct: builtinNewRegExp,
 			},
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: 2,
 					},
 				},
-				"prototype": _property{
+				"prototype": {
 					mode: 0,
 					value: Value{
 						kind:  valueObject,
-						value: runtime.global.RegExpPrototype,
+						value: rt.global.RegExpPrototype,
 					},
 				},
 			},
@@ -5176,24 +5167,23 @@ func _newContext(runtime *_runtime) {
 				"prototype",
 			},
 		}
-		runtime.global.RegExpPrototype.property["constructor"] =
-			_property{
-				mode: 0101,
-				value: Value{
-					kind:  valueObject,
-					value: runtime.global.RegExp,
-				},
-			}
+		rt.global.RegExpPrototype.property["constructor"] = property{
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.RegExp,
+			},
+		}
 	}
 	{
-		toString_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		toString := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -5204,35 +5194,35 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "toString",
-				call: builtinError_toString,
+				call: builtinErrorToString,
 			},
 		}
-		runtime.global.ErrorPrototype = &_object{
-			runtime:     runtime,
-			class:       classError,
-			objectClass: _classObject,
-			prototype:   runtime.global.ObjectPrototype,
+		rt.global.ErrorPrototype = &object{
+			runtime:     rt,
+			class:       classErrorName,
+			objectClass: classObject,
+			prototype:   rt.global.ObjectPrototype,
 			extensible:  true,
 			value:       nil,
-			property: map[string]_property{
-				"toString": _property{
-					mode: 0101,
+			property: map[string]property{
+				"toString": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: toString_function,
+						value: toString,
 					},
 				},
-				"name": _property{
-					mode: 0101,
+				"name": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueString,
-						value: classError,
+						value: classErrorName,
 					},
 				},
-				"message": _property{
-					mode: 0101,
+				"message": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueString,
 						value: "",
@@ -5245,30 +5235,30 @@ func _newContext(runtime *_runtime) {
 				"message",
 			},
 		}
-		runtime.global.Error = &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		rt.global.Error = &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			value: _nativeFunctionObject{
-				name:      classError,
+			value: nativeFunctionObject{
+				name:      classErrorName,
 				call:      builtinError,
 				construct: builtinNewError,
 			},
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: 1,
 					},
 				},
-				"prototype": _property{
+				"prototype": {
 					mode: 0,
 					value: Value{
 						kind:  valueObject,
-						value: runtime.global.ErrorPrototype,
+						value: rt.global.ErrorPrototype,
 					},
 				},
 			},
@@ -5277,26 +5267,25 @@ func _newContext(runtime *_runtime) {
 				"prototype",
 			},
 		}
-		runtime.global.ErrorPrototype.property["constructor"] =
-			_property{
-				mode: 0101,
-				value: Value{
-					kind:  valueObject,
-					value: runtime.global.Error,
-				},
-			}
+		rt.global.ErrorPrototype.property["constructor"] = property{
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.Error,
+			},
+		}
 	}
 	{
-		runtime.global.EvalErrorPrototype = &_object{
-			runtime:     runtime,
+		rt.global.EvalErrorPrototype = &object{
+			runtime:     rt,
 			class:       "EvalError",
-			objectClass: _classObject,
-			prototype:   runtime.global.ErrorPrototype,
+			objectClass: classObject,
+			prototype:   rt.global.ErrorPrototype,
 			extensible:  true,
 			value:       nil,
-			property: map[string]_property{
-				"name": _property{
-					mode: 0101,
+			property: map[string]property{
+				"name": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueString,
 						value: "EvalError",
@@ -5307,30 +5296,30 @@ func _newContext(runtime *_runtime) {
 				"name",
 			},
 		}
-		runtime.global.EvalError = &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		rt.global.EvalError = &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name:      "EvalError",
 				call:      builtinEvalError,
 				construct: builtinNewEvalError,
 			},
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: 1,
 					},
 				},
-				"prototype": _property{
+				"prototype": {
 					mode: 0,
 					value: Value{
 						kind:  valueObject,
-						value: runtime.global.EvalErrorPrototype,
+						value: rt.global.EvalErrorPrototype,
 					},
 				},
 			},
@@ -5339,26 +5328,25 @@ func _newContext(runtime *_runtime) {
 				"prototype",
 			},
 		}
-		runtime.global.EvalErrorPrototype.property["constructor"] =
-			_property{
-				mode: 0101,
-				value: Value{
-					kind:  valueObject,
-					value: runtime.global.EvalError,
-				},
-			}
+		rt.global.EvalErrorPrototype.property["constructor"] = property{
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.EvalError,
+			},
+		}
 	}
 	{
-		runtime.global.TypeErrorPrototype = &_object{
-			runtime:     runtime,
+		rt.global.TypeErrorPrototype = &object{
+			runtime:     rt,
 			class:       "TypeError",
-			objectClass: _classObject,
-			prototype:   runtime.global.ErrorPrototype,
+			objectClass: classObject,
+			prototype:   rt.global.ErrorPrototype,
 			extensible:  true,
 			value:       nil,
-			property: map[string]_property{
-				"name": _property{
-					mode: 0101,
+			property: map[string]property{
+				"name": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueString,
 						value: "TypeError",
@@ -5369,30 +5357,30 @@ func _newContext(runtime *_runtime) {
 				"name",
 			},
 		}
-		runtime.global.TypeError = &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		rt.global.TypeError = &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name:      "TypeError",
 				call:      builtinTypeError,
 				construct: builtinNewTypeError,
 			},
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: 1,
 					},
 				},
-				"prototype": _property{
+				"prototype": {
 					mode: 0,
 					value: Value{
 						kind:  valueObject,
-						value: runtime.global.TypeErrorPrototype,
+						value: rt.global.TypeErrorPrototype,
 					},
 				},
 			},
@@ -5401,26 +5389,25 @@ func _newContext(runtime *_runtime) {
 				"prototype",
 			},
 		}
-		runtime.global.TypeErrorPrototype.property["constructor"] =
-			_property{
-				mode: 0101,
-				value: Value{
-					kind:  valueObject,
-					value: runtime.global.TypeError,
-				},
-			}
+		rt.global.TypeErrorPrototype.property["constructor"] = property{
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.TypeError,
+			},
+		}
 	}
 	{
-		runtime.global.RangeErrorPrototype = &_object{
-			runtime:     runtime,
+		rt.global.RangeErrorPrototype = &object{
+			runtime:     rt,
 			class:       "RangeError",
-			objectClass: _classObject,
-			prototype:   runtime.global.ErrorPrototype,
+			objectClass: classObject,
+			prototype:   rt.global.ErrorPrototype,
 			extensible:  true,
 			value:       nil,
-			property: map[string]_property{
-				"name": _property{
-					mode: 0101,
+			property: map[string]property{
+				"name": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueString,
 						value: "RangeError",
@@ -5431,30 +5418,30 @@ func _newContext(runtime *_runtime) {
 				"name",
 			},
 		}
-		runtime.global.RangeError = &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		rt.global.RangeError = &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name:      "RangeError",
 				call:      builtinRangeError,
 				construct: builtinNewRangeError,
 			},
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: 1,
 					},
 				},
-				"prototype": _property{
+				"prototype": {
 					mode: 0,
 					value: Value{
 						kind:  valueObject,
-						value: runtime.global.RangeErrorPrototype,
+						value: rt.global.RangeErrorPrototype,
 					},
 				},
 			},
@@ -5463,26 +5450,25 @@ func _newContext(runtime *_runtime) {
 				"prototype",
 			},
 		}
-		runtime.global.RangeErrorPrototype.property["constructor"] =
-			_property{
-				mode: 0101,
-				value: Value{
-					kind:  valueObject,
-					value: runtime.global.RangeError,
-				},
-			}
+		rt.global.RangeErrorPrototype.property["constructor"] = property{
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.RangeError,
+			},
+		}
 	}
 	{
-		runtime.global.ReferenceErrorPrototype = &_object{
-			runtime:     runtime,
+		rt.global.ReferenceErrorPrototype = &object{
+			runtime:     rt,
 			class:       "ReferenceError",
-			objectClass: _classObject,
-			prototype:   runtime.global.ErrorPrototype,
+			objectClass: classObject,
+			prototype:   rt.global.ErrorPrototype,
 			extensible:  true,
 			value:       nil,
-			property: map[string]_property{
-				"name": _property{
-					mode: 0101,
+			property: map[string]property{
+				"name": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueString,
 						value: "ReferenceError",
@@ -5493,30 +5479,30 @@ func _newContext(runtime *_runtime) {
 				"name",
 			},
 		}
-		runtime.global.ReferenceError = &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		rt.global.ReferenceError = &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name:      "ReferenceError",
 				call:      builtinReferenceError,
 				construct: builtinNewReferenceError,
 			},
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: 1,
 					},
 				},
-				"prototype": _property{
+				"prototype": {
 					mode: 0,
 					value: Value{
 						kind:  valueObject,
-						value: runtime.global.ReferenceErrorPrototype,
+						value: rt.global.ReferenceErrorPrototype,
 					},
 				},
 			},
@@ -5525,26 +5511,25 @@ func _newContext(runtime *_runtime) {
 				"prototype",
 			},
 		}
-		runtime.global.ReferenceErrorPrototype.property["constructor"] =
-			_property{
-				mode: 0101,
-				value: Value{
-					kind:  valueObject,
-					value: runtime.global.ReferenceError,
-				},
-			}
+		rt.global.ReferenceErrorPrototype.property["constructor"] = property{
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.ReferenceError,
+			},
+		}
 	}
 	{
-		runtime.global.SyntaxErrorPrototype = &_object{
-			runtime:     runtime,
+		rt.global.SyntaxErrorPrototype = &object{
+			runtime:     rt,
 			class:       "SyntaxError",
-			objectClass: _classObject,
-			prototype:   runtime.global.ErrorPrototype,
+			objectClass: classObject,
+			prototype:   rt.global.ErrorPrototype,
 			extensible:  true,
 			value:       nil,
-			property: map[string]_property{
-				"name": _property{
-					mode: 0101,
+			property: map[string]property{
+				"name": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueString,
 						value: "SyntaxError",
@@ -5555,30 +5540,30 @@ func _newContext(runtime *_runtime) {
 				"name",
 			},
 		}
-		runtime.global.SyntaxError = &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		rt.global.SyntaxError = &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name:      "SyntaxError",
 				call:      builtinSyntaxError,
 				construct: builtinNewSyntaxError,
 			},
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: 1,
 					},
 				},
-				"prototype": _property{
+				"prototype": {
 					mode: 0,
 					value: Value{
 						kind:  valueObject,
-						value: runtime.global.SyntaxErrorPrototype,
+						value: rt.global.SyntaxErrorPrototype,
 					},
 				},
 			},
@@ -5587,26 +5572,25 @@ func _newContext(runtime *_runtime) {
 				"prototype",
 			},
 		}
-		runtime.global.SyntaxErrorPrototype.property["constructor"] =
-			_property{
-				mode: 0101,
-				value: Value{
-					kind:  valueObject,
-					value: runtime.global.SyntaxError,
-				},
-			}
+		rt.global.SyntaxErrorPrototype.property["constructor"] = property{
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.SyntaxError,
+			},
+		}
 	}
 	{
-		runtime.global.URIErrorPrototype = &_object{
-			runtime:     runtime,
+		rt.global.URIErrorPrototype = &object{
+			runtime:     rt,
 			class:       "URIError",
-			objectClass: _classObject,
-			prototype:   runtime.global.ErrorPrototype,
+			objectClass: classObject,
+			prototype:   rt.global.ErrorPrototype,
 			extensible:  true,
 			value:       nil,
-			property: map[string]_property{
-				"name": _property{
-					mode: 0101,
+			property: map[string]property{
+				"name": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueString,
 						value: "URIError",
@@ -5617,30 +5601,30 @@ func _newContext(runtime *_runtime) {
 				"name",
 			},
 		}
-		runtime.global.URIError = &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		rt.global.URIError = &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name:      "URIError",
 				call:      builtinURIError,
 				construct: builtinNewURIError,
 			},
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
 						value: 1,
 					},
 				},
-				"prototype": _property{
+				"prototype": {
 					mode: 0,
 					value: Value{
 						kind:  valueObject,
-						value: runtime.global.URIErrorPrototype,
+						value: rt.global.URIErrorPrototype,
 					},
 				},
 			},
@@ -5649,24 +5633,23 @@ func _newContext(runtime *_runtime) {
 				"prototype",
 			},
 		}
-		runtime.global.URIErrorPrototype.property["constructor"] =
-			_property{
-				mode: 0101,
-				value: Value{
-					kind:  valueObject,
-					value: runtime.global.URIError,
-				},
-			}
+		rt.global.URIErrorPrototype.property["constructor"] = property{
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.URIError,
+			},
+		}
 	}
 	{
-		parse_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		parse := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -5677,19 +5660,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "parse",
-				call: builtinJSON_parse,
+				call: builtinJSONParse,
 			},
 		}
-		stringify_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		stringify := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -5700,30 +5683,30 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "stringify",
-				call: builtinJSON_stringify,
+				call: builtinJSONStringify,
 			},
 		}
-		runtime.global.JSON = &_object{
-			runtime:     runtime,
+		rt.global.JSON = &object{
+			runtime:     rt,
 			class:       "JSON",
-			objectClass: _classObject,
-			prototype:   runtime.global.ObjectPrototype,
+			objectClass: classObject,
+			prototype:   rt.global.ObjectPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				"parse": _property{
-					mode: 0101,
+			property: map[string]property{
+				"parse": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: parse_function,
+						value: parse,
 					},
 				},
-				"stringify": _property{
-					mode: 0101,
+				"stringify": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: stringify_function,
+						value: stringify,
 					},
 				},
 			},
@@ -5734,14 +5717,14 @@ func _newContext(runtime *_runtime) {
 		}
 	}
 	{
-		eval_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		eval := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -5752,19 +5735,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "eval",
-				call: builtinGlobal_eval,
+				call: builtinGlobalEval,
 			},
 		}
-		parseInt_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		parseInt := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -5775,19 +5758,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "parseInt",
-				call: builtinGlobal_parseInt,
+				call: builtinGlobalParseInt,
 			},
 		}
-		parseFloat_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		parseFloat := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -5798,19 +5781,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "parseFloat",
-				call: builtinGlobal_parseFloat,
+				call: builtinGlobalParseFloat,
 			},
 		}
-		isNaN_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		isNaN := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -5821,19 +5804,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "isNaN",
-				call: builtinGlobal_isNaN,
+				call: builtinGlobalIsNaN,
 			},
 		}
-		isFinite_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		isFinite := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -5844,19 +5827,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "isFinite",
-				call: builtinGlobal_isFinite,
+				call: builtinGlobalIsFinite,
 			},
 		}
-		decodeURI_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		decodeURI := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -5867,19 +5850,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "decodeURI",
-				call: builtinGlobal_decodeURI,
+				call: builtinGlobalDecodeURI,
 			},
 		}
-		decodeURIComponent_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		decodeURIComponent := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -5890,19 +5873,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "decodeURIComponent",
-				call: builtinGlobal_decodeURIComponent,
+				call: builtinGlobalDecodeURIComponent,
 			},
 		}
-		encodeURI_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		encodeURI := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -5913,19 +5896,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "encodeURI",
-				call: builtinGlobal_encodeURI,
+				call: builtinGlobalEncodeURI,
 			},
 		}
-		encodeURIComponent_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		encodeURIComponent := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -5936,19 +5919,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "encodeURIComponent",
-				call: builtinGlobal_encodeURIComponent,
+				call: builtinGlobalEncodeURIComponent,
 			},
 		}
-		escape_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		escape := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -5959,19 +5942,19 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "escape",
-				call: builtinGlobal_escape,
+				call: builtinGlobalEscape,
 			},
 		}
-		unescape_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		unescape := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -5982,222 +5965,222 @@ func _newContext(runtime *_runtime) {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "unescape",
-				call: builtinGlobal_unescape,
+				call: builtinGlobalUnescape,
 			},
 		}
-		runtime.globalObject.property = map[string]_property{
-			"eval": _property{
-				mode: 0101,
+		rt.globalObject.property = map[string]property{
+			"eval": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: eval_function,
+					value: eval,
 				},
 			},
-			"parseInt": _property{
-				mode: 0101,
+			"parseInt": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: parseInt_function,
+					value: parseInt,
 				},
 			},
-			"parseFloat": _property{
-				mode: 0101,
+			"parseFloat": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: parseFloat_function,
+					value: parseFloat,
 				},
 			},
-			"isNaN": _property{
-				mode: 0101,
+			"isNaN": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: isNaN_function,
+					value: isNaN,
 				},
 			},
-			"isFinite": _property{
-				mode: 0101,
+			"isFinite": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: isFinite_function,
+					value: isFinite,
 				},
 			},
-			"decodeURI": _property{
-				mode: 0101,
+			"decodeURI": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: decodeURI_function,
+					value: decodeURI,
 				},
 			},
-			"decodeURIComponent": _property{
-				mode: 0101,
+			"decodeURIComponent": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: decodeURIComponent_function,
+					value: decodeURIComponent,
 				},
 			},
-			"encodeURI": _property{
-				mode: 0101,
+			"encodeURI": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: encodeURI_function,
+					value: encodeURI,
 				},
 			},
-			"encodeURIComponent": _property{
-				mode: 0101,
+			"encodeURIComponent": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: encodeURIComponent_function,
+					value: encodeURIComponent,
 				},
 			},
-			"escape": _property{
-				mode: 0101,
+			"escape": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: escape_function,
+					value: escape,
 				},
 			},
-			"unescape": _property{
-				mode: 0101,
+			"unescape": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: unescape_function,
+					value: unescape,
 				},
 			},
-			classObject: _property{
-				mode: 0101,
+			classObjectName: {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: runtime.global.Object,
+					value: rt.global.Object,
 				},
 			},
-			classFunction: _property{
-				mode: 0101,
+			classFunctionName: {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: runtime.global.Function,
+					value: rt.global.Function,
 				},
 			},
-			classArray: _property{
-				mode: 0101,
+			classArrayName: {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: runtime.global.Array,
+					value: rt.global.Array,
 				},
 			},
-			classString: _property{
-				mode: 0101,
+			classStringName: {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: runtime.global.String,
+					value: rt.global.String,
 				},
 			},
-			classBoolean: _property{
-				mode: 0101,
+			classBooleanName: {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: runtime.global.Boolean,
+					value: rt.global.Boolean,
 				},
 			},
-			classNumber: _property{
-				mode: 0101,
+			classNumberName: {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: runtime.global.Number,
+					value: rt.global.Number,
 				},
 			},
-			"Math": _property{
-				mode: 0101,
+			"Math": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: runtime.global.Math,
+					value: rt.global.Math,
 				},
 			},
-			classDate: _property{
-				mode: 0101,
+			classDateName: {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: runtime.global.Date,
+					value: rt.global.Date,
 				},
 			},
-			classRegExp: _property{
-				mode: 0101,
+			classRegExpName: {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: runtime.global.RegExp,
+					value: rt.global.RegExp,
 				},
 			},
-			classError: _property{
-				mode: 0101,
+			classErrorName: {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: runtime.global.Error,
+					value: rt.global.Error,
 				},
 			},
-			"EvalError": _property{
-				mode: 0101,
+			"EvalError": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: runtime.global.EvalError,
+					value: rt.global.EvalError,
 				},
 			},
-			"TypeError": _property{
-				mode: 0101,
+			"TypeError": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: runtime.global.TypeError,
+					value: rt.global.TypeError,
 				},
 			},
-			"RangeError": _property{
-				mode: 0101,
+			"RangeError": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: runtime.global.RangeError,
+					value: rt.global.RangeError,
 				},
 			},
-			"ReferenceError": _property{
-				mode: 0101,
+			"ReferenceError": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: runtime.global.ReferenceError,
+					value: rt.global.ReferenceError,
 				},
 			},
-			"SyntaxError": _property{
-				mode: 0101,
+			"SyntaxError": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: runtime.global.SyntaxError,
+					value: rt.global.SyntaxError,
 				},
 			},
-			"URIError": _property{
-				mode: 0101,
+			"URIError": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: runtime.global.URIError,
+					value: rt.global.URIError,
 				},
 			},
-			"JSON": _property{
-				mode: 0101,
+			"JSON": {
+				mode: 0o101,
 				value: Value{
 					kind:  valueObject,
-					value: runtime.global.JSON,
+					value: rt.global.JSON,
 				},
 			},
-			"undefined": _property{
+			"undefined": {
 				mode: 0,
 				value: Value{
 					kind: valueUndefined,
 				},
 			},
-			"NaN": _property{
+			"NaN": {
 				mode: 0,
 				value: Value{
 					kind:  valueNumber,
 					value: math.NaN(),
 				},
 			},
-			"Infinity": _property{
+			"Infinity": {
 				mode: 0,
 				value: Value{
 					kind:  valueNumber,
@@ -6205,7 +6188,7 @@ func _newContext(runtime *_runtime) {
 				},
 			},
 		}
-		runtime.globalObject.propertyOrder = []string{
+		rt.globalObject.propertyOrder = []string{
 			"eval",
 			"parseInt",
 			"parseFloat",
@@ -6217,16 +6200,16 @@ func _newContext(runtime *_runtime) {
 			"encodeURIComponent",
 			"escape",
 			"unescape",
-			classObject,
-			classFunction,
-			classArray,
-			classString,
-			classBoolean,
-			classNumber,
+			classObjectName,
+			classFunctionName,
+			classArrayName,
+			classStringName,
+			classBooleanName,
+			classNumberName,
 			"Math",
-			classDate,
-			classRegExp,
-			classError,
+			classDateName,
+			classRegExpName,
+			classErrorName,
 			"EvalError",
 			"TypeError",
 			"RangeError",
@@ -6241,16 +6224,16 @@ func _newContext(runtime *_runtime) {
 	}
 }
 
-func newConsoleObject(runtime *_runtime) *_object {
+func newConsoleObject(rt *runtime) *object {
 	{
-		log_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		log := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -6261,19 +6244,19 @@ func newConsoleObject(runtime *_runtime) *_object {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "log",
-				call: builtinConsole_log,
+				call: builtinConsoleLog,
 			},
 		}
-		debug_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		debug := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -6284,19 +6267,19 @@ func newConsoleObject(runtime *_runtime) *_object {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "debug",
-				call: builtinConsole_log,
+				call: builtinConsoleLog,
 			},
 		}
-		info_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		info := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -6307,19 +6290,19 @@ func newConsoleObject(runtime *_runtime) *_object {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "info",
-				call: builtinConsole_log,
+				call: builtinConsoleLog,
 			},
 		}
-		error_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		errorObj := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -6330,19 +6313,19 @@ func newConsoleObject(runtime *_runtime) *_object {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "error",
-				call: builtinConsole_error,
+				call: builtinConsoleError,
 			},
 		}
-		warn_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		warn := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -6353,19 +6336,19 @@ func newConsoleObject(runtime *_runtime) *_object {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "warn",
-				call: builtinConsole_error,
+				call: builtinConsoleError,
 			},
 		}
-		dir_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		dir := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -6376,19 +6359,19 @@ func newConsoleObject(runtime *_runtime) *_object {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "dir",
-				call: builtinConsole_dir,
+				call: builtinConsoleDir,
 			},
 		}
-		time_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		time := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -6399,19 +6382,19 @@ func newConsoleObject(runtime *_runtime) *_object {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "time",
-				call: builtinConsole_time,
+				call: builtinConsoleTime,
 			},
 		}
-		timeEnd_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		timeEnd := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -6422,19 +6405,19 @@ func newConsoleObject(runtime *_runtime) *_object {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "timeEnd",
-				call: builtinConsole_timeEnd,
+				call: builtinConsoleTimeEnd,
 			},
 		}
-		trace_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		trace := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -6445,19 +6428,19 @@ func newConsoleObject(runtime *_runtime) *_object {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "trace",
-				call: builtinConsole_trace,
+				call: builtinConsoleTrace,
 			},
 		}
-		assert_function := &_object{
-			runtime:     runtime,
-			class:       classFunction,
-			objectClass: _classObject,
-			prototype:   runtime.global.FunctionPrototype,
+		assert := &object{
+			runtime:     rt,
+			class:       classFunctionName,
+			objectClass: classObject,
+			prototype:   rt.global.FunctionPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				propertyLength: _property{
+			property: map[string]property{
+				propertyLength: {
 					mode: 0,
 					value: Value{
 						kind:  valueNumber,
@@ -6468,86 +6451,86 @@ func newConsoleObject(runtime *_runtime) *_object {
 			propertyOrder: []string{
 				propertyLength,
 			},
-			value: _nativeFunctionObject{
+			value: nativeFunctionObject{
 				name: "assert",
-				call: builtinConsole_assert,
+				call: builtinConsoleAssert,
 			},
 		}
-		return &_object{
-			runtime:     runtime,
-			class:       classObject,
-			objectClass: _classObject,
-			prototype:   runtime.global.ObjectPrototype,
+		return &object{
+			runtime:     rt,
+			class:       classObjectName,
+			objectClass: classObject,
+			prototype:   rt.global.ObjectPrototype,
 			extensible:  true,
-			property: map[string]_property{
-				"log": _property{
-					mode: 0101,
+			property: map[string]property{
+				"log": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: log_function,
+						value: log,
 					},
 				},
-				"debug": _property{
-					mode: 0101,
+				"debug": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: debug_function,
+						value: debug,
 					},
 				},
-				"info": _property{
-					mode: 0101,
+				"info": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: info_function,
+						value: info,
 					},
 				},
-				"error": _property{
-					mode: 0101,
+				"error": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: error_function,
+						value: errorObj,
 					},
 				},
-				"warn": _property{
-					mode: 0101,
+				"warn": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: warn_function,
+						value: warn,
 					},
 				},
-				"dir": _property{
-					mode: 0101,
+				"dir": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: dir_function,
+						value: dir,
 					},
 				},
-				"time": _property{
-					mode: 0101,
+				"time": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: time_function,
+						value: time,
 					},
 				},
-				"timeEnd": _property{
-					mode: 0101,
+				"timeEnd": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: timeEnd_function,
+						value: timeEnd,
 					},
 				},
-				"trace": _property{
-					mode: 0101,
+				"trace": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: trace_function,
+						value: trace,
 					},
 				},
-				"assert": _property{
-					mode: 0101,
+				"assert": {
+					mode: 0o101,
 					value: Value{
 						kind:  valueObject,
-						value: assert_function,
+						value: assert,
 					},
 				},
 			},
@@ -6567,70 +6550,70 @@ func newConsoleObject(runtime *_runtime) *_object {
 	}
 }
 
-func toValue_int(value int) Value {
+func intValue(value int) Value {
 	return Value{
 		kind:  valueNumber,
 		value: value,
 	}
 }
 
-func toValue_int32(value int32) Value {
+func int32Value(value int32) Value {
 	return Value{
 		kind:  valueNumber,
 		value: value,
 	}
 }
 
-func toValue_int64(value int64) Value {
+func int64Value(value int64) Value {
 	return Value{
 		kind:  valueNumber,
 		value: value,
 	}
 }
 
-func toValue_uint16(value uint16) Value {
+func uint16Value(value uint16) Value {
 	return Value{
 		kind:  valueNumber,
 		value: value,
 	}
 }
 
-func toValue_uint32(value uint32) Value {
+func uint32Value(value uint32) Value {
 	return Value{
 		kind:  valueNumber,
 		value: value,
 	}
 }
 
-func toValue_float64(value float64) Value {
+func float64Value(value float64) Value {
 	return Value{
 		kind:  valueNumber,
 		value: value,
 	}
 }
 
-func toValue_string(value string) Value {
+func stringValue(value string) Value {
 	return Value{
 		kind:  valueString,
 		value: value,
 	}
 }
 
-func toValue_string16(value []uint16) Value {
+func string16Value(value []uint16) Value {
 	return Value{
 		kind:  valueString,
 		value: value,
 	}
 }
 
-func toValue_bool(value bool) Value {
+func boolValue(value bool) Value {
 	return Value{
 		kind:  valueBoolean,
 		value: value,
 	}
 }
 
-func toValue_object(value *_object) Value {
+func objectValue(value *object) Value {
 	return Value{
 		kind:  valueObject,
 		value: value,

--- a/inline.go
+++ b/inline.go
@@ -5,6172 +5,2654 @@ import (
 )
 
 func (rt *runtime) newContext() {
-	{
-		rt.global.ObjectPrototype = &object{
-			runtime:     rt,
-			class:       classObjectName,
-			objectClass: classObject,
-			prototype:   nil,
-			extensible:  true,
-			value:       prototypeValueObject,
-		}
-
-		rt.global.FunctionPrototype = &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.ObjectPrototype,
-			extensible:  true,
-			value:       prototypeValueFunction,
-		}
-
-		valueOf := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
+	rt.global.ObjectPrototype = &object{
+		runtime:     rt,
+		class:       classObjectName,
+		objectClass: classObject,
+		prototype:   nil,
+		extensible:  true,
+		value:       prototypeValueObject,
+	}
+	rt.global.FunctionPrototype = &object{
+		runtime:     rt,
+		class:       classFunctionName,
+		objectClass: classObject,
+		prototype:   rt.global.ObjectPrototype,
+		extensible:  true,
+		value:       prototypeValueFunction,
+	}
+	rt.global.ObjectPrototype.property = map[string]property{
+		"valueOf": {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 0,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: "valueOf",
+						call: builtinObjectValueOf,
 					},
 				},
 			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "valueOf",
-				call: builtinObjectValueOf,
-			},
-		}
-		toString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
+		},
+		methodToString: {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 0,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: methodToString,
+						call: builtinObjectToString,
 					},
 				},
 			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toString",
-				call: builtinObjectToString,
-			},
-		}
-		toLocaleString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
+		},
+		"toLocaleString": {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 0,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: "toLocaleString",
+						call: builtinObjectToLocaleString,
 					},
 				},
 			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toLocaleString",
-				call: builtinObjectToLocaleString,
-			},
-		}
-		hasOwnProperty := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
+		},
+		"hasOwnProperty": {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 1,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: "hasOwnProperty",
+						call: builtinObjectHasOwnProperty,
 					},
 				},
 			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "hasOwnProperty",
-				call: builtinObjectHasOwnProperty,
-			},
-		}
-		isPrototypeOf := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
+		},
+		"isPrototypeOf": {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 1,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: "isPrototypeOf",
+						call: builtinObjectIsPrototypeOf,
 					},
 				},
 			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "isPrototypeOf",
-				call: builtinObjectIsPrototypeOf,
-			},
-		}
-		propertyIsEnumerable := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
+		},
+		"propertyIsEnumerable": {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 1,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: "propertyIsEnumerable",
+						call: builtinObjectPropertyIsEnumerable,
 					},
 				},
 			},
-			propertyOrder: []string{
-				propertyLength,
+		},
+		propertyConstructor: {
+			mode:  0o101,
+			value: Value{},
+		},
+	}
+	rt.global.ObjectPrototype.propertyOrder = []string{
+		"valueOf",
+		methodToString,
+		"toLocaleString",
+		"hasOwnProperty",
+		"isPrototypeOf",
+		"propertyIsEnumerable",
+		propertyConstructor,
+	}
+	rt.global.FunctionPrototype.property = map[string]property{
+		methodToString: {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 0,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: methodToString,
+						call: builtinFunctionToString,
+					},
+				},
 			},
-			value: nativeFunctionObject{
-				name: "propertyIsEnumerable",
-				call: builtinObjectPropertyIsEnumerable,
+		},
+		"apply": {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 2,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: "apply",
+						call: builtinFunctionApply,
+					},
+				},
 			},
-		}
-		rt.global.ObjectPrototype.property = map[string]property{
-			"valueOf": {
-				mode: 0o101,
+		},
+		"call": {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 1,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: "call",
+						call: builtinFunctionCall,
+					},
+				},
+			},
+		},
+		"bind": {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 1,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: "bind",
+						call: builtinFunctionBind,
+					},
+				},
+			},
+		},
+		propertyConstructor: {
+			mode:  0o101,
+			value: Value{},
+		},
+		propertyLength: {
+			mode: 0,
+			value: Value{
+				kind:  valueNumber,
+				value: 0,
+			},
+		},
+	}
+	rt.global.FunctionPrototype.propertyOrder = []string{
+		methodToString,
+		"apply",
+		"call",
+		"bind",
+		propertyConstructor,
+		propertyLength,
+	}
+	rt.global.Object = &object{
+		runtime:     rt,
+		class:       classFunctionName,
+		objectClass: classObject,
+		prototype:   rt.global.FunctionPrototype,
+		extensible:  true,
+		value: nativeFunctionObject{
+			name:      classObjectName,
+			call:      builtinObject,
+			construct: builtinNewObject,
+		},
+		property: map[string]property{
+			propertyLength: {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: 1,
+				},
+			},
+			propertyPrototype: {
+				mode: 0,
 				value: Value{
 					kind:  valueObject,
-					value: valueOf,
+					value: rt.global.ObjectPrototype,
 				},
 			},
-			"toString": {
+			"getPrototypeOf": {
 				mode: 0o101,
 				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getPrototypeOf",
+							call: builtinObjectGetPrototypeOf,
+						},
+					},
+				},
+			},
+			"getOwnPropertyDescriptor": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getOwnPropertyDescriptor",
+							call: builtinObjectGetOwnPropertyDescriptor,
+						},
+					},
+				},
+			},
+			"defineProperty": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 3,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "defineProperty",
+							call: builtinObjectDefineProperty,
+						},
+					},
+				},
+			},
+			"defineProperties": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "defineProperties",
+							call: builtinObjectDefineProperties,
+						},
+					},
+				},
+			},
+			"create": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "create",
+							call: builtinObjectCreate,
+						},
+					},
+				},
+			},
+			"isExtensible": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "isExtensible",
+							call: builtinObjectIsExtensible,
+						},
+					},
+				},
+			},
+			"preventExtensions": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "preventExtensions",
+							call: builtinObjectPreventExtensions,
+						},
+					},
+				},
+			},
+			"isSealed": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "isSealed",
+							call: builtinObjectIsSealed,
+						},
+					},
+				},
+			},
+			"seal": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "seal",
+							call: builtinObjectSeal,
+						},
+					},
+				},
+			},
+			"isFrozen": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "isFrozen",
+							call: builtinObjectIsFrozen,
+						},
+					},
+				},
+			},
+			"freeze": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "freeze",
+							call: builtinObjectFreeze,
+						},
+					},
+				},
+			},
+			"keys": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "keys",
+							call: builtinObjectKeys,
+						},
+					},
+				},
+			},
+			"getOwnPropertyNames": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getOwnPropertyNames",
+							call: builtinObjectGetOwnPropertyNames,
+						},
+					},
+				},
+			},
+		},
+		propertyOrder: []string{
+			propertyLength,
+			propertyPrototype,
+			"getPrototypeOf",
+			"getOwnPropertyDescriptor",
+			"defineProperty",
+			"defineProperties",
+			"create",
+			"isExtensible",
+			"preventExtensions",
+			"isSealed",
+			"seal",
+			"isFrozen",
+			"freeze",
+			"keys",
+			"getOwnPropertyNames",
+		},
+	}
+	rt.global.ObjectPrototype.property[propertyConstructor] = property{
+		mode: 0o101,
+		value: Value{
+			kind:  valueObject,
+			value: rt.global.Object,
+		},
+	}
+	rt.global.Function = &object{
+		runtime:     rt,
+		class:       classFunctionName,
+		objectClass: classObject,
+		prototype:   rt.global.FunctionPrototype,
+		extensible:  true,
+		value: nativeFunctionObject{
+			name:      classFunctionName,
+			call:      builtinFunction,
+			construct: builtinNewFunction,
+		},
+		property: map[string]property{
+			propertyLength: {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: 1,
+				},
+			},
+			propertyPrototype: {
+				mode: 0,
+				value: Value{
 					kind:  valueObject,
-					value: toString,
+					value: rt.global.FunctionPrototype,
+				},
+			},
+		},
+		propertyOrder: []string{
+			propertyLength,
+			propertyPrototype,
+		},
+	}
+	rt.global.FunctionPrototype.property[propertyConstructor] = property{
+		mode: 0o101,
+		value: Value{
+			kind:  valueObject,
+			value: rt.global.Function,
+		},
+	}
+	rt.global.ArrayPrototype = &object{
+		runtime:     rt,
+		class:       classArrayName,
+		objectClass: classArray,
+		prototype:   rt.global.ObjectPrototype,
+		extensible:  true,
+		value:       nil,
+		property: map[string]property{
+			propertyLength: {
+				mode: 0o100,
+				value: Value{
+					kind:  valueNumber,
+					value: uint32(0),
+				},
+			},
+			methodToString: {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: methodToString,
+							call: builtinArrayToString,
+						},
+					},
 				},
 			},
 			"toLocaleString": {
 				mode: 0o101,
 				value: Value{
-					kind:  valueObject,
-					value: toLocaleString,
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "toLocaleString",
+							call: builtinArrayToLocaleString,
+						},
+					},
 				},
 			},
-			"hasOwnProperty": {
+			"concat": {
 				mode: 0o101,
 				value: Value{
-					kind:  valueObject,
-					value: hasOwnProperty,
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "concat",
+							call: builtinArrayConcat,
+						},
+					},
 				},
 			},
-			"isPrototypeOf": {
+			"join": {
 				mode: 0o101,
 				value: Value{
-					kind:  valueObject,
-					value: isPrototypeOf,
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "join",
+							call: builtinArrayJoin,
+						},
+					},
 				},
 			},
-			"propertyIsEnumerable": {
+			"splice": {
 				mode: 0o101,
 				value: Value{
-					kind:  valueObject,
-					value: propertyIsEnumerable,
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "splice",
+							call: builtinArraySplice,
+						},
+					},
 				},
 			},
-			"constructor": {
-				mode:  0o101,
-				value: Value{},
+			"shift": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "shift",
+							call: builtinArrayShift,
+						},
+					},
+				},
 			},
-		}
-		rt.global.ObjectPrototype.propertyOrder = []string{
-			"valueOf",
-			"toString",
+			"pop": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "pop",
+							call: builtinArrayPop,
+						},
+					},
+				},
+			},
+			"push": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "push",
+							call: builtinArrayPush,
+						},
+					},
+				},
+			},
+			"slice": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "slice",
+							call: builtinArraySlice,
+						},
+					},
+				},
+			},
+			"unshift": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "unshift",
+							call: builtinArrayUnshift,
+						},
+					},
+				},
+			},
+			"reverse": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "reverse",
+							call: builtinArrayReverse,
+						},
+					},
+				},
+			},
+			"sort": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "sort",
+							call: builtinArraySort,
+						},
+					},
+				},
+			},
+			"indexOf": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "indexOf",
+							call: builtinArrayIndexOf,
+						},
+					},
+				},
+			},
+			"lastIndexOf": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "lastIndexOf",
+							call: builtinArrayLastIndexOf,
+						},
+					},
+				},
+			},
+			"every": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "every",
+							call: builtinArrayEvery,
+						},
+					},
+				},
+			},
+			"some": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "some",
+							call: builtinArraySome,
+						},
+					},
+				},
+			},
+			"forEach": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "forEach",
+							call: builtinArrayForEach,
+						},
+					},
+				},
+			},
+			"map": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "map",
+							call: builtinArrayMap,
+						},
+					},
+				},
+			},
+			"filter": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "filter",
+							call: builtinArrayFilter,
+						},
+					},
+				},
+			},
+			"reduce": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "reduce",
+							call: builtinArrayReduce,
+						},
+					},
+				},
+			},
+			"reduceRight": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "reduceRight",
+							call: builtinArrayReduceRight,
+						},
+					},
+				},
+			},
+		},
+		propertyOrder: []string{
+			propertyLength,
+			methodToString,
 			"toLocaleString",
-			"hasOwnProperty",
-			"isPrototypeOf",
-			"propertyIsEnumerable",
-			"constructor",
-		}
+			"concat",
+			"join",
+			"splice",
+			"shift",
+			"pop",
+			"push",
+			"slice",
+			"unshift",
+			"reverse",
+			"sort",
+			"indexOf",
+			"lastIndexOf",
+			"every",
+			"some",
+			"forEach",
+			"map",
+			"filter",
+			"reduce",
+			"reduceRight",
+		},
 	}
-	{
-		toString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toString",
-				call: builtinFunctionToString,
-			},
-		}
-		apply := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "apply",
-				call: builtinFunctionApply,
-			},
-		}
-		call := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "call",
-				call: builtinFunctionCall,
-			},
-		}
-		bind := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "bind",
-				call: builtinFunctionBind,
-			},
-		}
-		rt.global.FunctionPrototype.property = map[string]property{
-			"toString": {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: toString,
-				},
-			},
-			"apply": {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: apply,
-				},
-			},
-			"call": {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: call,
-				},
-			},
-			"bind": {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: bind,
-				},
-			},
-			"constructor": {
-				mode:  0o101,
-				value: Value{},
-			},
+	rt.global.Array = &object{
+		runtime:     rt,
+		class:       classFunctionName,
+		objectClass: classObject,
+		prototype:   rt.global.FunctionPrototype,
+		extensible:  true,
+		value: nativeFunctionObject{
+			name:      classArrayName,
+			call:      builtinArray,
+			construct: builtinNewArray,
+		},
+		property: map[string]property{
 			propertyLength: {
 				mode: 0,
 				value: Value{
 					kind:  valueNumber,
-					value: 0,
+					value: 1,
 				},
 			},
-		}
-		rt.global.FunctionPrototype.propertyOrder = []string{
-			"toString",
-			"apply",
-			"call",
-			"bind",
-			"constructor",
+			propertyPrototype: {
+				mode: 0,
+				value: Value{
+					kind:  valueObject,
+					value: rt.global.ArrayPrototype,
+				},
+			},
+			"isArray": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "isArray",
+							call: builtinArrayIsArray,
+						},
+					},
+				},
+			},
+		},
+		propertyOrder: []string{
 			propertyLength,
-		}
+			propertyPrototype,
+			"isArray",
+		},
 	}
-	{
-		getPrototypeOf := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getPrototypeOf",
-				call: builtinObjectGetPrototypeOf,
-			},
-		}
-		getOwnPropertyDescriptor := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getOwnPropertyDescriptor",
-				call: builtinObjectGetOwnPropertyDescriptor,
-			},
-		}
-		defineProperty := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 3,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "defineProperty",
-				call: builtinObjectDefineProperty,
-			},
-		}
-		defineProperties := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "defineProperties",
-				call: builtinObjectDefineProperties,
-			},
-		}
-		create := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "create",
-				call: builtinObjectCreate,
-			},
-		}
-		isExtensible := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "isExtensible",
-				call: builtinObjectIsExtensible,
-			},
-		}
-		preventExtensions := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "preventExtensions",
-				call: builtinObjectPreventExtensions,
-			},
-		}
-		isSealed := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "isSealed",
-				call: builtinObjectIsSealed,
-			},
-		}
-		seal := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "seal",
-				call: builtinObjectSeal,
-			},
-		}
-		isFrozen := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "isFrozen",
-				call: builtinObjectIsFrozen,
-			},
-		}
-		freeze := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "freeze",
-				call: builtinObjectFreeze,
-			},
-		}
-		keys := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "keys",
-				call: builtinObjectKeys,
-			},
-		}
-		getOwnPropertyNames := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getOwnPropertyNames",
-				call: builtinObjectGetOwnPropertyNames,
-			},
-		}
-		rt.global.Object = &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			value: nativeFunctionObject{
-				name:      classObjectName,
-				call:      builtinObject,
-				construct: builtinNewObject,
-			},
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-				"prototype": {
-					mode: 0,
-					value: Value{
-						kind:  valueObject,
-						value: rt.global.ObjectPrototype,
-					},
-				},
-				"getPrototypeOf": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getPrototypeOf,
-					},
-				},
-				"getOwnPropertyDescriptor": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getOwnPropertyDescriptor,
-					},
-				},
-				"defineProperty": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: defineProperty,
-					},
-				},
-				"defineProperties": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: defineProperties,
-					},
-				},
-				"create": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: create,
-					},
-				},
-				"isExtensible": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: isExtensible,
-					},
-				},
-				"preventExtensions": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: preventExtensions,
-					},
-				},
-				"isSealed": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: isSealed,
-					},
-				},
-				"seal": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: seal,
-					},
-				},
-				"isFrozen": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: isFrozen,
-					},
-				},
-				"freeze": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: freeze,
-					},
-				},
-				"keys": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: keys,
-					},
-				},
-				"getOwnPropertyNames": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getOwnPropertyNames,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-				"prototype",
-				"getPrototypeOf",
-				"getOwnPropertyDescriptor",
-				"defineProperty",
-				"defineProperties",
-				"create",
-				"isExtensible",
-				"preventExtensions",
-				"isSealed",
-				"seal",
-				"isFrozen",
-				"freeze",
-				"keys",
-				"getOwnPropertyNames",
-			},
-		}
-		rt.global.ObjectPrototype.property["constructor"] = property{
-			mode: 0o101,
-			value: Value{
-				kind:  valueObject,
-				value: rt.global.Object,
-			},
-		}
+	rt.global.ArrayPrototype.property[propertyConstructor] = property{
+		mode: 0o101,
+		value: Value{
+			kind:  valueObject,
+			value: rt.global.Array,
+		},
 	}
-	{
-		Function := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			value: nativeFunctionObject{
-				name:      classFunctionName,
-				call:      builtinFunction,
-				construct: builtinNewFunction,
-			},
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-				"prototype": {
-					mode: 0,
-					value: Value{
-						kind:  valueObject,
-						value: rt.global.FunctionPrototype,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-				"prototype",
-			},
-		}
-		rt.global.Function = Function
-		rt.global.FunctionPrototype.property["constructor"] = property{
-			mode: 0o101,
-			value: Value{
-				kind:  valueObject,
-				value: rt.global.Function,
-			},
-		}
-	}
-	{
-		toString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toString",
-				call: builtinArrayToString,
-			},
-		}
-		toLocaleString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toLocaleString",
-				call: builtinArrayToLocaleString,
-			},
-		}
-		concat := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "concat",
-				call: builtinArrayConcat,
-			},
-		}
-		join := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "join",
-				call: builtinArrayJoin,
-			},
-		}
-		splice := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "splice",
-				call: builtinArraySplice,
-			},
-		}
-		shift := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "shift",
-				call: builtinArrayShift,
-			},
-		}
-		pop := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "pop",
-				call: builtinArrayPop,
-			},
-		}
-		push := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "push",
-				call: builtinArrayPush,
-			},
-		}
-		slice := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "slice",
-				call: builtinArraySlice,
-			},
-		}
-		unshift := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "unshift",
-				call: builtinArrayUnshift,
-			},
-		}
-		reverse := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "reverse",
-				call: builtinArrayReverse,
-			},
-		}
-		sort := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "sort",
-				call: builtinArraySort,
-			},
-		}
-		indexOf := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "indexOf",
-				call: builtinArrayIndexOf,
-			},
-		}
-		lastIndexOf := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "lastIndexOf",
-				call: builtinArrayLastIndexOf,
-			},
-		}
-		every := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "every",
-				call: builtinArrayEvery,
-			},
-		}
-		some := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "some",
-				call: builtinArraySome,
-			},
-		}
-		forEach := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "forEach",
-				call: builtinArrayForEach,
-			},
-		}
-		mapObj := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "map",
-				call: builtinArrayMap,
-			},
-		}
-		filter := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "filter",
-				call: builtinArrayFilter,
-			},
-		}
-		reduce := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "reduce",
-				call: builtinArrayReduce,
-			},
-		}
-		reduceRight := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "reduceRight",
-				call: builtinArrayReduceRight,
-			},
-		}
-		isArray := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "isArray",
-				call: builtinArrayIsArray,
-			},
-		}
-		rt.global.ArrayPrototype = &object{
-			runtime:     rt,
-			class:       classArrayName,
-			objectClass: classArray,
-			prototype:   rt.global.ObjectPrototype,
-			extensible:  true,
-			value:       nil,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0o100,
-					value: Value{
-						kind:  valueNumber,
-						value: uint32(0),
-					},
-				},
-				"toString": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toString,
-					},
-				},
-				"toLocaleString": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toLocaleString,
-					},
-				},
-				"concat": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: concat,
-					},
-				},
-				"join": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: join,
-					},
-				},
-				"splice": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: splice,
-					},
-				},
-				"shift": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: shift,
-					},
-				},
-				"pop": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: pop,
-					},
-				},
-				"push": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: push,
-					},
-				},
-				"slice": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: slice,
-					},
-				},
-				"unshift": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: unshift,
-					},
-				},
-				"reverse": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: reverse,
-					},
-				},
-				"sort": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: sort,
-					},
-				},
-				"indexOf": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: indexOf,
-					},
-				},
-				"lastIndexOf": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: lastIndexOf,
-					},
-				},
-				"every": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: every,
-					},
-				},
-				"some": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: some,
-					},
-				},
-				"forEach": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: forEach,
-					},
-				},
-				"map": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: mapObj,
-					},
-				},
-				"filter": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: filter,
-					},
-				},
-				"reduce": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: reduce,
-					},
-				},
-				"reduceRight": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: reduceRight,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-				"toString",
-				"toLocaleString",
-				"concat",
-				"join",
-				"splice",
-				"shift",
-				"pop",
-				"push",
-				"slice",
-				"unshift",
-				"reverse",
-				"sort",
-				"indexOf",
-				"lastIndexOf",
-				"every",
-				"some",
-				"forEach",
-				"map",
-				"filter",
-				"reduce",
-				"reduceRight",
-			},
-		}
-		rt.global.Array = &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			value: nativeFunctionObject{
-				name:      classArrayName,
-				call:      builtinArray,
-				construct: builtinNewArray,
-			},
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-				"prototype": {
-					mode: 0,
-					value: Value{
-						kind:  valueObject,
-						value: rt.global.ArrayPrototype,
-					},
-				},
-				"isArray": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: isArray,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-				"prototype",
-				"isArray",
-			},
-		}
-		rt.global.ArrayPrototype.property["constructor"] = property{
-			mode: 0o101,
-			value: Value{
-				kind:  valueObject,
-				value: rt.global.Array,
-			},
-		}
-	}
-	{
-		toString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toString",
-				call: builtinStringToString,
-			},
-		}
-		valueOf := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "valueOf",
-				call: builtinStringValueOf,
-			},
-		}
-		charAt := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "charAt",
-				call: builtinStringCharAt,
-			},
-		}
-		charCodeAt := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "charCodeAt",
-				call: builtinStringCharCodeAt,
-			},
-		}
-		concat := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "concat",
-				call: builtinStringConcat,
-			},
-		}
-		indexOf := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "indexOf",
-				call: builtinStringIndexOf,
-			},
-		}
-		lastIndexOf := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "lastIndexOf",
-				call: builtinStringLastIndexOf,
-			},
-		}
-		match := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "match",
-				call: builtinStringMatch,
-			},
-		}
-		replace := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "replace",
-				call: builtinStringReplace,
-			},
-		}
-		search := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "search",
-				call: builtinStringSearch,
-			},
-		}
-		split := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "split",
-				call: builtinStringSplit,
-			},
-		}
-		slice := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "slice",
-				call: builtinStringSlice,
-			},
-		}
-		substring := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "substring",
-				call: builtinStringSubstring,
-			},
-		}
-		toLowerCase := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toLowerCase",
-				call: builtinStringToLowerCase,
-			},
-		}
-		toUpperCase := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toUpperCase",
-				call: builtinStringToUpperCase,
-			},
-		}
-		substr := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "substr",
-				call: builtinStringSubstr,
-			},
-		}
-		trim := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "trim",
-				call: builtinStringTrim,
-			},
-		}
-		trimLeft := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "trimLeft",
-				call: builtinStringTrimLeft,
-			},
-		}
-		trimRight := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "trimRight",
-				call: builtinStringTrimRight,
-			},
-		}
-		localeCompare := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "localeCompare",
-				call: builtinStringLocaleCompare,
-			},
-		}
-		toLocaleLowerCase := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toLocaleLowerCase",
-				call: builtinStringToLocaleLowerCase,
-			},
-		}
-		toLocaleUpperCase := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toLocaleUpperCase",
-				call: builtinStringToLocaleUpperCase,
-			},
-		}
-		fromCharCode := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "fromCharCode",
-				call: builtinStringFromCharCode,
-			},
-		}
-		rt.global.StringPrototype = &object{
-			runtime:     rt,
-			class:       classStringName,
-			objectClass: classString,
-			prototype:   rt.global.ObjectPrototype,
-			extensible:  true,
-			value:       prototypeValueString,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: int(0),
-					},
-				},
-				"toString": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toString,
-					},
-				},
-				"valueOf": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: valueOf,
-					},
-				},
-				"charAt": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: charAt,
-					},
-				},
-				"charCodeAt": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: charCodeAt,
-					},
-				},
-				"concat": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: concat,
-					},
-				},
-				"indexOf": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: indexOf,
-					},
-				},
-				"lastIndexOf": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: lastIndexOf,
-					},
-				},
-				"match": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: match,
-					},
-				},
-				"replace": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: replace,
-					},
-				},
-				"search": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: search,
-					},
-				},
-				"split": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: split,
-					},
-				},
-				"slice": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: slice,
-					},
-				},
-				"substring": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: substring,
-					},
-				},
-				"toLowerCase": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toLowerCase,
-					},
-				},
-				"toUpperCase": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toUpperCase,
-					},
-				},
-				"substr": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: substr,
-					},
-				},
-				"trim": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: trim,
-					},
-				},
-				"trimLeft": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: trimLeft,
-					},
-				},
-				"trimRight": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: trimRight,
-					},
-				},
-				"localeCompare": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: localeCompare,
-					},
-				},
-				"toLocaleLowerCase": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toLocaleLowerCase,
-					},
-				},
-				"toLocaleUpperCase": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toLocaleUpperCase,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-				"toString",
-				"valueOf",
-				"charAt",
-				"charCodeAt",
-				"concat",
-				"indexOf",
-				"lastIndexOf",
-				"match",
-				"replace",
-				"search",
-				"split",
-				"slice",
-				"substring",
-				"toLowerCase",
-				"toUpperCase",
-				"substr",
-				"trim",
-				"trimLeft",
-				"trimRight",
-				"localeCompare",
-				"toLocaleLowerCase",
-				"toLocaleUpperCase",
-			},
-		}
-		rt.global.String = &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			value: nativeFunctionObject{
-				name:      classStringName,
-				call:      builtinString,
-				construct: builtinNewString,
-			},
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-				"prototype": {
-					mode: 0,
-					value: Value{
-						kind:  valueObject,
-						value: rt.global.StringPrototype,
-					},
-				},
-				"fromCharCode": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: fromCharCode,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-				"prototype",
-				"fromCharCode",
-			},
-		}
-		rt.global.StringPrototype.property["constructor"] = property{
-			mode: 0o101,
-			value: Value{
-				kind:  valueObject,
-				value: rt.global.String,
-			},
-		}
-	}
-	{
-		toString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toString",
-				call: builtinBooleanToString,
-			},
-		}
-		valueOf := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "valueOf",
-				call: builtinBooleanValueOf,
-			},
-		}
-		rt.global.BooleanPrototype = &object{
-			runtime:     rt,
-			class:       classBooleanName,
-			objectClass: classObject,
-			prototype:   rt.global.ObjectPrototype,
-			extensible:  true,
-			value:       prototypeValueBoolean,
-			property: map[string]property{
-				"toString": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toString,
-					},
-				},
-				"valueOf": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: valueOf,
-					},
-				},
-			},
-			propertyOrder: []string{
-				"toString",
-				"valueOf",
-			},
-		}
-		rt.global.Boolean = &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			value: nativeFunctionObject{
-				name:      classBooleanName,
-				call:      builtinBoolean,
-				construct: builtinNewBoolean,
-			},
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-				"prototype": {
-					mode: 0,
-					value: Value{
-						kind:  valueObject,
-						value: rt.global.BooleanPrototype,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-				"prototype",
-			},
-		}
-		rt.global.BooleanPrototype.property["constructor"] = property{
-			mode: 0o101,
-			value: Value{
-				kind:  valueObject,
-				value: rt.global.Boolean,
-			},
-		}
-	}
-	{
-		toString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toString",
-				call: builtinNumberToString,
-			},
-		}
-		valueOf := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "valueOf",
-				call: builtinNumberValueOf,
-			},
-		}
-		toFixed := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toFixed",
-				call: builtinNumberToFixed,
-			},
-		}
-		toExponential := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toExponential",
-				call: builtinNumberToExponential,
-			},
-		}
-		toPrecision := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toPrecision",
-				call: builtinNumberToPrecision,
-			},
-		}
-		toLocaleString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toLocaleString",
-				call: builtinNumberToLocaleString,
-			},
-		}
-		isNaN := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "isNaN",
-				call: builtinNumberIsNaN,
-			},
-		}
-		rt.global.NumberPrototype = &object{
-			runtime:     rt,
-			class:       classNumberName,
-			objectClass: classObject,
-			prototype:   rt.global.ObjectPrototype,
-			extensible:  true,
-			value:       prototypeValueNumber,
-			property: map[string]property{
-				"toString": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toString,
-					},
-				},
-				"valueOf": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: valueOf,
-					},
-				},
-				"toFixed": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toFixed,
-					},
-				},
-				"toExponential": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toExponential,
-					},
-				},
-				"toPrecision": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toPrecision,
-					},
-				},
-				"toLocaleString": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toLocaleString,
-					},
-				},
-			},
-			propertyOrder: []string{
-				"toString",
-				"valueOf",
-				"toFixed",
-				"toExponential",
-				"toPrecision",
-				"toLocaleString",
-			},
-		}
-		rt.global.Number = &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			value: nativeFunctionObject{
-				name:      classNumberName,
-				call:      builtinNumber,
-				construct: builtinNewNumber,
-			},
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-				"prototype": {
-					mode: 0,
-					value: Value{
-						kind:  valueObject,
-						value: rt.global.NumberPrototype,
-					},
-				},
-				"isNaN": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: isNaN,
-					},
-				},
-				"MAX_VALUE": {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: math.MaxFloat64,
-					},
-				},
-				"MIN_VALUE": {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: math.SmallestNonzeroFloat64,
-					},
-				},
-				"NaN": {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: math.NaN(),
-					},
-				},
-				"NEGATIVE_INFINITY": {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: math.Inf(-1),
-					},
-				},
-				"POSITIVE_INFINITY": {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: math.Inf(+1),
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-				"prototype",
-				"isNaN",
-				"MAX_VALUE",
-				"MIN_VALUE",
-				"NaN",
-				"NEGATIVE_INFINITY",
-				"POSITIVE_INFINITY",
-			},
-		}
-		rt.global.NumberPrototype.property["constructor"] = property{
-			mode: 0o101,
-			value: Value{
-				kind:  valueObject,
-				value: rt.global.Number,
-			},
-		}
-	}
-	{
-		abs := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "abs",
-				call: builtinMathAbs,
-			},
-		}
-		acos := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "acos",
-				call: builtinMathAcos,
-			},
-		}
-		asin := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "asin",
-				call: builtinMathAsin,
-			},
-		}
-		atan := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "atan",
-				call: builtinMathAtan,
-			},
-		}
-		atan2 := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "atan2",
-				call: builtinMathAtan2,
-			},
-		}
-		ceil := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "ceil",
-				call: builtinMathCeil,
-			},
-		}
-		cos := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "cos",
-				call: builtinMathCos,
-			},
-		}
-		exp := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "exp",
-				call: builtinMathExp,
-			},
-		}
-		floor := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "floor",
-				call: builtinMathFloor,
-			},
-		}
-		log := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "log",
-				call: builtinMathLog,
-			},
-		}
-		max := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "max",
-				call: builtinMathMax,
-			},
-		}
-		min := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "min",
-				call: builtinMathMin,
-			},
-		}
-		pow := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "pow",
-				call: builtinMathPow,
-			},
-		}
-		random := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "random",
-				call: builtinMathRandom,
-			},
-		}
-		round := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "round",
-				call: builtinMathRound,
-			},
-		}
-		sin := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "sin",
-				call: builtinMathSin,
-			},
-		}
-		sqrt := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "sqrt",
-				call: builtinMathSqrt,
-			},
-		}
-		tan := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "tan",
-				call: builtinMathTan,
-			},
-		}
-		rt.global.Math = &object{
-			runtime:     rt,
-			class:       "Math",
-			objectClass: classObject,
-			prototype:   rt.global.ObjectPrototype,
-			extensible:  true,
-			property: map[string]property{
-				"abs": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: abs,
-					},
-				},
-				"acos": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: acos,
-					},
-				},
-				"asin": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: asin,
-					},
-				},
-				"atan": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: atan,
-					},
-				},
-				"atan2": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: atan2,
-					},
-				},
-				"ceil": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: ceil,
-					},
-				},
-				"cos": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: cos,
-					},
-				},
-				"exp": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: exp,
-					},
-				},
-				"floor": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: floor,
-					},
-				},
-				"log": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: log,
-					},
-				},
-				"max": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: max,
-					},
-				},
-				"min": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: min,
-					},
-				},
-				"pow": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: pow,
-					},
-				},
-				"random": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: random,
-					},
-				},
-				"round": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: round,
-					},
-				},
-				"sin": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: sin,
-					},
-				},
-				"sqrt": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: sqrt,
-					},
-				},
-				"tan": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: tan,
-					},
-				},
-				"E": {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: math.E,
-					},
-				},
-				"LN10": {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: math.Ln10,
-					},
-				},
-				"LN2": {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: math.Ln2,
-					},
-				},
-				"LOG2E": {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: math.Log2E,
-					},
-				},
-				"LOG10E": {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: math.Log10E,
-					},
-				},
-				"PI": {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: math.Pi,
-					},
-				},
-				"SQRT1_2": {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: sqrt1_2,
-					},
-				},
-				"SQRT2": {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: math.Sqrt2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				"abs",
-				"acos",
-				"asin",
-				"atan",
-				"atan2",
-				"ceil",
-				"cos",
-				"exp",
-				"floor",
-				"log",
-				"max",
-				"min",
-				"pow",
-				"random",
-				"round",
-				"sin",
-				"sqrt",
-				"tan",
-				"E",
-				"LN10",
-				"LN2",
-				"LOG2E",
-				"LOG10E",
-				"PI",
-				"SQRT1_2",
-				"SQRT2",
-			},
-		}
-	}
-	{
-		toString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toString",
-				call: builtinDateToString,
-			},
-		}
-		toDateString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toDateString",
-				call: builtinDateToDateString,
-			},
-		}
-		toTimeString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toTimeString",
-				call: builtinDateToTimeString,
-			},
-		}
-		toUTCString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toUTCString",
-				call: builtinDateToUTCString,
-			},
-		}
-		toISOString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toISOString",
-				call: builtinDateToISOString,
-			},
-		}
-		toJSON := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toJSON",
-				call: builtinDateToJSON,
-			},
-		}
-		toGMTString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toGMTString",
-				call: builtinDateToGMTString,
-			},
-		}
-		toLocaleString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toLocaleString",
-				call: builtinDateToLocaleString,
-			},
-		}
-		toLocaleDateString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toLocaleDateString",
-				call: builtinDateToLocaleDateString,
-			},
-		}
-		toLocaleTimeString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toLocaleTimeString",
-				call: builtinDateToLocaleTimeString,
-			},
-		}
-		valueOf := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "valueOf",
-				call: builtinDateValueOf,
-			},
-		}
-		getTime := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getTime",
-				call: builtinDateGetTime,
-			},
-		}
-		getYear := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getYear",
-				call: builtinDateGetYear,
-			},
-		}
-		getFullYear := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getFullYear",
-				call: builtinDateGetFullYear,
-			},
-		}
-		getUTCFullYear := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getUTCFullYear",
-				call: builtinDateGetUTCFullYear,
-			},
-		}
-		getMonth := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getMonth",
-				call: builtinDateGetMonth,
-			},
-		}
-		getUTCMonth := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getUTCMonth",
-				call: builtinDateGetUTCMonth,
-			},
-		}
-		getDate := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getDate",
-				call: builtinDateGetDate,
-			},
-		}
-		getUTCDate := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getUTCDate",
-				call: builtinDateGetUTCDate,
-			},
-		}
-		getDay := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getDay",
-				call: builtinDateGetDay,
-			},
-		}
-		getUTCDay := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getUTCDay",
-				call: builtinDateGetUTCDay,
-			},
-		}
-		getHours := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getHours",
-				call: builtinDateGetHours,
-			},
-		}
-		getUTCHours := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getUTCHours",
-				call: builtinDateGetUTCHours,
-			},
-		}
-		getMinutes := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getMinutes",
-				call: builtinDateGetMinutes,
-			},
-		}
-		getUTCMinutes := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getUTCMinutes",
-				call: builtinDateGetUTCMinutes,
-			},
-		}
-		getSeconds := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getSeconds",
-				call: builtinDateGetSeconds,
-			},
-		}
-		getUTCSeconds := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getUTCSeconds",
-				call: builtinDateGetUTCSeconds,
-			},
-		}
-		getMilliseconds := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getMilliseconds",
-				call: builtinDateGetMilliseconds,
-			},
-		}
-		getUTCMilliseconds := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getUTCMilliseconds",
-				call: builtinDateGetUTCMilliseconds,
-			},
-		}
-		getTimezoneOffset := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "getTimezoneOffset",
-				call: builtinDateGetTimezoneOffset,
-			},
-		}
-		setTime := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "setTime",
-				call: builtinDateSetTime,
-			},
-		}
-		setMilliseconds := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "setMilliseconds",
-				call: builtinDateSetMilliseconds,
-			},
-		}
-		setUTCMilliseconds := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "setUTCMilliseconds",
-				call: builtinDateSetUTCMilliseconds,
-			},
-		}
-		setSeconds := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "setSeconds",
-				call: builtinDateSetSeconds,
-			},
-		}
-		setUTCSeconds := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "setUTCSeconds",
-				call: builtinDateSetUTCSeconds,
-			},
-		}
-		setMinutes := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 3,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "setMinutes",
-				call: builtinDateSetMinutes,
-			},
-		}
-		setUTCMinutes := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 3,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "setUTCMinutes",
-				call: builtinDateSetUTCMinutes,
-			},
-		}
-		setHours := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 4,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "setHours",
-				call: builtinDateSetHours,
-			},
-		}
-		setUTCHours := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 4,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "setUTCHours",
-				call: builtinDateSetUTCHours,
-			},
-		}
-		setDate := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "setDate",
-				call: builtinDateSetDate,
-			},
-		}
-		setUTCDate := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "setUTCDate",
-				call: builtinDateSetUTCDate,
-			},
-		}
-		setMonth := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "setMonth",
-				call: builtinDateSetMonth,
-			},
-		}
-		setUTCMonth := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "setUTCMonth",
-				call: builtinDateSetUTCMonth,
-			},
-		}
-		setYear := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "setYear",
-				call: builtinDateSetYear,
-			},
-		}
-		setFullYear := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 3,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "setFullYear",
-				call: builtinDateSetFullYear,
-			},
-		}
-		setUTCFullYear := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 3,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "setUTCFullYear",
-				call: builtinDateSetUTCFullYear,
-			},
-		}
-		parse := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "parse",
-				call: builtinDateParse,
-			},
-		}
-		UTC := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 7,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "UTC",
-				call: builtinDateUTC,
-			},
-		}
-		now := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "now",
-				call: builtinDateNow,
-			},
-		}
-		rt.global.DatePrototype = &object{
-			runtime:     rt,
-			class:       classDateName,
-			objectClass: classObject,
-			prototype:   rt.global.ObjectPrototype,
-			extensible:  true,
-			value:       prototypeValueDate,
-			property: map[string]property{
-				"toString": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toString,
-					},
-				},
-				"toDateString": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toDateString,
-					},
-				},
-				"toTimeString": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toTimeString,
-					},
-				},
-				"toUTCString": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toUTCString,
-					},
-				},
-				"toISOString": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toISOString,
-					},
-				},
-				"toJSON": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toJSON,
-					},
-				},
-				"toGMTString": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toGMTString,
-					},
-				},
-				"toLocaleString": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toLocaleString,
-					},
-				},
-				"toLocaleDateString": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toLocaleDateString,
-					},
-				},
-				"toLocaleTimeString": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toLocaleTimeString,
-					},
-				},
-				"valueOf": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: valueOf,
-					},
-				},
-				"getTime": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getTime,
-					},
-				},
-				"getYear": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getYear,
-					},
-				},
-				"getFullYear": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getFullYear,
-					},
-				},
-				"getUTCFullYear": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getUTCFullYear,
-					},
-				},
-				"getMonth": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getMonth,
-					},
-				},
-				"getUTCMonth": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getUTCMonth,
-					},
-				},
-				"getDate": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getDate,
-					},
-				},
-				"getUTCDate": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getUTCDate,
-					},
-				},
-				"getDay": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getDay,
-					},
-				},
-				"getUTCDay": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getUTCDay,
-					},
-				},
-				"getHours": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getHours,
-					},
-				},
-				"getUTCHours": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getUTCHours,
-					},
-				},
-				"getMinutes": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getMinutes,
-					},
-				},
-				"getUTCMinutes": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getUTCMinutes,
-					},
-				},
-				"getSeconds": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getSeconds,
-					},
-				},
-				"getUTCSeconds": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getUTCSeconds,
-					},
-				},
-				"getMilliseconds": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getMilliseconds,
-					},
-				},
-				"getUTCMilliseconds": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getUTCMilliseconds,
-					},
-				},
-				"getTimezoneOffset": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: getTimezoneOffset,
-					},
-				},
-				"setTime": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: setTime,
-					},
-				},
-				"setMilliseconds": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: setMilliseconds,
-					},
-				},
-				"setUTCMilliseconds": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: setUTCMilliseconds,
-					},
-				},
-				"setSeconds": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: setSeconds,
-					},
-				},
-				"setUTCSeconds": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: setUTCSeconds,
-					},
-				},
-				"setMinutes": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: setMinutes,
-					},
-				},
-				"setUTCMinutes": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: setUTCMinutes,
-					},
-				},
-				"setHours": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: setHours,
-					},
-				},
-				"setUTCHours": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: setUTCHours,
-					},
-				},
-				"setDate": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: setDate,
-					},
-				},
-				"setUTCDate": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: setUTCDate,
-					},
-				},
-				"setMonth": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: setMonth,
-					},
-				},
-				"setUTCMonth": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: setUTCMonth,
-					},
-				},
-				"setYear": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: setYear,
-					},
-				},
-				"setFullYear": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: setFullYear,
-					},
-				},
-				"setUTCFullYear": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: setUTCFullYear,
-					},
-				},
-			},
-			propertyOrder: []string{
-				"toString",
-				"toDateString",
-				"toTimeString",
-				"toUTCString",
-				"toISOString",
-				"toJSON",
-				"toGMTString",
-				"toLocaleString",
-				"toLocaleDateString",
-				"toLocaleTimeString",
-				"valueOf",
-				"getTime",
-				"getYear",
-				"getFullYear",
-				"getUTCFullYear",
-				"getMonth",
-				"getUTCMonth",
-				"getDate",
-				"getUTCDate",
-				"getDay",
-				"getUTCDay",
-				"getHours",
-				"getUTCHours",
-				"getMinutes",
-				"getUTCMinutes",
-				"getSeconds",
-				"getUTCSeconds",
-				"getMilliseconds",
-				"getUTCMilliseconds",
-				"getTimezoneOffset",
-				"setTime",
-				"setMilliseconds",
-				"setUTCMilliseconds",
-				"setSeconds",
-				"setUTCSeconds",
-				"setMinutes",
-				"setUTCMinutes",
-				"setHours",
-				"setUTCHours",
-				"setDate",
-				"setUTCDate",
-				"setMonth",
-				"setUTCMonth",
-				"setYear",
-				"setFullYear",
-				"setUTCFullYear",
-			},
-		}
-		rt.global.Date = &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			value: nativeFunctionObject{
-				name:      classDateName,
-				call:      builtinDate,
-				construct: builtinNewDate,
-			},
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 7,
-					},
-				},
-				"prototype": {
-					mode: 0,
-					value: Value{
-						kind:  valueObject,
-						value: rt.global.DatePrototype,
-					},
-				},
-				"parse": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: parse,
-					},
-				},
-				"UTC": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: UTC,
-					},
-				},
-				"now": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: now,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-				"prototype",
-				"parse",
-				"UTC",
-				"now",
-			},
-		}
-		rt.global.DatePrototype.property["constructor"] = property{
-			mode: 0o101,
-			value: Value{
-				kind:  valueObject,
-				value: rt.global.Date,
-			},
-		}
-	}
-	{
-		toString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toString",
-				call: builtinRegExpToString,
-			},
-		}
-		exec := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "exec",
-				call: builtinRegExpExec,
-			},
-		}
-		test := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "test",
-				call: builtinRegExpTest,
-			},
-		}
-		compile := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "compile",
-				call: builtinRegExpCompile,
-			},
-		}
-		rt.global.RegExpPrototype = &object{
-			runtime:     rt,
-			class:       classRegExpName,
-			objectClass: classObject,
-			prototype:   rt.global.ObjectPrototype,
-			extensible:  true,
-			value:       prototypeValueRegExp,
-			property: map[string]property{
-				"toString": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toString,
-					},
-				},
-				"exec": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: exec,
-					},
-				},
-				"test": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: test,
-					},
-				},
-				"compile": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: compile,
-					},
-				},
-			},
-			propertyOrder: []string{
-				"toString",
-				"exec",
-				"test",
-				"compile",
-			},
-		}
-		rt.global.RegExp = &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			value: nativeFunctionObject{
-				name:      classRegExpName,
-				call:      builtinRegExp,
-				construct: builtinNewRegExp,
-			},
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-				"prototype": {
-					mode: 0,
-					value: Value{
-						kind:  valueObject,
-						value: rt.global.RegExpPrototype,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-				"prototype",
-			},
-		}
-		rt.global.RegExpPrototype.property["constructor"] = property{
-			mode: 0o101,
-			value: Value{
-				kind:  valueObject,
-				value: rt.global.RegExp,
-			},
-		}
-	}
-	{
-		toString := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "toString",
-				call: builtinErrorToString,
-			},
-		}
-		rt.global.ErrorPrototype = &object{
-			runtime:     rt,
-			class:       classErrorName,
-			objectClass: classObject,
-			prototype:   rt.global.ObjectPrototype,
-			extensible:  true,
-			value:       nil,
-			property: map[string]property{
-				"toString": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: toString,
-					},
-				},
-				"name": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueString,
-						value: classErrorName,
-					},
-				},
-				"message": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueString,
-						value: "",
-					},
-				},
-			},
-			propertyOrder: []string{
-				"toString",
-				"name",
-				"message",
-			},
-		}
-		rt.global.Error = &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			value: nativeFunctionObject{
-				name:      classErrorName,
-				call:      builtinError,
-				construct: builtinNewError,
-			},
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-				"prototype": {
-					mode: 0,
-					value: Value{
-						kind:  valueObject,
-						value: rt.global.ErrorPrototype,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-				"prototype",
-			},
-		}
-		rt.global.ErrorPrototype.property["constructor"] = property{
-			mode: 0o101,
-			value: Value{
-				kind:  valueObject,
-				value: rt.global.Error,
-			},
-		}
-	}
-	{
-		rt.global.EvalErrorPrototype = &object{
-			runtime:     rt,
-			class:       "EvalError",
-			objectClass: classObject,
-			prototype:   rt.global.ErrorPrototype,
-			extensible:  true,
-			value:       nil,
-			property: map[string]property{
-				"name": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueString,
-						value: "EvalError",
-					},
-				},
-			},
-			propertyOrder: []string{
-				"name",
-			},
-		}
-		rt.global.EvalError = &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			value: nativeFunctionObject{
-				name:      "EvalError",
-				call:      builtinEvalError,
-				construct: builtinNewEvalError,
-			},
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-				"prototype": {
-					mode: 0,
-					value: Value{
-						kind:  valueObject,
-						value: rt.global.EvalErrorPrototype,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-				"prototype",
-			},
-		}
-		rt.global.EvalErrorPrototype.property["constructor"] = property{
-			mode: 0o101,
-			value: Value{
-				kind:  valueObject,
-				value: rt.global.EvalError,
-			},
-		}
-	}
-	{
-		rt.global.TypeErrorPrototype = &object{
-			runtime:     rt,
-			class:       "TypeError",
-			objectClass: classObject,
-			prototype:   rt.global.ErrorPrototype,
-			extensible:  true,
-			value:       nil,
-			property: map[string]property{
-				"name": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueString,
-						value: "TypeError",
-					},
-				},
-			},
-			propertyOrder: []string{
-				"name",
-			},
-		}
-		rt.global.TypeError = &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			value: nativeFunctionObject{
-				name:      "TypeError",
-				call:      builtinTypeError,
-				construct: builtinNewTypeError,
-			},
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-				"prototype": {
-					mode: 0,
-					value: Value{
-						kind:  valueObject,
-						value: rt.global.TypeErrorPrototype,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-				"prototype",
-			},
-		}
-		rt.global.TypeErrorPrototype.property["constructor"] = property{
-			mode: 0o101,
-			value: Value{
-				kind:  valueObject,
-				value: rt.global.TypeError,
-			},
-		}
-	}
-	{
-		rt.global.RangeErrorPrototype = &object{
-			runtime:     rt,
-			class:       "RangeError",
-			objectClass: classObject,
-			prototype:   rt.global.ErrorPrototype,
-			extensible:  true,
-			value:       nil,
-			property: map[string]property{
-				"name": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueString,
-						value: "RangeError",
-					},
-				},
-			},
-			propertyOrder: []string{
-				"name",
-			},
-		}
-		rt.global.RangeError = &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			value: nativeFunctionObject{
-				name:      "RangeError",
-				call:      builtinRangeError,
-				construct: builtinNewRangeError,
-			},
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-				"prototype": {
-					mode: 0,
-					value: Value{
-						kind:  valueObject,
-						value: rt.global.RangeErrorPrototype,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-				"prototype",
-			},
-		}
-		rt.global.RangeErrorPrototype.property["constructor"] = property{
-			mode: 0o101,
-			value: Value{
-				kind:  valueObject,
-				value: rt.global.RangeError,
-			},
-		}
-	}
-	{
-		rt.global.ReferenceErrorPrototype = &object{
-			runtime:     rt,
-			class:       "ReferenceError",
-			objectClass: classObject,
-			prototype:   rt.global.ErrorPrototype,
-			extensible:  true,
-			value:       nil,
-			property: map[string]property{
-				"name": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueString,
-						value: "ReferenceError",
-					},
-				},
-			},
-			propertyOrder: []string{
-				"name",
-			},
-		}
-		rt.global.ReferenceError = &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			value: nativeFunctionObject{
-				name:      "ReferenceError",
-				call:      builtinReferenceError,
-				construct: builtinNewReferenceError,
-			},
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-				"prototype": {
-					mode: 0,
-					value: Value{
-						kind:  valueObject,
-						value: rt.global.ReferenceErrorPrototype,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-				"prototype",
-			},
-		}
-		rt.global.ReferenceErrorPrototype.property["constructor"] = property{
-			mode: 0o101,
-			value: Value{
-				kind:  valueObject,
-				value: rt.global.ReferenceError,
-			},
-		}
-	}
-	{
-		rt.global.SyntaxErrorPrototype = &object{
-			runtime:     rt,
-			class:       "SyntaxError",
-			objectClass: classObject,
-			prototype:   rt.global.ErrorPrototype,
-			extensible:  true,
-			value:       nil,
-			property: map[string]property{
-				"name": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueString,
-						value: "SyntaxError",
-					},
-				},
-			},
-			propertyOrder: []string{
-				"name",
-			},
-		}
-		rt.global.SyntaxError = &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			value: nativeFunctionObject{
-				name:      "SyntaxError",
-				call:      builtinSyntaxError,
-				construct: builtinNewSyntaxError,
-			},
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-				"prototype": {
-					mode: 0,
-					value: Value{
-						kind:  valueObject,
-						value: rt.global.SyntaxErrorPrototype,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-				"prototype",
-			},
-		}
-		rt.global.SyntaxErrorPrototype.property["constructor"] = property{
-			mode: 0o101,
-			value: Value{
-				kind:  valueObject,
-				value: rt.global.SyntaxError,
-			},
-		}
-	}
-	{
-		rt.global.URIErrorPrototype = &object{
-			runtime:     rt,
-			class:       "URIError",
-			objectClass: classObject,
-			prototype:   rt.global.ErrorPrototype,
-			extensible:  true,
-			value:       nil,
-			property: map[string]property{
-				"name": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueString,
-						value: "URIError",
-					},
-				},
-			},
-			propertyOrder: []string{
-				"name",
-			},
-		}
-		rt.global.URIError = &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			value: nativeFunctionObject{
-				name:      "URIError",
-				call:      builtinURIError,
-				construct: builtinNewURIError,
-			},
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-				"prototype": {
-					mode: 0,
-					value: Value{
-						kind:  valueObject,
-						value: rt.global.URIErrorPrototype,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-				"prototype",
-			},
-		}
-		rt.global.URIErrorPrototype.property["constructor"] = property{
-			mode: 0o101,
-			value: Value{
-				kind:  valueObject,
-				value: rt.global.URIError,
-			},
-		}
-	}
-	{
-		parse := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "parse",
-				call: builtinJSONParse,
-			},
-		}
-		stringify := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 3,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "stringify",
-				call: builtinJSONStringify,
-			},
-		}
-		rt.global.JSON = &object{
-			runtime:     rt,
-			class:       "JSON",
-			objectClass: classObject,
-			prototype:   rt.global.ObjectPrototype,
-			extensible:  true,
-			property: map[string]property{
-				"parse": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: parse,
-					},
-				},
-				"stringify": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: stringify,
-					},
-				},
-			},
-			propertyOrder: []string{
-				"parse",
-				"stringify",
-			},
-		}
-	}
-	{
-		eval := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "eval",
-				call: builtinGlobalEval,
-			},
-		}
-		parseInt := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 2,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "parseInt",
-				call: builtinGlobalParseInt,
-			},
-		}
-		parseFloat := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "parseFloat",
-				call: builtinGlobalParseFloat,
-			},
-		}
-		isNaN := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "isNaN",
-				call: builtinGlobalIsNaN,
-			},
-		}
-		isFinite := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "isFinite",
-				call: builtinGlobalIsFinite,
-			},
-		}
-		decodeURI := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "decodeURI",
-				call: builtinGlobalDecodeURI,
-			},
-		}
-		decodeURIComponent := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "decodeURIComponent",
-				call: builtinGlobalDecodeURIComponent,
-			},
-		}
-		encodeURI := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "encodeURI",
-				call: builtinGlobalEncodeURI,
-			},
-		}
-		encodeURIComponent := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "encodeURIComponent",
-				call: builtinGlobalEncodeURIComponent,
-			},
-		}
-		escape := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "escape",
-				call: builtinGlobalEscape,
-			},
-		}
-		unescape := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 1,
-					},
-				},
-			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "unescape",
-				call: builtinGlobalUnescape,
-			},
-		}
-		rt.globalObject.property = map[string]property{
-			"eval": {
+	rt.global.StringPrototype = &object{
+		runtime:     rt,
+		class:       classStringName,
+		objectClass: classString,
+		prototype:   rt.global.ObjectPrototype,
+		extensible:  true,
+		value:       prototypeValueString,
+		property: map[string]property{
+			propertyLength: {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: int(0),
+				},
+			},
+			methodToString: {
 				mode: 0o101,
 				value: Value{
-					kind:  valueObject,
-					value: eval,
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: methodToString,
+							call: builtinStringToString,
+						},
+					},
 				},
 			},
-			"parseInt": {
+			"valueOf": {
 				mode: 0o101,
 				value: Value{
-					kind:  valueObject,
-					value: parseInt,
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "valueOf",
+							call: builtinStringValueOf,
+						},
+					},
 				},
 			},
-			"parseFloat": {
+			"charAt": {
 				mode: 0o101,
 				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "charAt",
+							call: builtinStringCharAt,
+						},
+					},
+				},
+			},
+			"charCodeAt": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "charCodeAt",
+							call: builtinStringCharCodeAt,
+						},
+					},
+				},
+			},
+			"concat": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "concat",
+							call: builtinStringConcat,
+						},
+					},
+				},
+			},
+			"indexOf": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "indexOf",
+							call: builtinStringIndexOf,
+						},
+					},
+				},
+			},
+			"lastIndexOf": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "lastIndexOf",
+							call: builtinStringLastIndexOf,
+						},
+					},
+				},
+			},
+			"match": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "match",
+							call: builtinStringMatch,
+						},
+					},
+				},
+			},
+			"replace": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "replace",
+							call: builtinStringReplace,
+						},
+					},
+				},
+			},
+			"search": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "search",
+							call: builtinStringSearch,
+						},
+					},
+				},
+			},
+			"split": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "split",
+							call: builtinStringSplit,
+						},
+					},
+				},
+			},
+			"slice": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "slice",
+							call: builtinStringSlice,
+						},
+					},
+				},
+			},
+			"substring": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "substring",
+							call: builtinStringSubstring,
+						},
+					},
+				},
+			},
+			"toLowerCase": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "toLowerCase",
+							call: builtinStringToLowerCase,
+						},
+					},
+				},
+			},
+			"toUpperCase": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "toUpperCase",
+							call: builtinStringToUpperCase,
+						},
+					},
+				},
+			},
+			"substr": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "substr",
+							call: builtinStringSubstr,
+						},
+					},
+				},
+			},
+			"trim": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "trim",
+							call: builtinStringTrim,
+						},
+					},
+				},
+			},
+			"trimLeft": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "trimLeft",
+							call: builtinStringTrimLeft,
+						},
+					},
+				},
+			},
+			"trimRight": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "trimRight",
+							call: builtinStringTrimRight,
+						},
+					},
+				},
+			},
+			"localeCompare": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "localeCompare",
+							call: builtinStringLocaleCompare,
+						},
+					},
+				},
+			},
+			"toLocaleLowerCase": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "toLocaleLowerCase",
+							call: builtinStringToLocaleLowerCase,
+						},
+					},
+				},
+			},
+			"toLocaleUpperCase": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "toLocaleUpperCase",
+							call: builtinStringToLocaleUpperCase,
+						},
+					},
+				},
+			},
+		},
+		propertyOrder: []string{
+			propertyLength,
+			methodToString,
+			"valueOf",
+			"charAt",
+			"charCodeAt",
+			"concat",
+			"indexOf",
+			"lastIndexOf",
+			"match",
+			"replace",
+			"search",
+			"split",
+			"slice",
+			"substring",
+			"toLowerCase",
+			"toUpperCase",
+			"substr",
+			"trim",
+			"trimLeft",
+			"trimRight",
+			"localeCompare",
+			"toLocaleLowerCase",
+			"toLocaleUpperCase",
+		},
+	}
+	rt.global.String = &object{
+		runtime:     rt,
+		class:       classFunctionName,
+		objectClass: classObject,
+		prototype:   rt.global.FunctionPrototype,
+		extensible:  true,
+		value: nativeFunctionObject{
+			name:      classStringName,
+			call:      builtinString,
+			construct: builtinNewString,
+		},
+		property: map[string]property{
+			propertyLength: {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: 1,
+				},
+			},
+			propertyPrototype: {
+				mode: 0,
+				value: Value{
 					kind:  valueObject,
-					value: parseFloat,
+					value: rt.global.StringPrototype,
+				},
+			},
+			"fromCharCode": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "fromCharCode",
+							call: builtinStringFromCharCode,
+						},
+					},
+				},
+			},
+		},
+		propertyOrder: []string{
+			propertyLength,
+			propertyPrototype,
+			"fromCharCode",
+		},
+	}
+	rt.global.StringPrototype.property[propertyConstructor] = property{
+		mode: 0o101,
+		value: Value{
+			kind:  valueObject,
+			value: rt.global.String,
+		},
+	}
+	rt.global.BooleanPrototype = &object{
+		runtime:     rt,
+		class:       classBooleanName,
+		objectClass: classObject,
+		prototype:   rt.global.ObjectPrototype,
+		extensible:  true,
+		value:       prototypeValueBoolean,
+		property: map[string]property{
+			methodToString: {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: methodToString,
+							call: builtinBooleanToString,
+						},
+					},
+				},
+			},
+			"valueOf": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "valueOf",
+							call: builtinBooleanValueOf,
+						},
+					},
+				},
+			},
+		},
+		propertyOrder: []string{
+			methodToString,
+			"valueOf",
+		},
+	}
+	rt.global.Boolean = &object{
+		runtime:     rt,
+		class:       classFunctionName,
+		objectClass: classObject,
+		prototype:   rt.global.FunctionPrototype,
+		extensible:  true,
+		value: nativeFunctionObject{
+			name:      classBooleanName,
+			call:      builtinBoolean,
+			construct: builtinNewBoolean,
+		},
+		property: map[string]property{
+			propertyLength: {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: 1,
+				},
+			},
+			propertyPrototype: {
+				mode: 0,
+				value: Value{
+					kind:  valueObject,
+					value: rt.global.BooleanPrototype,
+				},
+			},
+		},
+		propertyOrder: []string{
+			propertyLength,
+			propertyPrototype,
+		},
+	}
+	rt.global.BooleanPrototype.property[propertyConstructor] = property{
+		mode: 0o101,
+		value: Value{
+			kind:  valueObject,
+			value: rt.global.Boolean,
+		},
+	}
+	rt.global.NumberPrototype = &object{
+		runtime:     rt,
+		class:       classNumberName,
+		objectClass: classObject,
+		prototype:   rt.global.ObjectPrototype,
+		extensible:  true,
+		value:       prototypeValueNumber,
+		property: map[string]property{
+			methodToString: {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: methodToString,
+							call: builtinNumberToString,
+						},
+					},
+				},
+			},
+			"valueOf": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "valueOf",
+							call: builtinNumberValueOf,
+						},
+					},
+				},
+			},
+			"toFixed": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "toFixed",
+							call: builtinNumberToFixed,
+						},
+					},
+				},
+			},
+			"toExponential": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "toExponential",
+							call: builtinNumberToExponential,
+						},
+					},
+				},
+			},
+			"toPrecision": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "toPrecision",
+							call: builtinNumberToPrecision,
+						},
+					},
+				},
+			},
+			"toLocaleString": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "toLocaleString",
+							call: builtinNumberToLocaleString,
+						},
+					},
+				},
+			},
+		},
+		propertyOrder: []string{
+			methodToString,
+			"valueOf",
+			"toFixed",
+			"toExponential",
+			"toPrecision",
+			"toLocaleString",
+		},
+	}
+	rt.global.Number = &object{
+		runtime:     rt,
+		class:       classFunctionName,
+		objectClass: classObject,
+		prototype:   rt.global.FunctionPrototype,
+		extensible:  true,
+		value: nativeFunctionObject{
+			name:      classNumberName,
+			call:      builtinNumber,
+			construct: builtinNewNumber,
+		},
+		property: map[string]property{
+			propertyLength: {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: 1,
+				},
+			},
+			propertyPrototype: {
+				mode: 0,
+				value: Value{
+					kind:  valueObject,
+					value: rt.global.NumberPrototype,
 				},
 			},
 			"isNaN": {
 				mode: 0o101,
 				value: Value{
-					kind:  valueObject,
-					value: isNaN,
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "isNaN",
+							call: builtinNumberIsNaN,
+						},
+					},
 				},
 			},
-			"isFinite": {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: isFinite,
-				},
-			},
-			"decodeURI": {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: decodeURI,
-				},
-			},
-			"decodeURIComponent": {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: decodeURIComponent,
-				},
-			},
-			"encodeURI": {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: encodeURI,
-				},
-			},
-			"encodeURIComponent": {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: encodeURIComponent,
-				},
-			},
-			"escape": {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: escape,
-				},
-			},
-			"unescape": {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: unescape,
-				},
-			},
-			classObjectName: {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: rt.global.Object,
-				},
-			},
-			classFunctionName: {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: rt.global.Function,
-				},
-			},
-			classArrayName: {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: rt.global.Array,
-				},
-			},
-			classStringName: {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: rt.global.String,
-				},
-			},
-			classBooleanName: {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: rt.global.Boolean,
-				},
-			},
-			classNumberName: {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: rt.global.Number,
-				},
-			},
-			"Math": {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: rt.global.Math,
-				},
-			},
-			classDateName: {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: rt.global.Date,
-				},
-			},
-			classRegExpName: {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: rt.global.RegExp,
-				},
-			},
-			classErrorName: {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: rt.global.Error,
-				},
-			},
-			"EvalError": {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: rt.global.EvalError,
-				},
-			},
-			"TypeError": {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: rt.global.TypeError,
-				},
-			},
-			"RangeError": {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: rt.global.RangeError,
-				},
-			},
-			"ReferenceError": {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: rt.global.ReferenceError,
-				},
-			},
-			"SyntaxError": {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: rt.global.SyntaxError,
-				},
-			},
-			"URIError": {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: rt.global.URIError,
-				},
-			},
-			"JSON": {
-				mode: 0o101,
-				value: Value{
-					kind:  valueObject,
-					value: rt.global.JSON,
-				},
-			},
-			"undefined": {
+			"MAX_VALUE": {
 				mode: 0,
 				value: Value{
-					kind: valueUndefined,
+					kind:  valueNumber,
+					value: math.MaxFloat64,
+				},
+			},
+			"MIN_VALUE": {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: math.SmallestNonzeroFloat64,
 				},
 			},
 			"NaN": {
@@ -6180,377 +2662,3692 @@ func (rt *runtime) newContext() {
 					value: math.NaN(),
 				},
 			},
-			"Infinity": {
+			"NEGATIVE_INFINITY": {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: math.Inf(-1),
+				},
+			},
+			"POSITIVE_INFINITY": {
 				mode: 0,
 				value: Value{
 					kind:  valueNumber,
 					value: math.Inf(+1),
 				},
 			},
-		}
-		rt.globalObject.propertyOrder = []string{
-			"eval",
-			"parseInt",
-			"parseFloat",
+		},
+		propertyOrder: []string{
+			propertyLength,
+			propertyPrototype,
 			"isNaN",
-			"isFinite",
-			"decodeURI",
-			"decodeURIComponent",
-			"encodeURI",
-			"encodeURIComponent",
-			"escape",
-			"unescape",
-			classObjectName,
-			classFunctionName,
-			classArrayName,
-			classStringName,
-			classBooleanName,
-			classNumberName,
-			"Math",
-			classDateName,
-			classRegExpName,
-			classErrorName,
-			"EvalError",
-			"TypeError",
-			"RangeError",
-			"ReferenceError",
-			"SyntaxError",
-			"URIError",
-			"JSON",
-			"undefined",
+			"MAX_VALUE",
+			"MIN_VALUE",
 			"NaN",
-			"Infinity",
-		}
+			"NEGATIVE_INFINITY",
+			"POSITIVE_INFINITY",
+		},
+	}
+	rt.global.NumberPrototype.property[propertyConstructor] = property{
+		mode: 0o101,
+		value: Value{
+			kind:  valueObject,
+			value: rt.global.Number,
+		},
+	}
+	rt.global.Math = &object{
+		runtime:     rt,
+		class:       classMathName,
+		objectClass: classObject,
+		prototype:   rt.global.ObjectPrototype,
+		extensible:  true,
+		property: map[string]property{
+			"abs": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "abs",
+							call: builtinMathAbs,
+						},
+					},
+				},
+			},
+			"acos": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "acos",
+							call: builtinMathAcos,
+						},
+					},
+				},
+			},
+			"asin": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "asin",
+							call: builtinMathAsin,
+						},
+					},
+				},
+			},
+			"atan": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "atan",
+							call: builtinMathAtan,
+						},
+					},
+				},
+			},
+			"atan2": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "atan2",
+							call: builtinMathAtan2,
+						},
+					},
+				},
+			},
+			"ceil": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "ceil",
+							call: builtinMathCeil,
+						},
+					},
+				},
+			},
+			"cos": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "cos",
+							call: builtinMathCos,
+						},
+					},
+				},
+			},
+			"exp": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "exp",
+							call: builtinMathExp,
+						},
+					},
+				},
+			},
+			"floor": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "floor",
+							call: builtinMathFloor,
+						},
+					},
+				},
+			},
+			"log": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "log",
+							call: builtinMathLog,
+						},
+					},
+				},
+			},
+			"max": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "max",
+							call: builtinMathMax,
+						},
+					},
+				},
+			},
+			"min": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "min",
+							call: builtinMathMin,
+						},
+					},
+				},
+			},
+			"pow": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "pow",
+							call: builtinMathPow,
+						},
+					},
+				},
+			},
+			"random": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "random",
+							call: builtinMathRandom,
+						},
+					},
+				},
+			},
+			"round": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "round",
+							call: builtinMathRound,
+						},
+					},
+				},
+			},
+			"sin": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "sin",
+							call: builtinMathSin,
+						},
+					},
+				},
+			},
+			"sqrt": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "sqrt",
+							call: builtinMathSqrt,
+						},
+					},
+				},
+			},
+			"tan": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "tan",
+							call: builtinMathTan,
+						},
+					},
+				},
+			},
+			"E": {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: math.E,
+				},
+			},
+			"LN10": {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: math.Ln10,
+				},
+			},
+			"LN2": {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: math.Ln2,
+				},
+			},
+			"LOG2E": {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: math.Log2E,
+				},
+			},
+			"LOG10E": {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: math.Log10E,
+				},
+			},
+			"PI": {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: math.Pi,
+				},
+			},
+			"SQRT1_2": {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: sqrt1_2,
+				},
+			},
+			"SQRT2": {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: math.Sqrt2,
+				},
+			},
+		},
+		propertyOrder: []string{
+			"abs",
+			"acos",
+			"asin",
+			"atan",
+			"atan2",
+			"ceil",
+			"cos",
+			"exp",
+			"floor",
+			"log",
+			"max",
+			"min",
+			"pow",
+			"random",
+			"round",
+			"sin",
+			"sqrt",
+			"tan",
+			"E",
+			"LN10",
+			"LN2",
+			"LOG2E",
+			"LOG10E",
+			"PI",
+			"SQRT1_2",
+			"SQRT2",
+		},
+	}
+	rt.global.DatePrototype = &object{
+		runtime:     rt,
+		class:       classDateName,
+		objectClass: classObject,
+		prototype:   rt.global.ObjectPrototype,
+		extensible:  true,
+		value:       prototypeValueDate,
+		property: map[string]property{
+			methodToString: {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: methodToString,
+							call: builtinDateToString,
+						},
+					},
+				},
+			},
+			"toDateString": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "toDateString",
+							call: builtinDateToDateString,
+						},
+					},
+				},
+			},
+			"toTimeString": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "toTimeString",
+							call: builtinDateToTimeString,
+						},
+					},
+				},
+			},
+			"toUTCString": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "toUTCString",
+							call: builtinDateToUTCString,
+						},
+					},
+				},
+			},
+			"toISOString": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "toISOString",
+							call: builtinDateToISOString,
+						},
+					},
+				},
+			},
+			"toJSON": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "toJSON",
+							call: builtinDateToJSON,
+						},
+					},
+				},
+			},
+			"toGMTString": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "toGMTString",
+							call: builtinDateToGMTString,
+						},
+					},
+				},
+			},
+			"toLocaleString": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "toLocaleString",
+							call: builtinDateToLocaleString,
+						},
+					},
+				},
+			},
+			"toLocaleDateString": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "toLocaleDateString",
+							call: builtinDateToLocaleDateString,
+						},
+					},
+				},
+			},
+			"toLocaleTimeString": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "toLocaleTimeString",
+							call: builtinDateToLocaleTimeString,
+						},
+					},
+				},
+			},
+			"valueOf": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "valueOf",
+							call: builtinDateValueOf,
+						},
+					},
+				},
+			},
+			"getTime": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getTime",
+							call: builtinDateGetTime,
+						},
+					},
+				},
+			},
+			"getYear": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getYear",
+							call: builtinDateGetYear,
+						},
+					},
+				},
+			},
+			"getFullYear": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getFullYear",
+							call: builtinDateGetFullYear,
+						},
+					},
+				},
+			},
+			"getUTCFullYear": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getUTCFullYear",
+							call: builtinDateGetUTCFullYear,
+						},
+					},
+				},
+			},
+			"getMonth": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getMonth",
+							call: builtinDateGetMonth,
+						},
+					},
+				},
+			},
+			"getUTCMonth": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getUTCMonth",
+							call: builtinDateGetUTCMonth,
+						},
+					},
+				},
+			},
+			"getDate": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getDate",
+							call: builtinDateGetDate,
+						},
+					},
+				},
+			},
+			"getUTCDate": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getUTCDate",
+							call: builtinDateGetUTCDate,
+						},
+					},
+				},
+			},
+			"getDay": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getDay",
+							call: builtinDateGetDay,
+						},
+					},
+				},
+			},
+			"getUTCDay": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getUTCDay",
+							call: builtinDateGetUTCDay,
+						},
+					},
+				},
+			},
+			"getHours": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getHours",
+							call: builtinDateGetHours,
+						},
+					},
+				},
+			},
+			"getUTCHours": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getUTCHours",
+							call: builtinDateGetUTCHours,
+						},
+					},
+				},
+			},
+			"getMinutes": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getMinutes",
+							call: builtinDateGetMinutes,
+						},
+					},
+				},
+			},
+			"getUTCMinutes": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getUTCMinutes",
+							call: builtinDateGetUTCMinutes,
+						},
+					},
+				},
+			},
+			"getSeconds": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getSeconds",
+							call: builtinDateGetSeconds,
+						},
+					},
+				},
+			},
+			"getUTCSeconds": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getUTCSeconds",
+							call: builtinDateGetUTCSeconds,
+						},
+					},
+				},
+			},
+			"getMilliseconds": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getMilliseconds",
+							call: builtinDateGetMilliseconds,
+						},
+					},
+				},
+			},
+			"getUTCMilliseconds": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getUTCMilliseconds",
+							call: builtinDateGetUTCMilliseconds,
+						},
+					},
+				},
+			},
+			"getTimezoneOffset": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "getTimezoneOffset",
+							call: builtinDateGetTimezoneOffset,
+						},
+					},
+				},
+			},
+			"setTime": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "setTime",
+							call: builtinDateSetTime,
+						},
+					},
+				},
+			},
+			"setMilliseconds": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "setMilliseconds",
+							call: builtinDateSetMilliseconds,
+						},
+					},
+				},
+			},
+			"setUTCMilliseconds": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "setUTCMilliseconds",
+							call: builtinDateSetUTCMilliseconds,
+						},
+					},
+				},
+			},
+			"setSeconds": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "setSeconds",
+							call: builtinDateSetSeconds,
+						},
+					},
+				},
+			},
+			"setUTCSeconds": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "setUTCSeconds",
+							call: builtinDateSetUTCSeconds,
+						},
+					},
+				},
+			},
+			"setMinutes": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 3,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "setMinutes",
+							call: builtinDateSetMinutes,
+						},
+					},
+				},
+			},
+			"setUTCMinutes": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 3,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "setUTCMinutes",
+							call: builtinDateSetUTCMinutes,
+						},
+					},
+				},
+			},
+			"setHours": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 4,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "setHours",
+							call: builtinDateSetHours,
+						},
+					},
+				},
+			},
+			"setUTCHours": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 4,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "setUTCHours",
+							call: builtinDateSetUTCHours,
+						},
+					},
+				},
+			},
+			"setDate": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "setDate",
+							call: builtinDateSetDate,
+						},
+					},
+				},
+			},
+			"setUTCDate": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "setUTCDate",
+							call: builtinDateSetUTCDate,
+						},
+					},
+				},
+			},
+			"setMonth": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "setMonth",
+							call: builtinDateSetMonth,
+						},
+					},
+				},
+			},
+			"setUTCMonth": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "setUTCMonth",
+							call: builtinDateSetUTCMonth,
+						},
+					},
+				},
+			},
+			"setYear": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "setYear",
+							call: builtinDateSetYear,
+						},
+					},
+				},
+			},
+			"setFullYear": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 3,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "setFullYear",
+							call: builtinDateSetFullYear,
+						},
+					},
+				},
+			},
+			"setUTCFullYear": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 3,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "setUTCFullYear",
+							call: builtinDateSetUTCFullYear,
+						},
+					},
+				},
+			},
+		},
+		propertyOrder: []string{
+			methodToString,
+			"toDateString",
+			"toTimeString",
+			"toUTCString",
+			"toISOString",
+			"toJSON",
+			"toGMTString",
+			"toLocaleString",
+			"toLocaleDateString",
+			"toLocaleTimeString",
+			"valueOf",
+			"getTime",
+			"getYear",
+			"getFullYear",
+			"getUTCFullYear",
+			"getMonth",
+			"getUTCMonth",
+			"getDate",
+			"getUTCDate",
+			"getDay",
+			"getUTCDay",
+			"getHours",
+			"getUTCHours",
+			"getMinutes",
+			"getUTCMinutes",
+			"getSeconds",
+			"getUTCSeconds",
+			"getMilliseconds",
+			"getUTCMilliseconds",
+			"getTimezoneOffset",
+			"setTime",
+			"setMilliseconds",
+			"setUTCMilliseconds",
+			"setSeconds",
+			"setUTCSeconds",
+			"setMinutes",
+			"setUTCMinutes",
+			"setHours",
+			"setUTCHours",
+			"setDate",
+			"setUTCDate",
+			"setMonth",
+			"setUTCMonth",
+			"setYear",
+			"setFullYear",
+			"setUTCFullYear",
+		},
+	}
+	rt.global.Date = &object{
+		runtime:     rt,
+		class:       classFunctionName,
+		objectClass: classObject,
+		prototype:   rt.global.FunctionPrototype,
+		extensible:  true,
+		value: nativeFunctionObject{
+			name:      classDateName,
+			call:      builtinDate,
+			construct: builtinNewDate,
+		},
+		property: map[string]property{
+			propertyLength: {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: 7,
+				},
+			},
+			propertyPrototype: {
+				mode: 0,
+				value: Value{
+					kind:  valueObject,
+					value: rt.global.DatePrototype,
+				},
+			},
+			"parse": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "parse",
+							call: builtinDateParse,
+						},
+					},
+				},
+			},
+			"UTC": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 7,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "UTC",
+							call: builtinDateUTC,
+						},
+					},
+				},
+			},
+			"now": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "now",
+							call: builtinDateNow,
+						},
+					},
+				},
+			},
+		},
+		propertyOrder: []string{
+			propertyLength,
+			propertyPrototype,
+			"parse",
+			"UTC",
+			"now",
+		},
+	}
+	rt.global.DatePrototype.property[propertyConstructor] = property{
+		mode: 0o101,
+		value: Value{
+			kind:  valueObject,
+			value: rt.global.Date,
+		},
+	}
+	rt.global.RegExpPrototype = &object{
+		runtime:     rt,
+		class:       classRegExpName,
+		objectClass: classObject,
+		prototype:   rt.global.ObjectPrototype,
+		extensible:  true,
+		value:       prototypeValueRegExp,
+		property: map[string]property{
+			methodToString: {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: methodToString,
+							call: builtinRegExpToString,
+						},
+					},
+				},
+			},
+			"exec": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "exec",
+							call: builtinRegExpExec,
+						},
+					},
+				},
+			},
+			"test": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "test",
+							call: builtinRegExpTest,
+						},
+					},
+				},
+			},
+			"compile": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 1,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "compile",
+							call: builtinRegExpCompile,
+						},
+					},
+				},
+			},
+		},
+		propertyOrder: []string{
+			methodToString,
+			"exec",
+			"test",
+			"compile",
+		},
+	}
+	rt.global.RegExp = &object{
+		runtime:     rt,
+		class:       classFunctionName,
+		objectClass: classObject,
+		prototype:   rt.global.FunctionPrototype,
+		extensible:  true,
+		value: nativeFunctionObject{
+			name:      classRegExpName,
+			call:      builtinRegExp,
+			construct: builtinNewRegExp,
+		},
+		property: map[string]property{
+			propertyLength: {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: 2,
+				},
+			},
+			propertyPrototype: {
+				mode: 0,
+				value: Value{
+					kind:  valueObject,
+					value: rt.global.RegExpPrototype,
+				},
+			},
+		},
+		propertyOrder: []string{
+			propertyLength,
+			propertyPrototype,
+		},
+	}
+	rt.global.RegExpPrototype.property[propertyConstructor] = property{
+		mode: 0o101,
+		value: Value{
+			kind:  valueObject,
+			value: rt.global.RegExp,
+		},
+	}
+	rt.global.ErrorPrototype = &object{
+		runtime:     rt,
+		class:       classErrorName,
+		objectClass: classObject,
+		prototype:   rt.global.ObjectPrototype,
+		extensible:  true,
+		value:       nil,
+		property: map[string]property{
+			methodToString: {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: methodToString,
+							call: builtinErrorToString,
+						},
+					},
+				},
+			},
+			"name": {
+				mode: 0o101,
+				value: Value{
+					kind:  valueString,
+					value: classErrorName,
+				},
+			},
+			"message": {
+				mode: 0o101,
+				value: Value{
+					kind:  valueString,
+					value: "",
+				},
+			},
+		},
+		propertyOrder: []string{
+			methodToString,
+			"name",
+			"message",
+		},
+	}
+	rt.global.Error = &object{
+		runtime:     rt,
+		class:       classFunctionName,
+		objectClass: classObject,
+		prototype:   rt.global.FunctionPrototype,
+		extensible:  true,
+		value: nativeFunctionObject{
+			name:      classErrorName,
+			call:      builtinError,
+			construct: builtinNewError,
+		},
+		property: map[string]property{
+			propertyLength: {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: 1,
+				},
+			},
+			propertyPrototype: {
+				mode: 0,
+				value: Value{
+					kind:  valueObject,
+					value: rt.global.ErrorPrototype,
+				},
+			},
+		},
+		propertyOrder: []string{
+			propertyLength,
+			propertyPrototype,
+		},
+	}
+	rt.global.ErrorPrototype.property[propertyConstructor] = property{
+		mode: 0o101,
+		value: Value{
+			kind:  valueObject,
+			value: rt.global.Error,
+		},
+	}
+	rt.global.EvalErrorPrototype = &object{
+		runtime:     rt,
+		class:       classEvalErrorName,
+		objectClass: classObject,
+		prototype:   rt.global.ErrorPrototype,
+		extensible:  true,
+		value:       nil,
+		property: map[string]property{
+			"name": {
+				mode: 0o101,
+				value: Value{
+					kind:  valueString,
+					value: classEvalErrorName,
+				},
+			},
+		},
+		propertyOrder: []string{
+			"name",
+		},
+	}
+	rt.global.EvalError = &object{
+		runtime:     rt,
+		class:       classFunctionName,
+		objectClass: classObject,
+		prototype:   rt.global.FunctionPrototype,
+		extensible:  true,
+		value: nativeFunctionObject{
+			name:      classEvalErrorName,
+			call:      builtinEvalError,
+			construct: builtinNewEvalError,
+		},
+		property: map[string]property{
+			propertyLength: {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: 1,
+				},
+			},
+			propertyPrototype: {
+				mode: 0,
+				value: Value{
+					kind:  valueObject,
+					value: rt.global.EvalErrorPrototype,
+				},
+			},
+		},
+		propertyOrder: []string{
+			propertyLength,
+			propertyPrototype,
+		},
+	}
+	rt.global.EvalErrorPrototype.property[propertyConstructor] = property{
+		mode: 0o101,
+		value: Value{
+			kind:  valueObject,
+			value: rt.global.EvalError,
+		},
+	}
+	rt.global.TypeErrorPrototype = &object{
+		runtime:     rt,
+		class:       classTypeErrorName,
+		objectClass: classObject,
+		prototype:   rt.global.ErrorPrototype,
+		extensible:  true,
+		value:       nil,
+		property: map[string]property{
+			"name": {
+				mode: 0o101,
+				value: Value{
+					kind:  valueString,
+					value: classTypeErrorName,
+				},
+			},
+		},
+		propertyOrder: []string{
+			"name",
+		},
+	}
+	rt.global.TypeError = &object{
+		runtime:     rt,
+		class:       classFunctionName,
+		objectClass: classObject,
+		prototype:   rt.global.FunctionPrototype,
+		extensible:  true,
+		value: nativeFunctionObject{
+			name:      classTypeErrorName,
+			call:      builtinTypeError,
+			construct: builtinNewTypeError,
+		},
+		property: map[string]property{
+			propertyLength: {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: 1,
+				},
+			},
+			propertyPrototype: {
+				mode: 0,
+				value: Value{
+					kind:  valueObject,
+					value: rt.global.TypeErrorPrototype,
+				},
+			},
+		},
+		propertyOrder: []string{
+			propertyLength,
+			propertyPrototype,
+		},
+	}
+	rt.global.TypeErrorPrototype.property[propertyConstructor] = property{
+		mode: 0o101,
+		value: Value{
+			kind:  valueObject,
+			value: rt.global.TypeError,
+		},
+	}
+	rt.global.RangeErrorPrototype = &object{
+		runtime:     rt,
+		class:       classRangeErrorName,
+		objectClass: classObject,
+		prototype:   rt.global.ErrorPrototype,
+		extensible:  true,
+		value:       nil,
+		property: map[string]property{
+			"name": {
+				mode: 0o101,
+				value: Value{
+					kind:  valueString,
+					value: classRangeErrorName,
+				},
+			},
+		},
+		propertyOrder: []string{
+			"name",
+		},
+	}
+	rt.global.RangeError = &object{
+		runtime:     rt,
+		class:       classFunctionName,
+		objectClass: classObject,
+		prototype:   rt.global.FunctionPrototype,
+		extensible:  true,
+		value: nativeFunctionObject{
+			name:      classRangeErrorName,
+			call:      builtinRangeError,
+			construct: builtinNewRangeError,
+		},
+		property: map[string]property{
+			propertyLength: {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: 1,
+				},
+			},
+			propertyPrototype: {
+				mode: 0,
+				value: Value{
+					kind:  valueObject,
+					value: rt.global.RangeErrorPrototype,
+				},
+			},
+		},
+		propertyOrder: []string{
+			propertyLength,
+			propertyPrototype,
+		},
+	}
+	rt.global.RangeErrorPrototype.property[propertyConstructor] = property{
+		mode: 0o101,
+		value: Value{
+			kind:  valueObject,
+			value: rt.global.RangeError,
+		},
+	}
+	rt.global.ReferenceErrorPrototype = &object{
+		runtime:     rt,
+		class:       classReferenceErrorName,
+		objectClass: classObject,
+		prototype:   rt.global.ErrorPrototype,
+		extensible:  true,
+		value:       nil,
+		property: map[string]property{
+			"name": {
+				mode: 0o101,
+				value: Value{
+					kind:  valueString,
+					value: classReferenceErrorName,
+				},
+			},
+		},
+		propertyOrder: []string{
+			"name",
+		},
+	}
+	rt.global.ReferenceError = &object{
+		runtime:     rt,
+		class:       classFunctionName,
+		objectClass: classObject,
+		prototype:   rt.global.FunctionPrototype,
+		extensible:  true,
+		value: nativeFunctionObject{
+			name:      classReferenceErrorName,
+			call:      builtinReferenceError,
+			construct: builtinNewReferenceError,
+		},
+		property: map[string]property{
+			propertyLength: {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: 1,
+				},
+			},
+			propertyPrototype: {
+				mode: 0,
+				value: Value{
+					kind:  valueObject,
+					value: rt.global.ReferenceErrorPrototype,
+				},
+			},
+		},
+		propertyOrder: []string{
+			propertyLength,
+			propertyPrototype,
+		},
+	}
+	rt.global.ReferenceErrorPrototype.property[propertyConstructor] = property{
+		mode: 0o101,
+		value: Value{
+			kind:  valueObject,
+			value: rt.global.ReferenceError,
+		},
+	}
+	rt.global.SyntaxErrorPrototype = &object{
+		runtime:     rt,
+		class:       classSyntaxErrorName,
+		objectClass: classObject,
+		prototype:   rt.global.ErrorPrototype,
+		extensible:  true,
+		value:       nil,
+		property: map[string]property{
+			"name": {
+				mode: 0o101,
+				value: Value{
+					kind:  valueString,
+					value: classSyntaxErrorName,
+				},
+			},
+		},
+		propertyOrder: []string{
+			"name",
+		},
+	}
+	rt.global.SyntaxError = &object{
+		runtime:     rt,
+		class:       classFunctionName,
+		objectClass: classObject,
+		prototype:   rt.global.FunctionPrototype,
+		extensible:  true,
+		value: nativeFunctionObject{
+			name:      classSyntaxErrorName,
+			call:      builtinSyntaxError,
+			construct: builtinNewSyntaxError,
+		},
+		property: map[string]property{
+			propertyLength: {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: 1,
+				},
+			},
+			propertyPrototype: {
+				mode: 0,
+				value: Value{
+					kind:  valueObject,
+					value: rt.global.SyntaxErrorPrototype,
+				},
+			},
+		},
+		propertyOrder: []string{
+			propertyLength,
+			propertyPrototype,
+		},
+	}
+	rt.global.SyntaxErrorPrototype.property[propertyConstructor] = property{
+		mode: 0o101,
+		value: Value{
+			kind:  valueObject,
+			value: rt.global.SyntaxError,
+		},
+	}
+	rt.global.URIErrorPrototype = &object{
+		runtime:     rt,
+		class:       classURIErrorName,
+		objectClass: classObject,
+		prototype:   rt.global.ErrorPrototype,
+		extensible:  true,
+		value:       nil,
+		property: map[string]property{
+			"name": {
+				mode: 0o101,
+				value: Value{
+					kind:  valueString,
+					value: classURIErrorName,
+				},
+			},
+		},
+		propertyOrder: []string{
+			"name",
+		},
+	}
+	rt.global.URIError = &object{
+		runtime:     rt,
+		class:       classFunctionName,
+		objectClass: classObject,
+		prototype:   rt.global.FunctionPrototype,
+		extensible:  true,
+		value: nativeFunctionObject{
+			name:      classURIErrorName,
+			call:      builtinURIError,
+			construct: builtinNewURIError,
+		},
+		property: map[string]property{
+			propertyLength: {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: 1,
+				},
+			},
+			propertyPrototype: {
+				mode: 0,
+				value: Value{
+					kind:  valueObject,
+					value: rt.global.URIErrorPrototype,
+				},
+			},
+		},
+		propertyOrder: []string{
+			propertyLength,
+			propertyPrototype,
+		},
+	}
+	rt.global.URIErrorPrototype.property[propertyConstructor] = property{
+		mode: 0o101,
+		value: Value{
+			kind:  valueObject,
+			value: rt.global.URIError,
+		},
+	}
+	rt.global.JSON = &object{
+		runtime:     rt,
+		class:       classJSONName,
+		objectClass: classObject,
+		prototype:   rt.global.ObjectPrototype,
+		extensible:  true,
+		property: map[string]property{
+			"parse": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 2,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "parse",
+							call: builtinJSONParse,
+						},
+					},
+				},
+			},
+			"stringify": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 3,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "stringify",
+							call: builtinJSONStringify,
+						},
+					},
+				},
+			},
+		},
+		propertyOrder: []string{
+			"parse",
+			"stringify",
+		},
+	}
+	rt.globalObject.property = map[string]property{
+		"eval": {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 1,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: "eval",
+						call: builtinGlobalEval,
+					},
+				},
+			},
+		},
+		"parseInt": {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 2,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: "parseInt",
+						call: builtinGlobalParseInt,
+					},
+				},
+			},
+		},
+		"parseFloat": {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 1,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: "parseFloat",
+						call: builtinGlobalParseFloat,
+					},
+				},
+			},
+		},
+		"isNaN": {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 1,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: "isNaN",
+						call: builtinGlobalIsNaN,
+					},
+				},
+			},
+		},
+		"isFinite": {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 1,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: "isFinite",
+						call: builtinGlobalIsFinite,
+					},
+				},
+			},
+		},
+		"decodeURI": {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 1,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: "decodeURI",
+						call: builtinGlobalDecodeURI,
+					},
+				},
+			},
+		},
+		"decodeURIComponent": {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 1,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: "decodeURIComponent",
+						call: builtinGlobalDecodeURIComponent,
+					},
+				},
+			},
+		},
+		"encodeURI": {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 1,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: "encodeURI",
+						call: builtinGlobalEncodeURI,
+					},
+				},
+			},
+		},
+		"encodeURIComponent": {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 1,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: "encodeURIComponent",
+						call: builtinGlobalEncodeURIComponent,
+					},
+				},
+			},
+		},
+		"escape": {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 1,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: "escape",
+						call: builtinGlobalEscape,
+					},
+				},
+			},
+		},
+		"unescape": {
+			mode: 0o101,
+			value: Value{
+				kind: valueObject,
+				value: &object{
+					runtime:     rt,
+					class:       classFunctionName,
+					objectClass: classObject,
+					prototype:   rt.global.FunctionPrototype,
+					extensible:  true,
+					property: map[string]property{
+						propertyLength: {
+							mode: 0,
+							value: Value{
+								kind:  valueNumber,
+								value: 1,
+							},
+						},
+					},
+					propertyOrder: []string{
+						propertyLength,
+					},
+					value: nativeFunctionObject{
+						name: "unescape",
+						call: builtinGlobalUnescape,
+					},
+				},
+			},
+		},
+		classObjectName: {
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.Object,
+			},
+		},
+		classFunctionName: {
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.Function,
+			},
+		},
+		classArrayName: {
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.Array,
+			},
+		},
+		classStringName: {
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.String,
+			},
+		},
+		classBooleanName: {
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.Boolean,
+			},
+		},
+		classNumberName: {
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.Number,
+			},
+		},
+		classMathName: {
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.Math,
+			},
+		},
+		classDateName: {
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.Date,
+			},
+		},
+		classRegExpName: {
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.RegExp,
+			},
+		},
+		classErrorName: {
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.Error,
+			},
+		},
+		classEvalErrorName: {
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.EvalError,
+			},
+		},
+		classTypeErrorName: {
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.TypeError,
+			},
+		},
+		classRangeErrorName: {
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.RangeError,
+			},
+		},
+		classReferenceErrorName: {
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.ReferenceError,
+			},
+		},
+		classSyntaxErrorName: {
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.SyntaxError,
+			},
+		},
+		classURIErrorName: {
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.URIError,
+			},
+		},
+		classJSONName: {
+			mode: 0o101,
+			value: Value{
+				kind:  valueObject,
+				value: rt.global.JSON,
+			},
+		},
+		"undefined": {
+			mode: 0,
+			value: Value{
+				kind: valueUndefined,
+			},
+		},
+		"NaN": {
+			mode: 0,
+			value: Value{
+				kind:  valueNumber,
+				value: math.NaN(),
+			},
+		},
+		"Infinity": {
+			mode: 0,
+			value: Value{
+				kind:  valueNumber,
+				value: math.Inf(+1),
+			},
+		},
+	}
+	rt.globalObject.propertyOrder = []string{
+		"eval",
+		"parseInt",
+		"parseFloat",
+		"isNaN",
+		"isFinite",
+		"decodeURI",
+		"decodeURIComponent",
+		"encodeURI",
+		"encodeURIComponent",
+		"escape",
+		"unescape",
+		classObjectName,
+		classFunctionName,
+		classArrayName,
+		classStringName,
+		classBooleanName,
+		classNumberName,
+		classMathName,
+		classDateName,
+		classRegExpName,
+		classErrorName,
+		classEvalErrorName,
+		classTypeErrorName,
+		classRangeErrorName,
+		classReferenceErrorName,
+		classSyntaxErrorName,
+		classURIErrorName,
+		classJSONName,
+		"undefined",
+		"NaN",
+		"Infinity",
 	}
 }
 
-func newConsoleObject(rt *runtime) *object {
-	{
-		log := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
+func (rt *runtime) newConsole() *object {
+	return &object{
+		runtime:     rt,
+		class:       classObjectName,
+		objectClass: classObject,
+		prototype:   rt.global.ObjectPrototype,
+		extensible:  true,
+		property: map[string]property{
+			"log": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "log",
+							call: builtinConsoleLog,
+						},
 					},
 				},
 			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "log",
-				call: builtinConsoleLog,
-			},
-		}
-		debug := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
+			"debug": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "debug",
+							call: builtinConsoleLog,
+						},
 					},
 				},
 			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "debug",
-				call: builtinConsoleLog,
-			},
-		}
-		info := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
+			"info": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "info",
+							call: builtinConsoleLog,
+						},
 					},
 				},
 			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "info",
-				call: builtinConsoleLog,
-			},
-		}
-		errorObj := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
+			"error": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "error",
+							call: builtinConsoleError,
+						},
 					},
 				},
 			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "error",
-				call: builtinConsoleError,
-			},
-		}
-		warn := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
+			"warn": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "warn",
+							call: builtinConsoleError,
+						},
 					},
 				},
 			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "warn",
-				call: builtinConsoleError,
-			},
-		}
-		dir := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
+			"dir": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "dir",
+							call: builtinConsoleDir,
+						},
 					},
 				},
 			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "dir",
-				call: builtinConsoleDir,
-			},
-		}
-		time := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
+			"time": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "time",
+							call: builtinConsoleTime,
+						},
 					},
 				},
 			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "time",
-				call: builtinConsoleTime,
-			},
-		}
-		timeEnd := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
+			"timeEnd": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "timeEnd",
+							call: builtinConsoleTimeEnd,
+						},
 					},
 				},
 			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "timeEnd",
-				call: builtinConsoleTimeEnd,
-			},
-		}
-		trace := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
+			"trace": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "trace",
+							call: builtinConsoleTrace,
+						},
 					},
 				},
 			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "trace",
-				call: builtinConsoleTrace,
-			},
-		}
-		assert := &object{
-			runtime:     rt,
-			class:       classFunctionName,
-			objectClass: classObject,
-			prototype:   rt.global.FunctionPrototype,
-			extensible:  true,
-			property: map[string]property{
-				propertyLength: {
-					mode: 0,
-					value: Value{
-						kind:  valueNumber,
-						value: 0,
+			"assert": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+						},
+						value: nativeFunctionObject{
+							name: "assert",
+							call: builtinConsoleAssert,
+						},
 					},
 				},
 			},
-			propertyOrder: []string{
-				propertyLength,
-			},
-			value: nativeFunctionObject{
-				name: "assert",
-				call: builtinConsoleAssert,
-			},
-		}
-		return &object{
-			runtime:     rt,
-			class:       classObjectName,
-			objectClass: classObject,
-			prototype:   rt.global.ObjectPrototype,
-			extensible:  true,
-			property: map[string]property{
-				"log": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: log,
-					},
-				},
-				"debug": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: debug,
-					},
-				},
-				"info": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: info,
-					},
-				},
-				"error": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: errorObj,
-					},
-				},
-				"warn": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: warn,
-					},
-				},
-				"dir": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: dir,
-					},
-				},
-				"time": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: time,
-					},
-				},
-				"timeEnd": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: timeEnd,
-					},
-				},
-				"trace": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: trace,
-					},
-				},
-				"assert": {
-					mode: 0o101,
-					value: Value{
-						kind:  valueObject,
-						value: assert,
-					},
-				},
-			},
-			propertyOrder: []string{
-				"log",
-				"debug",
-				"info",
-				"error",
-				"warn",
-				"dir",
-				"time",
-				"timeEnd",
-				"trace",
-				"assert",
-			},
-		}
+		},
+		propertyOrder: []string{
+			"log",
+			"debug",
+			"info",
+			"error",
+			"warn",
+			"dir",
+			"time",
+			"timeEnd",
+			"trace",
+			"assert",
+		},
 	}
 }
 
 func intValue(value int) Value {
+	return Value{
+		kind:  valueNumber,
+		value: value,
+	}
+}
+
+func int8Value(value int8) Value {
+	return Value{
+		kind:  valueNumber,
+		value: value,
+	}
+}
+
+func int16Value(value int16) Value {
 	return Value{
 		kind:  valueNumber,
 		value: value,
@@ -6571,6 +6368,20 @@ func int64Value(value int64) Value {
 	}
 }
 
+func uintValue(value uint) Value {
+	return Value{
+		kind:  valueNumber,
+		value: value,
+	}
+}
+
+func uint8Value(value uint8) Value {
+	return Value{
+		kind:  valueNumber,
+		value: value,
+	}
+}
+
 func uint16Value(value uint16) Value {
 	return Value{
 		kind:  valueNumber,
@@ -6579,6 +6390,20 @@ func uint16Value(value uint16) Value {
 }
 
 func uint32Value(value uint32) Value {
+	return Value{
+		kind:  valueNumber,
+		value: value,
+	}
+}
+
+func uint64Value(value uint64) Value {
+	return Value{
+		kind:  valueNumber,
+		value: value,
+	}
+}
+
+func float32Value(value float32) Value {
 	return Value{
 		kind:  valueNumber,
 		value: value,

--- a/inline.go
+++ b/inline.go
@@ -6340,20 +6340,6 @@ func intValue(value int) Value {
 	}
 }
 
-func int8Value(value int8) Value {
-	return Value{
-		kind:  valueNumber,
-		value: value,
-	}
-}
-
-func int16Value(value int16) Value {
-	return Value{
-		kind:  valueNumber,
-		value: value,
-	}
-}
-
 func int32Value(value int32) Value {
 	return Value{
 		kind:  valueNumber,
@@ -6368,20 +6354,6 @@ func int64Value(value int64) Value {
 	}
 }
 
-func uintValue(value uint) Value {
-	return Value{
-		kind:  valueNumber,
-		value: value,
-	}
-}
-
-func uint8Value(value uint8) Value {
-	return Value{
-		kind:  valueNumber,
-		value: value,
-	}
-}
-
 func uint16Value(value uint16) Value {
 	return Value{
 		kind:  valueNumber,
@@ -6390,20 +6362,6 @@ func uint16Value(value uint16) Value {
 }
 
 func uint32Value(value uint32) Value {
-	return Value{
-		kind:  valueNumber,
-		value: value,
-	}
-}
-
-func uint64Value(value uint64) Value {
-	return Value{
-		kind:  valueNumber,
-		value: value,
-	}
-}
-
-func float32Value(value float32) Value {
 	return Value{
 		kind:  valueNumber,
 		value: value,

--- a/inline.pl
+++ b/inline.pl
@@ -29,11 +29,11 @@ import (
     "math"
 )
 
-func _newContext(runtime *_runtime) {
+func _newContext(rt *_runtime) {
 @{[ join "\n", $self->newContext() ]}
 }
 
-func newConsoleObject(runtime *_runtime) *_object {
+func newConsoleObject(rt *_runtime) *_object {
 @{[ join "\n", $self->newConsoleObject() ]}
 }
 _END_
@@ -643,9 +643,9 @@ sub newContext {
             my $propertyOrder = $self->propertyOrder(@propertyMap);
             $propertyOrder =~ s/^propertyOrder: //;
             return
-            "runtime.globalObject.property =",
+            "rt.globalObject.property =",
             @propertyMap,
-            "runtime.globalObject.propertyOrder =",
+            "rt.globalObject.propertyOrder =",
             $propertyOrder,
             ;
         }),
@@ -667,7 +667,7 @@ sub block {
     while (@input) {
         local $_ = shift @input;
         if (m/^\./) {
-            $_ = "runtime.global$_";
+            $_ = "rt.global$_";
         }
         if (m/ :?=$/) {
             $_ .= shift @input;
@@ -713,7 +713,7 @@ sub globalDeclare {
     my @got;
     while (@_) {
         my $name = shift;
-        push @got, $self->property($name, $self->objectValue("runtime.global.$name"), "0101"),
+        push @got, $self->property($name, $self->objectValue("rt.global.$name"), "0101"),
     }
     return @got;
 }
@@ -741,10 +741,10 @@ sub globalObject {
 
     return trim <<_END_;
 &_object{
-    runtime: runtime,
+    runtime: rt,
     class: "$name",
     objectClass: _classObject,
-    prototype: runtime.global.ObjectPrototype,
+    prototype: rt.global.ObjectPrototype,
     extensible: true,
     $propertyMap
 }
@@ -758,7 +758,7 @@ sub globalFunction {
 
     my $builtin = "builtin${name}";
     my $builtinNew = "builtinNew${name}";
-    my $prototype = "runtime.global.${name}Prototype";
+    my $prototype = "rt.global.${name}Prototype";
     my $propertyMap = "";
     unshift @_,
         $self->property("length", $self->numberValue($length), "0"),
@@ -773,15 +773,15 @@ sub globalFunction {
 
     push @postblock, $self->statement(
         "$prototype.property[\"constructor\"] =",
-        $self->property(undef, $self->objectValue("runtime.global.${name}"), "0101"),
+        $self->property(undef, $self->objectValue("rt.global.${name}"), "0101"),
     );
 
     return trim <<_END_;
 &_object{
-    runtime: runtime,
+    runtime: rt,
     class: "Function",
     objectClass: _classObject,
-    prototype: runtime.global.FunctionPrototype,
+    prototype: rt.global.FunctionPrototype,
     extensible: true,
     value: @{[ $self->nativeFunctionOf($name, $builtin, $builtinNew) ]},
     $propertyMap
@@ -814,7 +814,7 @@ sub globalPrototype {
     }
 
     if ($prototype =~ m/^\./) {
-        $prototype = "runtime.global$prototype";
+        $prototype = "rt.global$prototype";
     }
 
     my $propertyMap = "";
@@ -826,7 +826,7 @@ sub globalPrototype {
 
     return trim <<_END_;
 &_object{
-    runtime: runtime,
+    runtime: rt,
     class: "$class",
     objectClass: $classObject,
     prototype: $prototype,
@@ -867,10 +867,10 @@ sub newFunction {
     push @preblock, $self->statement(
         "$label := @{[ trim <<_END_ ]}",
 &_object{
-    runtime: runtime,
+    runtime: rt,
     class: "Function",
     objectClass: _classObject,
-    prototype: runtime.global.FunctionPrototype,
+    prototype: rt.global.FunctionPrototype,
     extensible: true,
     property: @{[ join "\n", $self->propertyMap(@propertyMap) ]},
     $propertyOrder
@@ -890,10 +890,10 @@ sub newObject {
 
     return trim <<_END_;
 &_object{
-    runtime: runtime,
+    runtime: rt,
     class: "Object",
     objectClass: _classObject,
-    prototype: runtime.global.ObjectPrototype,
+    prototype: rt.global.ObjectPrototype,
     extensible: true,
     property: $propertyMap,
     $propertyOrder,
@@ -915,10 +915,10 @@ sub newPrototypeObject {
 
     return trim <<_END_;
 &_object{
-    runtime: runtime,
+    runtime: rt,
     class: "$class",
     objectClass: $objectClass,
-    prototype: runtime.global.ObjectPrototype,
+    prototype: rt.global.ObjectPrototype,
     extensible: true,
     property: $propertyMap,
     $propertyOrder,

--- a/inline.pl
+++ b/inline.pl
@@ -48,7 +48,7 @@ func (rt *runtime) newConsole() *object {
 }
 _END_
 
-for (qw/int int8 int16 int32 int64 uint uint8 uint16 uint32 uint64 float32 float64/) {
+for (qw/int int32 int64 uint16 uint32 float64/) {
     $fmt->print(<<_END_);
 
 func ${_}Value(value $_) Value {

--- a/issue_test.go
+++ b/issue_test.go
@@ -31,7 +31,7 @@ func Test_issue262(t *testing.T) {
 		// 11.13.1-1-1
 		test(`raise:
             eval("42 = 42;");
-        `, "ReferenceError: Invalid left-hand side in assignment")
+        `, "SyntaxError: (anonymous): Line 1:1 invalid left-hand side in assignment")
 	})
 }
 
@@ -84,7 +84,8 @@ func Test_issue13(t *testing.T) {
 			},
 		}
 
-		vm.Set("anything", anything)
+		err = vm.Set("anything", anything)
+		require.NoError(t, err)
 		test(`
             [
                 anything,
@@ -138,7 +139,7 @@ func Test_issue16(t *testing.T) {
 func Test_issue21(t *testing.T) {
 	tt(t, func() {
 		vm1 := New()
-		vm1.Run(`
+		_, err := vm1.Run(`
             abc = {}
             abc.ghi = "Nothing happens.";
             var jkl = 0;
@@ -147,11 +148,13 @@ func Test_issue21(t *testing.T) {
                 return 1;
             }
         `)
+		require.NoError(t, err)
 		abc, err := vm1.Get("abc")
-		is(err, nil)
+		require.NoError(t, err)
 
 		vm2 := New()
-		vm2.Set("cba", abc)
+		err = vm2.Set("cba", abc)
+		require.NoError(t, err)
 		_, err = vm2.Run(`
             var pqr = 0;
             cba.mno = function() {
@@ -162,10 +165,10 @@ func Test_issue21(t *testing.T) {
             cba.def();
             cba.def();
         `)
-		is(err, nil)
+		require.NoError(t, err)
 
 		jkl, err := vm1.Get("jkl")
-		is(err, nil)
+		require.NoError(t, err)
 		is(jkl, 3)
 
 		_, err = vm1.Run(`
@@ -173,10 +176,10 @@ func Test_issue21(t *testing.T) {
             abc.mno();
             abc.mno();
         `)
-		is(err, nil)
+		require.NoError(t, err)
 
 		pqr, err := vm2.Get("pqr")
-		is(err, nil)
+		require.NoError(t, err)
 		is(pqr, -3)
 	})
 }
@@ -188,7 +191,7 @@ func Test_issue24(t *testing.T) {
 		{
 			vm.Set("abc", []string{"abc", "def", "ghi"})
 			value, err := vm.Get("abc")
-			is(err, nil)
+			require.NoError(t, err)
 			export, _ := value.Export()
 			{
 				value, valid := export.([]string)
@@ -202,7 +205,7 @@ func Test_issue24(t *testing.T) {
 		{
 			vm.Set("abc", [...]string{"abc", "def", "ghi"})
 			value, err := vm.Get("abc")
-			is(err, nil)
+			require.NoError(t, err)
 			export, _ := value.Export()
 			{
 				value, valid := export.([3]string)
@@ -216,7 +219,7 @@ func Test_issue24(t *testing.T) {
 		{
 			vm.Set("abc", &[...]string{"abc", "def", "ghi"})
 			value, err := vm.Get("abc")
-			is(err, nil)
+			require.NoError(t, err)
 			export, _ := value.Export()
 			{
 				value, valid := export.(*[3]string)
@@ -230,7 +233,7 @@ func Test_issue24(t *testing.T) {
 		{
 			vm.Set("abc", map[int]string{0: "abc", 1: "def", 2: "ghi"})
 			value, err := vm.Get("abc")
-			is(err, nil)
+			require.NoError(t, err)
 			export, _ := value.Export()
 			{
 				value, valid := export.(map[int]string)
@@ -242,12 +245,12 @@ func Test_issue24(t *testing.T) {
 		}
 
 		{
-			vm.Set("abc", _abcStruct{Abc: true, Ghi: "Nothing happens."})
+			vm.Set("abc", abcStruct{Abc: true, Ghi: "Nothing happens."})
 			value, err := vm.Get("abc")
-			is(err, nil)
+			require.NoError(t, err)
 			export, _ := value.Export()
 			{
-				value, valid := export.(_abcStruct)
+				value, valid := export.(abcStruct)
 				is(valid, true)
 
 				is(value.Abc, true)
@@ -256,12 +259,12 @@ func Test_issue24(t *testing.T) {
 		}
 
 		{
-			vm.Set("abc", &_abcStruct{Abc: true, Ghi: "Nothing happens."})
+			vm.Set("abc", &abcStruct{Abc: true, Ghi: "Nothing happens."})
 			value, err := vm.Get("abc")
-			is(err, nil)
+			require.NoError(t, err)
 			export, _ := value.Export()
 			{
-				value, valid := export.(*_abcStruct)
+				value, valid := export.(*abcStruct)
 				is(valid, true)
 
 				is(value.Abc, true)
@@ -360,7 +363,7 @@ func Test_S7_3_A2_1_T1(t *testing.T) {
 
 		test(`raise:
             eval("'\u000Astr\u000Aing\u000A'")
-        `, "SyntaxError: Unexpected token ILLEGAL")
+        `, "SyntaxError: (anonymous): Line 1:1 Unexpected token ILLEGAL")
 	})
 }
 
@@ -470,12 +473,12 @@ def"
             while (true) {
                 eval("continue abc");
             }
-        `, "SyntaxError: Undefined label 'abc'")
+        `, "SyntaxError: (anonymous): Line 1:1 Undefined label 'abc'")
 
 		// S15.1.2.1_A3.3_T3
 		test(`raise:
             eval("return");
-        `, "SyntaxError: Illegal return statement")
+        `, "SyntaxError: (anonymous): Line 1:1 Illegal return statement")
 
 		// 15.2.3.3-2-33
 		test(`
@@ -486,7 +489,7 @@ def"
 		// S15.3_A2_T1
 		test(`raise:
             Function.call(this, "var x / = 1;");
-        `, "SyntaxError: Unexpected token /")
+        `, "SyntaxError: (anonymous): Line 2:7 Unexpected token / (and 3 more errors)")
 
 		// ?
 		test(`
@@ -530,7 +533,7 @@ func Test_issue79(t *testing.T) {
 	tt(t, func() {
 		test, vm := test()
 
-		vm.Set("abc", []_abcStruct{
+		vm.Set("abc", []abcStruct{
 			{
 				Ghi: "一",
 				Def: 1,
@@ -634,7 +637,7 @@ d[e>>>5]|=128<<24-e%32;d[(e+64>>>9<<4)+14]=h.floor(b/4294967296);d[(e+64>>>9<<4)
 (function(){var h=CryptoJS,s=h.enc.Utf8;h.algo.HMAC=h.lib.Base.extend({init:function(f,g){f=this._hasher=new f.init;"string"==typeof g&&(g=s.parse(g));var h=f.blockSize,m=4*h;g.sigBytes>m&&(g=f.finalize(g));g.clamp();for(var r=this._oKey=g.clone(),l=this._iKey=g.clone(),k=r.words,n=l.words,j=0;j<h;j++)k[j]^=1549556828,n[j]^=909522486;r.sigBytes=l.sigBytes=m;this.reset()},reset:function(){var f=this._hasher;f.reset();f.update(this._iKey)},update:function(f){this._hasher.update(f);return this},finalize:function(f){var g=
 this._hasher;f=g.finalize(f);g.reset();return g.finalize(this._oKey.clone().concat(f))}})})();
         `)
-		is(err, nil)
+		require.NoError(t, err)
 
 		test(`CryptoJS.HmacSHA256("Message", "secret");`, "aa747c502a898200f9e4fa21bac68136f886a0e27aec70ba06daf2e2a5cb5597")
 	})
@@ -725,12 +728,14 @@ func Test_issue186(t *testing.T) {
 	}
 
 	vm := New()
-	vm.Set("abc", func(a string, b string, c string) int {
+	err := vm.Set("abc", func(a string, b string, c string) int {
 		return 1
 	})
-	vm.Set("num", func(a int, b int, c int) int {
+	require.NoError(t, err)
+	err = vm.Set("num", func(a int, b int, c int) int {
 		return 1
 	})
+	require.NoError(t, err)
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -866,7 +871,8 @@ func Test_issue390(t *testing.T) {
 	require.NoError(t, err)
 
 	vm := New()
-	vm.Set("db", db)
+	err = vm.Set("db", db)
+	require.NoError(t, err)
 	val, err := vm.Run(`
 		db.Exec("CREATE TABLE log (message)")
 		var results = db.Exec("INSERT INTO log(message) VALUES(?)", "test123");
@@ -931,10 +937,11 @@ func Test_issue386(t *testing.T) {
 
 func Test_issue383(t *testing.T) {
 	vm := New()
-	vm.Set("panicFunc", func(call FunctionCall) Value {
+	err := vm.Set("panicFunc", func(call FunctionCall) Value {
 		panic("test")
 	})
-	_, err := vm.Run(`
+	require.NoError(t, err)
+	_, err = vm.Run(`
 		try {
 			panicFunc()
 		} catch (err) {

--- a/json_test.go
+++ b/json_test.go
@@ -2,15 +2,21 @@ package otto
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkJSON_parse(b *testing.B) {
 	vm := New()
 	for i := 0; i < b.N; i++ {
-		vm.Run(`JSON.parse("1")`)
-		vm.Run(`JSON.parse("[1,2,3]")`)
-		vm.Run(`JSON.parse('{"a":{"x":100,"y":110},"b":[10,20,30],"c":"zazazaza"}')`)
-		vm.Run(`JSON.parse("[1,2,3]", function(k, v) { return undefined })`)
+		_, err := vm.Run(`JSON.parse("1")`)
+		require.NoError(b, err)
+		_, err = vm.Run(`JSON.parse("[1,2,3]")`)
+		require.NoError(b, err)
+		_, err = vm.Run(`JSON.parse('{"a":{"x":100,"y":110},"b":[10,20,30],"c":"zazazaza"}')`)
+		require.NoError(b, err)
+		_, err = vm.Run(`JSON.parse("[1,2,3]", function(k, v) { return undefined })`)
+		require.NoError(b, err)
 	}
 }
 

--- a/locale.go
+++ b/locale.go
@@ -2,6 +2,4 @@ package otto
 
 import "golang.org/x/text/language"
 
-var (
-	defaultLanguage = language.MustParse("en-US")
-)
+var defaultLanguage = language.MustParse("en-US")

--- a/math_test.go
+++ b/math_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 )
 
-var _NaN = math.NaN()
-var _Infinity = math.Inf(1)
+var (
+	naN      = math.NaN()
+	infinity = math.Inf(1)
+)
 
 func TestMath_toString(t *testing.T) {
 	tt(t, func() {
@@ -20,18 +22,18 @@ func TestMath_abs(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()
 
-		test(`Math.abs(NaN)`, _NaN)
+		test(`Math.abs(NaN)`, naN)
 		test(`Math.abs(2)`, 2)
 		test(`Math.abs(-2)`, 2)
-		test(`Math.abs(-Infinity)`, _Infinity)
+		test(`Math.abs(-Infinity)`, infinity)
 
 		test(`Math.acos(0.5)`, 1.0471975511965976)
 
 		test(`Math.abs('-1')`, 1)
 		test(`Math.abs(-2)`, 2)
 		test(`Math.abs(null)`, 0)
-		test(`Math.abs("string")`, _NaN)
-		test(`Math.abs()`, _NaN)
+		test(`Math.abs("string")`, naN)
+		test(`Math.abs()`, naN)
 	})
 }
 
@@ -39,10 +41,10 @@ func TestMath_acos(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()
 
-		test(`Math.acos(NaN)`, _NaN)
-		test(`Math.acos(2)`, _NaN)
-		test(`Math.acos(-2)`, _NaN)
-		test(`1/Math.acos(1)`, _Infinity)
+		test(`Math.acos(NaN)`, naN)
+		test(`Math.acos(2)`, naN)
+		test(`Math.acos(-2)`, naN)
+		test(`1/Math.acos(1)`, infinity)
 
 		test(`Math.acos(0.5)`, 1.0471975511965976)
 	})
@@ -52,11 +54,11 @@ func TestMath_asin(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()
 
-		test(`Math.asin(NaN)`, _NaN)
-		test(`Math.asin(2)`, _NaN)
-		test(`Math.asin(-2)`, _NaN)
-		test(`1/Math.asin(0)`, _Infinity)
-		test(`1/Math.asin(-0)`, -_Infinity)
+		test(`Math.asin(NaN)`, naN)
+		test(`Math.asin(2)`, naN)
+		test(`Math.asin(-2)`, naN)
+		test(`1/Math.asin(0)`, infinity)
+		test(`1/Math.asin(-0)`, -infinity)
 
 		test(`Math.asin(0.5)`, 0.5235987755982989)
 	})
@@ -66,9 +68,9 @@ func TestMath_atan(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()
 
-		test(`Math.atan(NaN)`, _NaN)
-		test(`1/Math.atan(0)`, _Infinity)
-		test(`1/Math.atan(-0)`, -_Infinity)
+		test(`Math.atan(NaN)`, naN)
+		test(`1/Math.atan(0)`, infinity)
+		test(`1/Math.atan(-0)`, -infinity)
 		test(`Math.atan(Infinity)`, 1.5707963267948966)
 		test(`Math.atan(-Infinity)`, -1.5707963267948966)
 
@@ -82,29 +84,29 @@ func TestMath_atan2(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()
 
-		test(`Math.atan2()`, _NaN)
-		test(`Math.atan2(NaN)`, _NaN)
-		test(`Math.atan2(0, NaN)`, _NaN)
+		test(`Math.atan2()`, naN)
+		test(`Math.atan2(NaN)`, naN)
+		test(`Math.atan2(0, NaN)`, naN)
 
 		test(`Math.atan2(1, 0)`, 1.5707963267948966)
 		test(`Math.atan2(1, -0)`, 1.5707963267948966)
 
-		test(`1/Math.atan2(0, 1)`, _Infinity)
-		test(`1/Math.atan2(0, 0)`, _Infinity)
+		test(`1/Math.atan2(0, 1)`, infinity)
+		test(`1/Math.atan2(0, 0)`, infinity)
 		test(`Math.atan2(0, -0)`, 3.141592653589793)
 		test(`Math.atan2(0, -1)`, 3.141592653589793)
 
-		test(`1/Math.atan2(-0, 1)`, -_Infinity)
-		test(`1/Math.atan2(-0, 0)`, -_Infinity)
+		test(`1/Math.atan2(-0, 1)`, -infinity)
+		test(`1/Math.atan2(-0, 0)`, -infinity)
 		test(`Math.atan2(-0, -0)`, -3.141592653589793)
 		test(`Math.atan2(-0, -1)`, -3.141592653589793)
 
 		test(`Math.atan2(-1, 0)`, -1.5707963267948966)
 		test(`Math.atan2(-1, -0)`, -1.5707963267948966)
 
-		test(`1/Math.atan2(1, Infinity)`, _Infinity)
+		test(`1/Math.atan2(1, Infinity)`, infinity)
 		test(`Math.atan2(1, -Infinity)`, 3.141592653589793)
-		test(`1/Math.atan2(-1, Infinity)`, -_Infinity)
+		test(`1/Math.atan2(-1, Infinity)`, -infinity)
 		test(`Math.atan2(-1, -Infinity)`, -3.141592653589793)
 
 		test(`Math.atan2(Infinity, 1)`, 1.5707963267948966)
@@ -121,12 +123,12 @@ func TestMath_ceil(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()
 
-		test(`Math.ceil(NaN)`, _NaN)
+		test(`Math.ceil(NaN)`, naN)
 		test(`Math.ceil(+0)`, 0)
-		test(`1/Math.ceil(-0)`, -_Infinity)
-		test(`Math.ceil(Infinity)`, _Infinity)
-		test(`Math.ceil(-Infinity)`, -_Infinity)
-		test(`1/Math.ceil(-0.5)`, -_Infinity)
+		test(`1/Math.ceil(-0)`, -infinity)
+		test(`Math.ceil(Infinity)`, infinity)
+		test(`Math.ceil(-Infinity)`, -infinity)
+		test(`1/Math.ceil(-0.5)`, -infinity)
 
 		test(`Math.ceil(-11)`, -11)
 		test(`Math.ceil(-0.5)`, 0)
@@ -138,11 +140,11 @@ func TestMath_cos(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()
 
-		test(`Math.cos(NaN)`, _NaN)
+		test(`Math.cos(NaN)`, naN)
 		test(`Math.cos(+0)`, 1)
 		test(`Math.cos(-0)`, 1)
-		test(`Math.cos(Infinity)`, _NaN)
-		test(`Math.cos(-Infinity)`, _NaN)
+		test(`Math.cos(Infinity)`, naN)
+		test(`Math.cos(-Infinity)`, naN)
 
 		test(`Math.cos(0.5)`, 0.8775825618903728)
 	})
@@ -152,10 +154,10 @@ func TestMath_exp(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()
 
-		test(`Math.exp(NaN)`, _NaN)
+		test(`Math.exp(NaN)`, naN)
 		test(`Math.exp(+0)`, 1)
 		test(`Math.exp(-0)`, 1)
-		test(`Math.exp(Infinity)`, _Infinity)
+		test(`Math.exp(Infinity)`, infinity)
 		test(`Math.exp(-Infinity)`, 0)
 	})
 }
@@ -164,11 +166,11 @@ func TestMath_floor(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()
 
-		test(`Math.floor(NaN)`, _NaN)
+		test(`Math.floor(NaN)`, naN)
 		test(`Math.floor(+0)`, 0)
-		test(`1/Math.floor(-0)`, -_Infinity)
-		test(`Math.floor(Infinity)`, _Infinity)
-		test(`Math.floor(-Infinity)`, -_Infinity)
+		test(`1/Math.floor(-0)`, -infinity)
+		test(`Math.floor(Infinity)`, infinity)
+		test(`Math.floor(-Infinity)`, -infinity)
 
 		test(`Math.floor(-11)`, -11)
 		test(`Math.floor(-0.5)`, -1)
@@ -180,12 +182,12 @@ func TestMath_log(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()
 
-		test(`Math.log(NaN)`, _NaN)
-		test(`Math.log(-1)`, _NaN)
-		test(`Math.log(+0)`, -_Infinity)
-		test(`Math.log(-0)`, -_Infinity)
-		test(`1/Math.log(1)`, _Infinity)
-		test(`Math.log(Infinity)`, _Infinity)
+		test(`Math.log(NaN)`, naN)
+		test(`Math.log(-1)`, naN)
+		test(`Math.log(+0)`, -infinity)
+		test(`Math.log(-0)`, -infinity)
+		test(`1/Math.log(1)`, infinity)
+		test(`Math.log(Infinity)`, infinity)
 
 		test(`Math.log(0.5)`, -0.6931471805599453)
 	})
@@ -211,31 +213,31 @@ func TestMath_pow(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()
 
-		test(`Math.pow(0, NaN)`, _NaN)
+		test(`Math.pow(0, NaN)`, naN)
 		test(`Math.pow(0, 0)`, 1)
 		test(`Math.pow(NaN, 0)`, 1)
 		test(`Math.pow(0, -0)`, 1)
 		test(`Math.pow(NaN, -0)`, 1)
-		test(`Math.pow(NaN, 1)`, _NaN)
-		test(`Math.pow(2, Infinity)`, _Infinity)
-		test(`1/Math.pow(2, -Infinity)`, _Infinity)
-		test(`Math.pow(1, Infinity)`, _NaN)
-		test(`Math.pow(1, -Infinity)`, _NaN)
-		test(`1/Math.pow(0.1, Infinity)`, _Infinity)
-		test(`Math.pow(0.1, -Infinity)`, _Infinity)
-		test(`Math.pow(Infinity, 1)`, _Infinity)
-		test(`1/Math.pow(Infinity, -1)`, _Infinity)
-		test(`Math.pow(-Infinity, 1)`, -_Infinity)
-		test(`Math.pow(-Infinity, 2)`, _Infinity)
-		test(`1/Math.pow(-Infinity, -1)`, -_Infinity)
-		test(`1/Math.pow(-Infinity, -2)`, _Infinity)
-		test(`1/Math.pow(0, 1)`, _Infinity)
-		test(`Math.pow(0, -1)`, _Infinity)
-		test(`1/Math.pow(-0, 1)`, -_Infinity)
-		test(`1/Math.pow(-0, 2)`, _Infinity)
-		test(`Math.pow(-0, -1)`, -_Infinity)
-		test(`Math.pow(-0, -2)`, _Infinity)
-		test(`Math.pow(-1, 0.1)`, _NaN)
+		test(`Math.pow(NaN, 1)`, naN)
+		test(`Math.pow(2, Infinity)`, infinity)
+		test(`1/Math.pow(2, -Infinity)`, infinity)
+		test(`Math.pow(1, Infinity)`, naN)
+		test(`Math.pow(1, -Infinity)`, naN)
+		test(`1/Math.pow(0.1, Infinity)`, infinity)
+		test(`Math.pow(0.1, -Infinity)`, infinity)
+		test(`Math.pow(Infinity, 1)`, infinity)
+		test(`1/Math.pow(Infinity, -1)`, infinity)
+		test(`Math.pow(-Infinity, 1)`, -infinity)
+		test(`Math.pow(-Infinity, 2)`, infinity)
+		test(`1/Math.pow(-Infinity, -1)`, -infinity)
+		test(`1/Math.pow(-Infinity, -2)`, infinity)
+		test(`1/Math.pow(0, 1)`, infinity)
+		test(`Math.pow(0, -1)`, infinity)
+		test(`1/Math.pow(-0, 1)`, -infinity)
+		test(`1/Math.pow(-0, 2)`, infinity)
+		test(`Math.pow(-0, -1)`, -infinity)
+		test(`Math.pow(-0, -2)`, infinity)
+		test(`Math.pow(-1, 0.1)`, naN)
 
 		test(`
             [ Math.pow(-1, +Infinity), Math.pow(1, Infinity) ];
@@ -247,13 +249,13 @@ func TestMath_round(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()
 
-		test(`Math.round(NaN)`, _NaN)
-		test(`1/Math.round(0)`, _Infinity)
-		test(`1/Math.round(-0)`, -_Infinity)
-		test(`Math.round(Infinity)`, _Infinity)
-		test(`Math.round(-Infinity)`, -_Infinity)
-		test(`1/Math.round(0.1)`, _Infinity)
-		test(`1/Math.round(-0.1)`, -_Infinity)
+		test(`Math.round(NaN)`, naN)
+		test(`1/Math.round(0)`, infinity)
+		test(`1/Math.round(-0)`, -infinity)
+		test(`Math.round(Infinity)`, infinity)
+		test(`Math.round(-Infinity)`, -infinity)
+		test(`1/Math.round(0.1)`, infinity)
+		test(`1/Math.round(-0.1)`, -infinity)
 
 		test(`Math.round(3.5)`, 4)
 		test(`Math.round(-3.5)`, -3)
@@ -264,11 +266,11 @@ func TestMath_sin(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()
 
-		test(`Math.sin(NaN)`, _NaN)
-		test(`1/Math.sin(+0)`, _Infinity)
-		test(`1/Math.sin(-0)`, -_Infinity)
-		test(`Math.sin(Infinity)`, _NaN)
-		test(`Math.sin(-Infinity)`, _NaN)
+		test(`Math.sin(NaN)`, naN)
+		test(`1/Math.sin(+0)`, infinity)
+		test(`1/Math.sin(-0)`, -infinity)
+		test(`Math.sin(Infinity)`, naN)
+		test(`Math.sin(-Infinity)`, naN)
 
 		test(`Math.sin(0.5)`, 0.479425538604203)
 	})
@@ -278,11 +280,11 @@ func TestMath_sqrt(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()
 
-		test(`Math.sqrt(NaN)`, _NaN)
-		test(`Math.sqrt(-1)`, _NaN)
-		test(`1/Math.sqrt(+0)`, _Infinity)
-		test(`1/Math.sqrt(-0)`, -_Infinity)
-		test(`Math.sqrt(Infinity)`, _Infinity)
+		test(`Math.sqrt(NaN)`, naN)
+		test(`Math.sqrt(-1)`, naN)
+		test(`1/Math.sqrt(+0)`, infinity)
+		test(`1/Math.sqrt(-0)`, -infinity)
+		test(`Math.sqrt(Infinity)`, infinity)
 
 		test(`Math.sqrt(2)`, 1.4142135623730951)
 	})
@@ -292,11 +294,11 @@ func TestMath_tan(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()
 
-		test(`Math.tan(NaN)`, _NaN)
-		test(`1/Math.tan(+0)`, _Infinity)
-		test(`1/Math.tan(-0)`, -_Infinity)
-		test(`Math.tan(Infinity)`, _NaN)
-		test(`Math.tan(-Infinity)`, _NaN)
+		test(`Math.tan(NaN)`, naN)
+		test(`1/Math.tan(+0)`, infinity)
+		test(`1/Math.tan(-0)`, -infinity)
+		test(`Math.tan(Infinity)`, naN)
+		test(`Math.tan(-Infinity)`, naN)
 
 		test(`Math.tan(0.5)`, 0.5463024898437905)
 	})

--- a/native_stack_test.go
+++ b/native_stack_test.go
@@ -14,7 +14,7 @@ func TestNativeStackFrames(t *testing.T) {
 			function A() { ext1(); }
 			function B() { ext2(); }
 			A();
-    	`)
+		`)
 		require.NoError(t, err)
 
 		err = vm.Set("ext1", func(c FunctionCall) Value {

--- a/native_stack_test.go
+++ b/native_stack_test.go
@@ -2,6 +2,8 @@ package otto
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNativeStackFrames(t *testing.T) {
@@ -9,37 +11,36 @@ func TestNativeStackFrames(t *testing.T) {
 		vm := New()
 
 		s, err := vm.Compile("input.js", `
-      function A() { ext1(); }
-      function B() { ext2(); }
-      A();
-    `)
-		if err != nil {
-			panic(err)
-		}
+			function A() { ext1(); }
+			function B() { ext2(); }
+			A();
+    	`)
+		require.NoError(t, err)
 
-		vm.Set("ext1", func(c FunctionCall) Value {
+		err = vm.Set("ext1", func(c FunctionCall) Value {
 			if _, err := c.Otto.Eval("B()"); err != nil {
 				panic(err)
 			}
 
 			return UndefinedValue()
 		})
+		require.NoError(t, err)
 
-		vm.Set("ext2", func(c FunctionCall) Value {
+		err = vm.Set("ext2", func(c FunctionCall) Value {
 			{
 				// no limit, include innermost native frames
 				ctx := c.Otto.ContextSkip(-1, false)
 
 				is(ctx.Stacktrace, []string{
-					"github.com/robertkrimen/otto.TestNativeStackFrames.func1.2 (native_stack_test.go:28)",
-					"B (input.js:3:22)",
+					"github.com/robertkrimen/otto.TestNativeStackFrames.func1.2 (native_stack_test.go:29)",
+					"B (input.js:3:19)",
 					"github.com/robertkrimen/otto.TestNativeStackFrames.func1.1 (native_stack_test.go:20)",
-					"A (input.js:2:22)", "input.js:4:7",
+					"A (input.js:2:19)", "input.js:4:4",
 				})
 
 				is(ctx.Callee, "github.com/robertkrimen/otto.TestNativeStackFrames.func1.2")
 				is(ctx.Filename, "native_stack_test.go")
-				is(ctx.Line, 28)
+				is(ctx.Line, 29)
 				is(ctx.Column, 0)
 			}
 
@@ -48,15 +49,15 @@ func TestNativeStackFrames(t *testing.T) {
 				ctx := c.Otto.ContextSkip(-1, true)
 
 				is(ctx.Stacktrace, []string{
-					"B (input.js:3:22)",
+					"B (input.js:3:19)",
 					"github.com/robertkrimen/otto.TestNativeStackFrames.func1.1 (native_stack_test.go:20)",
-					"A (input.js:2:22)", "input.js:4:7",
+					"A (input.js:2:19)", "input.js:4:4",
 				})
 
 				is(ctx.Callee, "B")
 				is(ctx.Filename, "input.js")
 				is(ctx.Line, 3)
-				is(ctx.Column, 22)
+				is(ctx.Column, 19)
 			}
 
 			if _, err := c.Otto.Eval("ext3()"); err != nil {
@@ -65,23 +66,24 @@ func TestNativeStackFrames(t *testing.T) {
 
 			return UndefinedValue()
 		})
+		require.NoError(t, err)
 
-		vm.Set("ext3", func(c FunctionCall) Value {
+		err = vm.Set("ext3", func(c FunctionCall) Value {
 			{
 				// no limit, include innermost native frames
 				ctx := c.Otto.ContextSkip(-1, false)
 
 				is(ctx.Stacktrace, []string{
-					"github.com/robertkrimen/otto.TestNativeStackFrames.func1.3 (native_stack_test.go:69)",
-					"github.com/robertkrimen/otto.TestNativeStackFrames.func1.2 (native_stack_test.go:28)",
-					"B (input.js:3:22)",
+					"github.com/robertkrimen/otto.TestNativeStackFrames.func1.3 (native_stack_test.go:71)",
+					"github.com/robertkrimen/otto.TestNativeStackFrames.func1.2 (native_stack_test.go:29)",
+					"B (input.js:3:19)",
 					"github.com/robertkrimen/otto.TestNativeStackFrames.func1.1 (native_stack_test.go:20)",
-					"A (input.js:2:22)", "input.js:4:7",
+					"A (input.js:2:19)", "input.js:4:4",
 				})
 
 				is(ctx.Callee, "github.com/robertkrimen/otto.TestNativeStackFrames.func1.3")
 				is(ctx.Filename, "native_stack_test.go")
-				is(ctx.Line, 69)
+				is(ctx.Line, 71)
 				is(ctx.Column, 0)
 			}
 
@@ -90,22 +92,22 @@ func TestNativeStackFrames(t *testing.T) {
 				ctx := c.Otto.ContextSkip(-1, true)
 
 				is(ctx.Stacktrace, []string{
-					"B (input.js:3:22)",
+					"B (input.js:3:19)",
 					"github.com/robertkrimen/otto.TestNativeStackFrames.func1.1 (native_stack_test.go:20)",
-					"A (input.js:2:22)", "input.js:4:7",
+					"A (input.js:2:19)", "input.js:4:4",
 				})
 
 				is(ctx.Callee, "B")
 				is(ctx.Filename, "input.js")
 				is(ctx.Line, 3)
-				is(ctx.Column, 22)
+				is(ctx.Column, 19)
 			}
 
 			return UndefinedValue()
 		})
+		require.NoError(t, err)
 
-		if _, err := vm.Run(s); err != nil {
-			panic(err)
-		}
+		_, err = vm.Run(s)
+		require.NoError(t, err)
 	})
 }

--- a/object_test.go
+++ b/object_test.go
@@ -8,11 +8,11 @@ func TestObject_(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()
 
-		object := newObject(nil, "")
-		is(object != nil, true)
+		obj := newObject(nil, "")
+		is(obj != nil, true)
 
-		object.put("xyzzy", toValue("Nothing happens."), true)
-		is(object.get("xyzzy"), "Nothing happens.")
+		obj.put("xyzzy", toValue("Nothing happens."), true)
+		is(obj.get("xyzzy"), "Nothing happens.")
 
 		test(`
             var abc = Object.getOwnPropertyDescriptor(Object, "prototype");
@@ -24,10 +24,10 @@ func TestObject_(t *testing.T) {
 
 func TestStringObject(t *testing.T) {
 	tt(t, func() {
-		object := New().runtime.newStringObject(toValue("xyzzy"))
-		is(object.get("1"), "y")
-		is(object.get("10"), "undefined")
-		is(object.get("2"), "z")
+		obj := New().runtime.newStringObject(toValue("xyzzy"))
+		is(obj.get("1"), "y")
+		is(obj.get("10"), "undefined")
+		is(obj.get("2"), "z")
 	})
 }
 
@@ -623,17 +623,17 @@ func TestObjectGetterSetter(t *testing.T) {
 
 func TestProperty(t *testing.T) {
 	tt(t, func() {
-		property := _property{}
-		property.writeOn()
-		is(property.writeSet(), true)
+		prop := property{}
+		prop.writeOn()
+		is(prop.writeSet(), true)
 
-		property.writeClear()
-		is(property.writeSet(), false)
+		prop.writeClear()
+		is(prop.writeSet(), false)
 
-		property.writeOff()
-		is(property.writeSet(), true)
+		prop.writeOff()
+		is(prop.writeSet(), true)
 
-		property.writeClear()
-		is(property.writeSet(), false)
+		prop.writeClear()
+		is(prop.writeSet(), false)
 	})
 }

--- a/otto_.go
+++ b/otto_.go
@@ -3,28 +3,28 @@ package otto
 import (
 	"fmt"
 	"regexp"
-	runtime_ "runtime"
+	goruntime "runtime"
 	"strconv"
 )
 
-var isIdentifier_Regexp *regexp.Regexp = regexp.MustCompile(`^[a-zA-Z\$][a-zA-Z0-9\$]*$`)
+var isIdentifierRegexp *regexp.Regexp = regexp.MustCompile(`^[a-zA-Z\$][a-zA-Z0-9\$]*$`)
 
-func isIdentifier(string_ string) bool {
-	return isIdentifier_Regexp.MatchString(string_)
+func isIdentifier(value string) bool {
+	return isIdentifierRegexp.MatchString(value)
 }
 
-func (self *_runtime) toValueArray(arguments ...interface{}) []Value {
+func (rt *runtime) toValueArray(arguments ...interface{}) []Value {
 	length := len(arguments)
 	if length == 1 {
 		if valueArray, ok := arguments[0].([]Value); ok {
 			return valueArray
 		}
-		return []Value{self.toValue(arguments[0])}
+		return []Value{rt.toValue(arguments[0])}
 	}
 
 	valueArray := make([]Value, length)
 	for index, value := range arguments {
-		valueArray[index] = self.toValue(value)
+		valueArray[index] = rt.toValue(value)
 	}
 
 	return valueArray
@@ -89,15 +89,13 @@ func valueToRangeIndex(indexValue Value, length int64, negativeIsZero bool) int6
 		if index < 0 {
 			index = 0
 		}
-	} else {
-		if index > length {
-			index = length
-		}
+	} else if index > length {
+		index = length
 	}
 	return index
 }
 
-func rangeStartEnd(array []Value, size int64, negativeIsZero bool) (start, end int64) {
+func rangeStartEnd(array []Value, size int64, negativeIsZero bool) (start, end int64) { //nolint: nonamedreturns
 	start = valueToRangeIndex(valueOfArrayIndex(array, 0), size, negativeIsZero)
 	if len(array) == 1 {
 		// If there is only the start argument, then end = size
@@ -115,14 +113,14 @@ func rangeStartEnd(array []Value, size int64, negativeIsZero bool) (start, end i
 	return
 }
 
-func rangeStartLength(source []Value, size int64) (start, length int64) {
+func rangeStartLength(source []Value, size int64) (start, length int64) { //nolint: nonamedreturns
 	start = valueToRangeIndex(valueOfArrayIndex(source, 0), size, false)
 
 	// Assume the second argument is missing or undefined
-	length = int64(size)
+	length = size
 	if len(source) == 1 {
 		// If there is only the start argument, then length = size
-		return
+		return start, length
 	}
 
 	lengthValue := valueOfArrayIndex(source, 1)
@@ -130,12 +128,12 @@ func rangeStartLength(source []Value, size int64) (start, length int64) {
 		// Which it is not, so get the value as an array index
 		length = lengthValue.number().int64
 	}
-	return
+	return start, length
 }
 
 func hereBeDragons(arguments ...interface{}) string {
-	pc, _, _, _ := runtime_.Caller(1) //nolint: dogsled
-	name := runtime_.FuncForPC(pc).Name()
+	pc, _, _, _ := goruntime.Caller(1) //nolint: dogsled
+	name := goruntime.FuncForPC(pc).Name()
 	message := fmt.Sprintf("Here be dragons -- %s", name)
 	if len(arguments) > 0 {
 		message += ": "

--- a/parser/comments_test.go
+++ b/parser/comments_test.go
@@ -22,10 +22,10 @@ func checkComments(actual []*ast.Comment, expected []string, position ast.Commen
 
 	for i, v := range comments {
 		if v.Text != expected[i] {
-			return fmt.Errorf("comments do not match. \"%v\" != \"%v\"\n", v.Text, expected[i])
+			return fmt.Errorf("comments do not match: %q != %q", v.Text, expected[i])
 		}
 		if v.Position != position {
-			return fmt.Errorf("the comment is not %v, was %v\n", position, v.Position)
+			return fmt.Errorf("comment positions do not match: %d != %d", position, v.Position)
 		}
 	}
 
@@ -33,11 +33,11 @@ func checkComments(actual []*ast.Comment, expected []string, position ast.Commen
 }
 
 func displayComments(m ast.CommentMap) {
-	fmt.Printf("Displaying comments:\n")
+	fmt.Printf("Displaying comments:\n") //nolint: forbidigo
 	for n, comments := range m {
-		fmt.Printf("%v %v:\n", reflect.TypeOf(n), n)
+		fmt.Printf("%v %v:\n", reflect.TypeOf(n), n) //nolint: forbidigo
 		for i, comment := range comments {
-			fmt.Printf(" [%v] %v @ %v\n", i, comment.Text, comment.Position)
+			fmt.Printf(" [%v] %v @ %v\n", i, comment.Text, comment.Position) //nolint: forbidigo
 		}
 	}
 }
@@ -49,7 +49,7 @@ func TestParser_comments(t *testing.T) {
 			is(firstErr(err), chk)
 
 			// Check unresolved comments
-			//is(len(parser.comments), 0)
+
 			return parser, program
 		}
 
@@ -1436,7 +1436,7 @@ func TestParser_comments2(t *testing.T) {
 a = /*comment1*/new /*comment2*/ obj/*comment3*/()
 `, nil)
 		n := program.Body[0]
-		fmt.Printf("FOUND NODE: %v, number of comments: %v\n", reflect.TypeOf(n), len(parser.comments.CommentMap[n]))
+		fmt.Printf("FOUND NODE: %v, number of comments: %v\n", reflect.TypeOf(n), len(parser.comments.CommentMap[n])) //nolint: forbidigo
 		displayComments(parser.comments.CommentMap)
 	})
 }

--- a/parser/error.go
+++ b/parser/error.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	err_UnexpectedToken      = "Unexpected token %v"
-	err_UnexpectedEndOfInput = "Unexpected end of input"
+	errUnexpectedToken      = "Unexpected token %v"
+	errUnexpectedEndOfInput = "Unexpected end of input"
 )
 
 //    UnexpectedNumber:  'Unexpected number',
@@ -20,7 +20,7 @@ const (
 //    NewlineAfterThrow:  'Illegal newline after throw',
 //    InvalidRegExp: 'Invalid regular expression',
 //    UnterminatedRegExp:  'Invalid regular expression: missing /',
-//    InvalidLHSInAssignment:  'Invalid left-hand side in assignment',
+//    InvalidLHSInAssignment:  'invalid left-hand side in assignment',
 //    InvalidLHSInForIn:  'Invalid left-hand side in for-in',
 //    MultipleDefaultsInSwitch: 'More than one default clause in switch statement',
 //    NoCatchOrFinally:  'Missing catch or finally after try',
@@ -55,27 +55,27 @@ type Error struct {
 
 // FIXME Should this be "SyntaxError"?
 
-func (self Error) Error() string {
-	filename := self.Position.Filename
+func (e Error) Error() string {
+	filename := e.Position.Filename
 	if filename == "" {
 		filename = "(anonymous)"
 	}
 	return fmt.Sprintf("%s: Line %d:%d %s",
 		filename,
-		self.Position.Line,
-		self.Position.Column,
-		self.Message,
+		e.Position.Line,
+		e.Position.Column,
+		e.Message,
 	)
 }
 
-func (self *_parser) error(place interface{}, msg string, msgValues ...interface{}) *Error {
+func (p *_parser) error(place interface{}, msg string, msgValues ...interface{}) {
 	var idx file.Idx
 	switch place := place.(type) {
 	case int:
-		idx = self.idxOf(place)
+		idx = p.idxOf(place)
 	case file.Idx:
 		if place == 0 {
-			idx = self.idxOf(self.chrOffset)
+			idx = p.idxOf(p.chrOffset)
 		} else {
 			idx = place
 		}
@@ -83,57 +83,69 @@ func (self *_parser) error(place interface{}, msg string, msgValues ...interface
 		panic(fmt.Errorf("error(%T, ...)", place))
 	}
 
-	position := self.position(idx)
+	position := p.position(idx)
 	msg = fmt.Sprintf(msg, msgValues...)
-	self.errors.Add(position, msg)
-	return self.errors[len(self.errors)-1]
+	p.errors.Add(position, msg)
 }
 
-func (self *_parser) errorUnexpected(idx file.Idx, chr rune) error {
+func (p *_parser) errorUnexpected(idx file.Idx, chr rune) {
 	if chr == -1 {
-		return self.error(idx, err_UnexpectedEndOfInput)
+		p.error(idx, errUnexpectedEndOfInput)
+		return
 	}
-	return self.error(idx, err_UnexpectedToken, token.ILLEGAL)
+	p.error(idx, errUnexpectedToken, token.ILLEGAL)
 }
 
-func (self *_parser) errorUnexpectedToken(tkn token.Token) error {
-	switch tkn {
-	case token.EOF:
-		return self.error(file.Idx(0), err_UnexpectedEndOfInput)
+func (p *_parser) errorUnexpectedToken(tkn token.Token) {
+	if tkn == token.EOF {
+		p.error(file.Idx(0), errUnexpectedEndOfInput)
+		return
 	}
 	value := tkn.String()
 	switch tkn {
 	case token.BOOLEAN, token.NULL:
-		value = self.literal
+		p.error(p.idx, errUnexpectedToken, p.literal)
 	case token.IDENTIFIER:
-		return self.error(self.idx, "Unexpected identifier")
+		p.error(p.idx, "Unexpected identifier")
 	case token.KEYWORD:
 		// TODO Might be a future reserved word
-		return self.error(self.idx, "Unexpected reserved word")
+		p.error(p.idx, "Unexpected reserved word")
 	case token.NUMBER:
-		return self.error(self.idx, "Unexpected number")
+		p.error(p.idx, "Unexpected number")
 	case token.STRING:
-		return self.error(self.idx, "Unexpected string")
+		p.error(p.idx, "Unexpected string")
+	default:
+		p.error(p.idx, errUnexpectedToken, value)
 	}
-	return self.error(self.idx, err_UnexpectedToken, value)
 }
 
 // ErrorList is a list of *Errors.
 type ErrorList []*Error //nolint: errname
 
 // Add adds an Error with given position and message to an ErrorList.
-func (self *ErrorList) Add(position file.Position, msg string) {
-	*self = append(*self, &Error{position, msg})
+func (el *ErrorList) Add(position file.Position, msg string) {
+	*el = append(*el, &Error{position, msg})
 }
 
 // Reset resets an ErrorList to no errors.
-func (self *ErrorList) Reset() { *self = (*self)[0:0] }
+func (el *ErrorList) Reset() {
+	*el = (*el)[0:0]
+}
 
-func (self ErrorList) Len() int      { return len(self) }
-func (self ErrorList) Swap(i, j int) { self[i], self[j] = self[j], self[i] }
-func (self ErrorList) Less(i, j int) bool {
-	x := &self[i].Position
-	y := &self[j].Position
+// Len implement sort.Interface.
+func (el *ErrorList) Len() int {
+	return len(*el)
+}
+
+// Swap implement sort.Interface.
+func (el *ErrorList) Swap(i, j int) {
+	(*el)[i], (*el)[j] = (*el)[j], (*el)[i]
+}
+
+// Less implement sort.Interface.
+func (el *ErrorList) Less(i, j int) bool {
+	x := (*el)[i].Position
+	y := (*el)[j].Position
 	if x.Filename < y.Filename {
 		return true
 	}
@@ -148,26 +160,28 @@ func (self ErrorList) Less(i, j int) bool {
 	return false
 }
 
-func (self ErrorList) Sort() {
-	sort.Sort(self)
+// Sort sorts el.
+func (el *ErrorList) Sort() {
+	sort.Sort(el)
 }
 
 // Error implements the Error interface.
-func (self ErrorList) Error() string {
-	switch len(self) {
+func (el *ErrorList) Error() string {
+	switch len(*el) {
 	case 0:
 		return "no errors"
 	case 1:
-		return self[0].Error()
+		return (*el)[0].Error()
+	default:
+		return fmt.Sprintf("%s (and %d more errors)", (*el)[0].Error(), len(*el)-1)
 	}
-	return fmt.Sprintf("%s (and %d more errors)", self[0].Error(), len(self)-1)
 }
 
 // Err returns an error equivalent to this ErrorList.
 // If the list is empty, Err returns nil.
-func (self ErrorList) Err() error {
-	if len(self) == 0 {
+func (el *ErrorList) Err() error {
+	if len(*el) == 0 {
 		return nil
 	}
-	return self
+	return el
 }

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -15,7 +15,7 @@ import (
 	"github.com/robertkrimen/otto/token"
 )
 
-type _chr struct {
+type chr struct { //nolint: unused
 	value rune
 	width int
 }
@@ -55,49 +55,50 @@ func isIdentifierPart(chr rune) bool {
 		chr >= utf8.RuneSelf && (unicode.IsLetter(chr) || unicode.IsDigit(chr))
 }
 
-func (self *_parser) scanIdentifier() (string, error) {
-	offset := self.chrOffset
+func (p *_parser) scanIdentifier() (string, error) {
+	offset := p.chrOffset
 	parse := false
-	for isIdentifierPart(self.chr) {
-		if self.chr == '\\' {
-			distance := self.chrOffset - offset
-			self.read()
-			if self.chr != 'u' {
-				return "", fmt.Errorf("Invalid identifier escape character: %c (%s)", self.chr, string(self.chr))
+	for isIdentifierPart(p.chr) {
+		if p.chr == '\\' {
+			distance := p.chrOffset - offset
+			p.read()
+			if p.chr != 'u' {
+				return "", fmt.Errorf("invalid identifier escape character: %c (%s)", p.chr, string(p.chr))
 			}
 			parse = true
 			var value rune
 			for j := 0; j < 4; j++ {
-				self.read()
-				decimal, ok := hex2decimal(byte(self.chr))
+				p.read()
+				decimal, ok := hex2decimal(byte(p.chr))
 				if !ok {
-					return "", fmt.Errorf("Invalid identifier escape character: %c (%s)", self.chr, string(self.chr))
+					return "", fmt.Errorf("invalid identifier escape character: %c (%s)", p.chr, string(p.chr))
 				}
 				value = value<<4 | decimal
 			}
-			if value == '\\' {
-				return "", fmt.Errorf("Invalid identifier escape value: %c (%s)", value, string(value))
-			} else if distance == 0 {
+			switch {
+			case value == '\\':
+				return "", fmt.Errorf("invalid identifier escape value: %c (%s)", value, string(value))
+			case distance == 0:
 				if !isIdentifierStart(value) {
-					return "", fmt.Errorf("Invalid identifier escape value: %c (%s)", value, string(value))
+					return "", fmt.Errorf("invalid identifier escape value: %c (%s)", value, string(value))
 				}
-			} else if distance > 0 {
+			case distance > 0:
 				if !isIdentifierPart(value) {
-					return "", fmt.Errorf("Invalid identifier escape value: %c (%s)", value, string(value))
+					return "", fmt.Errorf("invalid identifier escape value: %c (%s)", value, string(value))
 				}
 			}
 		}
-		self.read()
+		p.read()
 	}
-	literal := string(self.str[offset:self.chrOffset])
+	literal := p.str[offset:p.chrOffset]
 	if parse {
 		return parseStringLiteral(literal)
 	}
 	return literal, nil
 }
 
-// 7.2
-func isLineWhiteSpace(chr rune) bool {
+// 7.2.
+func isLineWhiteSpace(chr rune) bool { //nolint: unused, deadcode
 	switch chr {
 	case '\u0009', '\u000b', '\u000c', '\u0020', '\u00a0', '\ufeff':
 		return true
@@ -109,7 +110,7 @@ func isLineWhiteSpace(chr rune) bool {
 	return unicode.IsSpace(chr)
 }
 
-// 7.3
+// 7.3.
 func isLineTerminator(chr rune) bool {
 	switch chr {
 	case '\u000a', '\u000d', '\u2028', '\u2029':
@@ -118,19 +119,19 @@ func isLineTerminator(chr rune) bool {
 	return false
 }
 
-func (self *_parser) scan() (tkn token.Token, literal string, idx file.Idx) {
-	self.implicitSemicolon = false
+func (p *_parser) scan() (tkn token.Token, literal string, idx file.Idx) { //nolint: nonamedreturns
+	p.implicitSemicolon = false
 
 	for {
-		self.skipWhiteSpace()
+		p.skipWhiteSpace()
 
-		idx = self.idxOf(self.chrOffset)
+		idx = p.idxOf(p.chrOffset)
 		insertSemicolon := false
 
-		switch chr := self.chr; {
+		switch chr := p.chr; {
 		case isIdentifierStart(chr):
 			var err error
-			literal, err = self.scanIdentifier()
+			literal, err = p.scanIdentifier()
 			if err != nil {
 				tkn = token.ILLEGAL
 				break
@@ -143,11 +144,11 @@ func (self *_parser) scan() (tkn token.Token, literal string, idx file.Idx) {
 				switch tkn {
 				case 0: // Not a keyword
 					if literal == "true" || literal == "false" {
-						self.insertSemicolon = true
+						p.insertSemicolon = true
 						tkn = token.BOOLEAN
 						return
 					} else if literal == "null" {
-						self.insertSemicolon = true
+						p.insertSemicolon = true
 						tkn = token.NULL
 						return
 					}
@@ -167,40 +168,40 @@ func (self *_parser) scan() (tkn token.Token, literal string, idx file.Idx) {
 					token.RETURN,
 					token.CONTINUE,
 					token.DEBUGGER:
-					self.insertSemicolon = true
+					p.insertSemicolon = true
 					return
 
 				default:
 					return
 				}
 			}
-			self.insertSemicolon = true
+			p.insertSemicolon = true
 			tkn = token.IDENTIFIER
 			return
 		case '0' <= chr && chr <= '9':
-			self.insertSemicolon = true
-			tkn, literal = self.scanNumericLiteral(false)
+			p.insertSemicolon = true
+			tkn, literal = p.scanNumericLiteral(false)
 			return
 		default:
-			self.read()
+			p.read()
 			switch chr {
 			case -1:
-				if self.insertSemicolon {
-					self.insertSemicolon = false
-					self.implicitSemicolon = true
+				if p.insertSemicolon {
+					p.insertSemicolon = false
+					p.implicitSemicolon = true
 				}
 				tkn = token.EOF
 			case '\r', '\n', '\u2028', '\u2029':
-				self.insertSemicolon = false
-				self.implicitSemicolon = true
-				self.comments.AtLineBreak()
+				p.insertSemicolon = false
+				p.implicitSemicolon = true
+				p.comments.AtLineBreak()
 				continue
 			case ':':
 				tkn = token.COLON
 			case '.':
-				if digitValue(self.chr) < 10 {
+				if digitValue(p.chr) < 10 {
 					insertSemicolon = true
-					tkn, literal = self.scanNumericLiteral(true)
+					tkn, literal = p.scanNumericLiteral(true)
 				} else {
 					tkn = token.PERIOD
 				}
@@ -224,68 +225,69 @@ func (self *_parser) scan() (tkn token.Token, literal string, idx file.Idx) {
 				tkn = token.RIGHT_BRACE
 				insertSemicolon = true
 			case '+':
-				tkn = self.switch3(token.PLUS, token.ADD_ASSIGN, '+', token.INCREMENT)
+				tkn = p.switch3(token.PLUS, token.ADD_ASSIGN, '+', token.INCREMENT)
 				if tkn == token.INCREMENT {
 					insertSemicolon = true
 				}
 			case '-':
-				tkn = self.switch3(token.MINUS, token.SUBTRACT_ASSIGN, '-', token.DECREMENT)
+				tkn = p.switch3(token.MINUS, token.SUBTRACT_ASSIGN, '-', token.DECREMENT)
 				if tkn == token.DECREMENT {
 					insertSemicolon = true
 				}
 			case '*':
-				tkn = self.switch2(token.MULTIPLY, token.MULTIPLY_ASSIGN)
+				tkn = p.switch2(token.MULTIPLY, token.MULTIPLY_ASSIGN)
 			case '/':
-				if self.chr == '/' {
-					if self.mode&StoreComments != 0 {
-						literal := string(self.readSingleLineComment())
-						self.comments.AddComment(ast.NewComment(literal, self.idx))
+				switch p.chr {
+				case '/':
+					if p.mode&StoreComments != 0 {
+						literal := string(p.readSingleLineComment())
+						p.comments.AddComment(ast.NewComment(literal, p.idx))
 						continue
 					}
-					self.skipSingleLineComment()
+					p.skipSingleLineComment()
 					continue
-				} else if self.chr == '*' {
-					if self.mode&StoreComments != 0 {
-						literal = string(self.readMultiLineComment())
-						self.comments.AddComment(ast.NewComment(literal, self.idx))
+				case '*':
+					if p.mode&StoreComments != 0 {
+						literal = string(p.readMultiLineComment())
+						p.comments.AddComment(ast.NewComment(literal, p.idx))
 						continue
 					}
-					self.skipMultiLineComment()
+					p.skipMultiLineComment()
 					continue
-				} else {
+				default:
 					// Could be division, could be RegExp literal
-					tkn = self.switch2(token.SLASH, token.QUOTIENT_ASSIGN)
+					tkn = p.switch2(token.SLASH, token.QUOTIENT_ASSIGN)
 					insertSemicolon = true
 				}
 			case '%':
-				tkn = self.switch2(token.REMAINDER, token.REMAINDER_ASSIGN)
+				tkn = p.switch2(token.REMAINDER, token.REMAINDER_ASSIGN)
 			case '^':
-				tkn = self.switch2(token.EXCLUSIVE_OR, token.EXCLUSIVE_OR_ASSIGN)
+				tkn = p.switch2(token.EXCLUSIVE_OR, token.EXCLUSIVE_OR_ASSIGN)
 			case '<':
-				tkn = self.switch4(token.LESS, token.LESS_OR_EQUAL, '<', token.SHIFT_LEFT, token.SHIFT_LEFT_ASSIGN)
+				tkn = p.switch4(token.LESS, token.LESS_OR_EQUAL, '<', token.SHIFT_LEFT, token.SHIFT_LEFT_ASSIGN)
 			case '>':
-				tkn = self.switch6(token.GREATER, token.GREATER_OR_EQUAL, '>', token.SHIFT_RIGHT, token.SHIFT_RIGHT_ASSIGN, '>', token.UNSIGNED_SHIFT_RIGHT, token.UNSIGNED_SHIFT_RIGHT_ASSIGN)
+				tkn = p.switch6(token.GREATER, token.GREATER_OR_EQUAL, '>', token.SHIFT_RIGHT, token.SHIFT_RIGHT_ASSIGN, '>', token.UNSIGNED_SHIFT_RIGHT, token.UNSIGNED_SHIFT_RIGHT_ASSIGN)
 			case '=':
-				tkn = self.switch2(token.ASSIGN, token.EQUAL)
-				if tkn == token.EQUAL && self.chr == '=' {
-					self.read()
+				tkn = p.switch2(token.ASSIGN, token.EQUAL)
+				if tkn == token.EQUAL && p.chr == '=' {
+					p.read()
 					tkn = token.STRICT_EQUAL
 				}
 			case '!':
-				tkn = self.switch2(token.NOT, token.NOT_EQUAL)
-				if tkn == token.NOT_EQUAL && self.chr == '=' {
-					self.read()
+				tkn = p.switch2(token.NOT, token.NOT_EQUAL)
+				if tkn == token.NOT_EQUAL && p.chr == '=' {
+					p.read()
 					tkn = token.STRICT_NOT_EQUAL
 				}
 			case '&':
-				if self.chr == '^' {
-					self.read()
-					tkn = self.switch2(token.AND_NOT, token.AND_NOT_ASSIGN)
+				if p.chr == '^' {
+					p.read()
+					tkn = p.switch2(token.AND_NOT, token.AND_NOT_ASSIGN)
 				} else {
-					tkn = self.switch3(token.AND, token.AND_ASSIGN, '&', token.LOGICAL_AND)
+					tkn = p.switch3(token.AND, token.AND_ASSIGN, '&', token.LOGICAL_AND)
 				}
 			case '|':
-				tkn = self.switch3(token.OR, token.OR_ASSIGN, '|', token.LOGICAL_OR)
+				tkn = p.switch3(token.OR, token.OR_ASSIGN, '|', token.LOGICAL_OR)
 			case '~':
 				tkn = token.BITWISE_NOT
 			case '?':
@@ -294,49 +296,49 @@ func (self *_parser) scan() (tkn token.Token, literal string, idx file.Idx) {
 				insertSemicolon = true
 				tkn = token.STRING
 				var err error
-				literal, err = self.scanString(self.chrOffset - 1)
+				literal, err = p.scanString(p.chrOffset - 1)
 				if err != nil {
 					tkn = token.ILLEGAL
 				}
 			default:
-				self.errorUnexpected(idx, chr)
+				p.errorUnexpected(idx, chr)
 				tkn = token.ILLEGAL
 			}
 		}
-		self.insertSemicolon = insertSemicolon
+		p.insertSemicolon = insertSemicolon
 		return
 	}
 }
 
-func (self *_parser) switch2(tkn0, tkn1 token.Token) token.Token {
-	if self.chr == '=' {
-		self.read()
+func (p *_parser) switch2(tkn0, tkn1 token.Token) token.Token {
+	if p.chr == '=' {
+		p.read()
 		return tkn1
 	}
 	return tkn0
 }
 
-func (self *_parser) switch3(tkn0, tkn1 token.Token, chr2 rune, tkn2 token.Token) token.Token {
-	if self.chr == '=' {
-		self.read()
+func (p *_parser) switch3(tkn0, tkn1 token.Token, chr2 rune, tkn2 token.Token) token.Token {
+	if p.chr == '=' {
+		p.read()
 		return tkn1
 	}
-	if self.chr == chr2 {
-		self.read()
+	if p.chr == chr2 {
+		p.read()
 		return tkn2
 	}
 	return tkn0
 }
 
-func (self *_parser) switch4(tkn0, tkn1 token.Token, chr2 rune, tkn2, tkn3 token.Token) token.Token {
-	if self.chr == '=' {
-		self.read()
+func (p *_parser) switch4(tkn0, tkn1 token.Token, chr2 rune, tkn2, tkn3 token.Token) token.Token {
+	if p.chr == '=' {
+		p.read()
 		return tkn1
 	}
-	if self.chr == chr2 {
-		self.read()
-		if self.chr == '=' {
-			self.read()
+	if p.chr == chr2 {
+		p.read()
+		if p.chr == '=' {
+			p.read()
 			return tkn3
 		}
 		return tkn2
@@ -344,21 +346,21 @@ func (self *_parser) switch4(tkn0, tkn1 token.Token, chr2 rune, tkn2, tkn3 token
 	return tkn0
 }
 
-func (self *_parser) switch6(tkn0, tkn1 token.Token, chr2 rune, tkn2, tkn3 token.Token, chr3 rune, tkn4, tkn5 token.Token) token.Token {
-	if self.chr == '=' {
-		self.read()
+func (p *_parser) switch6(tkn0, tkn1 token.Token, chr2 rune, tkn2, tkn3 token.Token, chr3 rune, tkn4, tkn5 token.Token) token.Token {
+	if p.chr == '=' {
+		p.read()
 		return tkn1
 	}
-	if self.chr == chr2 {
-		self.read()
-		if self.chr == '=' {
-			self.read()
+	if p.chr == chr2 {
+		p.read()
+		if p.chr == '=' {
+			p.read()
 			return tkn3
 		}
-		if self.chr == chr3 {
-			self.read()
-			if self.chr == '=' {
-				self.read()
+		if p.chr == chr3 {
+			p.read()
+			if p.chr == '=' {
+				p.read()
 				return tkn5
 			}
 			return tkn4
@@ -368,137 +370,137 @@ func (self *_parser) switch6(tkn0, tkn1 token.Token, chr2 rune, tkn2, tkn3 token
 	return tkn0
 }
 
-func (self *_parser) chrAt(index int) _chr {
-	value, width := utf8.DecodeRuneInString(self.str[index:])
-	return _chr{
+func (p *_parser) chrAt(index int) chr { //nolint: unused
+	value, width := utf8.DecodeRuneInString(p.str[index:])
+	return chr{
 		value: value,
 		width: width,
 	}
 }
 
-func (self *_parser) _peek() rune {
-	if self.offset+1 < self.length {
-		return rune(self.str[self.offset+1])
+func (p *_parser) peek() rune {
+	if p.offset+1 < p.length {
+		return rune(p.str[p.offset+1])
 	}
 	return -1
 }
 
-func (self *_parser) read() {
-	if self.offset < self.length {
-		self.chrOffset = self.offset
-		chr, width := rune(self.str[self.offset]), 1
+func (p *_parser) read() {
+	if p.offset < p.length {
+		p.chrOffset = p.offset
+		chr, width := rune(p.str[p.offset]), 1
 		if chr >= utf8.RuneSelf { // !ASCII
-			chr, width = utf8.DecodeRuneInString(self.str[self.offset:])
+			chr, width = utf8.DecodeRuneInString(p.str[p.offset:])
 			if chr == utf8.RuneError && width == 1 {
-				self.error(self.chrOffset, "Invalid UTF-8 character")
+				p.error(p.chrOffset, "Invalid UTF-8 character")
 			}
 		}
-		self.offset += width
-		self.chr = chr
+		p.offset += width
+		p.chr = chr
 	} else {
-		self.chrOffset = self.length
-		self.chr = -1 // EOF
+		p.chrOffset = p.length
+		p.chr = -1 // EOF
 	}
 }
 
-// This is here since the functions are so similar
-func (self *_RegExp_parser) read() {
-	if self.offset < self.length {
-		self.chrOffset = self.offset
-		chr, width := rune(self.str[self.offset]), 1
+// This is here since the functions are so similar.
+func (p *regExpParser) read() {
+	if p.offset < p.length {
+		p.chrOffset = p.offset
+		chr, width := rune(p.str[p.offset]), 1
 		if chr >= utf8.RuneSelf { // !ASCII
-			chr, width = utf8.DecodeRuneInString(self.str[self.offset:])
+			chr, width = utf8.DecodeRuneInString(p.str[p.offset:])
 			if chr == utf8.RuneError && width == 1 {
-				self.error(self.chrOffset, "Invalid UTF-8 character")
+				p.error(p.chrOffset, "Invalid UTF-8 character")
 			}
 		}
-		self.offset += width
-		self.chr = chr
+		p.offset += width
+		p.chr = chr
 	} else {
-		self.chrOffset = self.length
-		self.chr = -1 // EOF
+		p.chrOffset = p.length
+		p.chr = -1 // EOF
 	}
 }
 
-func (self *_parser) readSingleLineComment() (result []rune) {
-	for self.chr != -1 {
-		self.read()
-		if isLineTerminator(self.chr) {
-			return
+func (p *_parser) readSingleLineComment() []rune {
+	var result []rune
+	for p.chr != -1 {
+		p.read()
+		if isLineTerminator(p.chr) {
+			return result
 		}
-		result = append(result, self.chr)
+		result = append(result, p.chr)
 	}
 
 	// Get rid of the trailing -1
-	result = result[:len(result)-1]
-
-	return
+	return result[:len(result)-1]
 }
 
-func (self *_parser) readMultiLineComment() (result []rune) {
-	self.read()
-	for self.chr >= 0 {
-		chr := self.chr
-		self.read()
-		if chr == '*' && self.chr == '/' {
-			self.read()
-			return
+func (p *_parser) readMultiLineComment() []rune {
+	var result []rune
+	p.read()
+	for p.chr >= 0 {
+		chr := p.chr
+		p.read()
+		if chr == '*' && p.chr == '/' {
+			p.read()
+			return result
 		}
 
 		result = append(result, chr)
 	}
 
-	self.errorUnexpected(0, self.chr)
+	p.errorUnexpected(0, p.chr)
 
-	return
+	return result
 }
 
-func (self *_parser) skipSingleLineComment() {
-	for self.chr != -1 {
-		self.read()
-		if isLineTerminator(self.chr) {
+func (p *_parser) skipSingleLineComment() {
+	for p.chr != -1 {
+		p.read()
+		if isLineTerminator(p.chr) {
 			return
 		}
 	}
 }
 
-func (self *_parser) skipMultiLineComment() {
-	self.read()
-	for self.chr >= 0 {
-		chr := self.chr
-		self.read()
-		if chr == '*' && self.chr == '/' {
-			self.read()
+func (p *_parser) skipMultiLineComment() {
+	p.read()
+	for p.chr >= 0 {
+		chr := p.chr
+		p.read()
+		if chr == '*' && p.chr == '/' {
+			p.read()
 			return
 		}
 	}
 
-	self.errorUnexpected(0, self.chr)
+	p.errorUnexpected(0, p.chr)
 }
 
-func (self *_parser) skipWhiteSpace() {
+func (p *_parser) skipWhiteSpace() {
 	for {
-		switch self.chr {
+		switch p.chr {
 		case ' ', '\t', '\f', '\v', '\u00a0', '\ufeff':
-			self.read()
+			p.read()
 			continue
 		case '\r':
-			if self._peek() == '\n' {
-				self.comments.AtLineBreak()
-				self.read()
+			if p.peek() == '\n' {
+				p.comments.AtLineBreak()
+				p.read()
 			}
 			fallthrough
 		case '\u2028', '\u2029', '\n':
-			if self.insertSemicolon {
+			if p.insertSemicolon {
 				return
 			}
-			self.comments.AtLineBreak()
-			self.read()
+			p.comments.AtLineBreak()
+			p.read()
 			continue
 		}
-		if self.chr >= utf8.RuneSelf {
-			if unicode.IsSpace(self.chr) {
-				self.read()
+		if p.chr >= utf8.RuneSelf {
+			if unicode.IsSpace(p.chr) {
+				p.read()
 				continue
 			}
 		}
@@ -506,121 +508,114 @@ func (self *_parser) skipWhiteSpace() {
 	}
 }
 
-func (self *_parser) skipLineWhiteSpace() {
-	for isLineWhiteSpace(self.chr) {
-		self.read()
+func (p *_parser) scanMantissa(base int) {
+	for digitValue(p.chr) < base {
+		p.read()
 	}
 }
 
-func (self *_parser) scanMantissa(base int) {
-	for digitValue(self.chr) < base {
-		self.read()
-	}
-}
-
-func (self *_parser) scanEscape(quote rune) {
+func (p *_parser) scanEscape(quote rune) {
 	var length, base uint32
-	switch self.chr {
-	//case '0', '1', '2', '3', '4', '5', '6', '7':
+	switch p.chr {
 	//    Octal:
 	//    length, base, limit = 3, 8, 255
 	case 'a', 'b', 'f', 'n', 'r', 't', 'v', '\\', '"', '\'', '0':
-		self.read()
+		p.read()
 		return
 	case '\r', '\n', '\u2028', '\u2029':
-		self.scanNewline()
+		p.scanNewline()
 		return
 	case 'x':
-		self.read()
+		p.read()
 		length, base = 2, 16
 	case 'u':
-		self.read()
+		p.read()
 		length, base = 4, 16
 	default:
-		self.read() // Always make progress
+		p.read() // Always make progress
 		return
 	}
 
 	var value uint32
-	for ; length > 0 && self.chr != quote && self.chr >= 0; length-- {
-		digit := uint32(digitValue(self.chr))
+	for ; length > 0 && p.chr != quote && p.chr >= 0; length-- {
+		digit := uint32(digitValue(p.chr))
 		if digit >= base {
 			break
 		}
 		value = value*base + digit
-		self.read()
+		p.read()
 	}
 }
 
-func (self *_parser) scanString(offset int) (string, error) {
+func (p *_parser) scanString(offset int) (string, error) {
 	// " ' /
-	quote := rune(self.str[offset])
+	quote := rune(p.str[offset])
 
-	for self.chr != quote {
-		chr := self.chr
+	for p.chr != quote {
+		chr := p.chr
 		if chr == '\n' || chr == '\r' || chr == '\u2028' || chr == '\u2029' || chr < 0 {
 			goto newline
 		}
-		self.read()
-		if chr == '\\' {
+		p.read()
+		switch {
+		case chr == '\\':
 			if quote == '/' {
-				if self.chr == '\n' || self.chr == '\r' || self.chr == '\u2028' || self.chr == '\u2029' || self.chr < 0 {
+				if p.chr == '\n' || p.chr == '\r' || p.chr == '\u2028' || p.chr == '\u2029' || p.chr < 0 {
 					goto newline
 				}
-				self.read()
+				p.read()
 			} else {
-				self.scanEscape(quote)
+				p.scanEscape(quote)
 			}
-		} else if chr == '[' && quote == '/' {
+		case chr == '[' && quote == '/':
 			// Allow a slash (/) in a bracket character class ([...])
 			// TODO Fix this, this is hacky...
 			quote = -1
-		} else if chr == ']' && quote == -1 {
+		case chr == ']' && quote == -1:
 			quote = '/'
 		}
 	}
 
 	// " ' /
-	self.read()
+	p.read()
 
-	return string(self.str[offset:self.chrOffset]), nil
+	return p.str[offset:p.chrOffset], nil
 
 newline:
-	self.scanNewline()
+	p.scanNewline()
 	err := "String not terminated"
 	if quote == '/' {
 		err = "Invalid regular expression: missing /"
-		self.error(self.idxOf(offset), err)
+		p.error(p.idxOf(offset), err)
 	}
 	return "", errors.New(err)
 }
 
-func (self *_parser) scanNewline() {
-	if self.chr == '\r' {
-		self.read()
-		if self.chr != '\n' {
+func (p *_parser) scanNewline() {
+	if p.chr == '\r' {
+		p.read()
+		if p.chr != '\n' {
 			return
 		}
 	}
-	self.read()
+	p.read()
 }
 
-func hex2decimal(chr byte) (value rune, ok bool) {
-	{
-		chr := rune(chr)
-		switch {
-		case '0' <= chr && chr <= '9':
-			return chr - '0', true
-		case 'a' <= chr && chr <= 'f':
-			return chr - 'a' + 10, true
-		case 'A' <= chr && chr <= 'F':
-			return chr - 'A' + 10, true
-		}
-		return
+func hex2decimal(chr byte) (rune, bool) {
+	r := rune(chr)
+	switch {
+	case '0' <= r && r <= '9':
+		return r - '0', true
+	case 'a' <= r && r <= 'f':
+		return r - 'a' + 10, true
+	case 'A' <= r && r <= 'F':
+		return r - 'A' + 10, true
+	default:
+		return 0, false
 	}
 }
 
-func parseNumberLiteral(literal string) (value interface{}, err error) {
+func parseNumberLiteral(literal string) (value interface{}, err error) { //nolint: nonamedreturns
 	// TODO Is Uint okay? What about -MAX_UINT
 	value, err = strconv.ParseInt(literal, 0, 64)
 	if err == nil {
@@ -632,14 +627,16 @@ func parseNumberLiteral(literal string) (value interface{}, err error) {
 	value, err = strconv.ParseFloat(literal, 64)
 	if err == nil {
 		return value, nil
-	} else if err.(*strconv.NumError).Err == strconv.ErrRange {
+	} else if errors.Is(err, strconv.ErrRange) {
 		// Infinity, etc.
 		return value, nil
 	}
 
+	// TODO(steve): Fix as this is assigning to err so we know the type.
+	// Need to understand what this was trying to do?
 	err = parseIntErr
 
-	if err.(*strconv.NumError).Err == strconv.ErrRange {
+	if errors.Is(err, strconv.ErrRange) {
 		if len(literal) > 2 && literal[0] == '0' && (literal[1] == 'X' || literal[1] == 'x') {
 			// Could just be a very large number (e.g. 0x8000000000000000)
 			var value float64
@@ -647,7 +644,7 @@ func parseNumberLiteral(literal string) (value interface{}, err error) {
 			for _, chr := range literal {
 				digit := digitValue(chr)
 				if digit >= 16 {
-					return nil, errors.New("Illegal numeric literal")
+					return nil, fmt.Errorf("illegal numeric literal: %v (>= 16)", digit)
 				}
 				value = value*16 + float64(digit)
 			}
@@ -655,7 +652,7 @@ func parseNumberLiteral(literal string) (value interface{}, err error) {
 		}
 	}
 
-	return nil, errors.New("Illegal numeric literal")
+	return nil, errors.New("illegal numeric literal")
 }
 
 func parseStringLiteral(literal string) (string, error) {
@@ -783,78 +780,79 @@ func parseStringLiteral(literal string) (string, error) {
 	return buffer.String(), nil
 }
 
-func (self *_parser) scanNumericLiteral(decimalPoint bool) (token.Token, string) {
-	offset := self.chrOffset
+func (p *_parser) scanNumericLiteral(decimalPoint bool) (token.Token, string) {
+	offset := p.chrOffset
 	tkn := token.NUMBER
 
 	if decimalPoint {
 		offset--
-		self.scanMantissa(10)
+		p.scanMantissa(10)
 		goto exponent
 	}
 
-	if self.chr == '0' {
-		offset := self.chrOffset
-		self.read()
-		if self.chr == 'x' || self.chr == 'X' {
+	if p.chr == '0' {
+		offset := p.chrOffset
+		p.read()
+		switch p.chr {
+		case 'x', 'X':
 			// Hexadecimal
-			self.read()
-			if isDigit(self.chr, 16) {
-				self.read()
+			p.read()
+			if isDigit(p.chr, 16) {
+				p.read()
 			} else {
-				return token.ILLEGAL, self.str[offset:self.chrOffset]
+				return token.ILLEGAL, p.str[offset:p.chrOffset]
 			}
-			self.scanMantissa(16)
+			p.scanMantissa(16)
 
-			if self.chrOffset-offset <= 2 {
+			if p.chrOffset-offset <= 2 {
 				// Only "0x" or "0X"
-				self.error(0, "Illegal hexadecimal number")
+				p.error(0, "Illegal hexadecimal number")
 			}
 
 			goto hexadecimal
-		} else if self.chr == '.' {
+		case '.':
 			// Float
 			goto float
-		} else {
+		default:
 			// Octal, Float
-			if self.chr == 'e' || self.chr == 'E' {
+			if p.chr == 'e' || p.chr == 'E' {
 				goto exponent
 			}
-			self.scanMantissa(8)
-			if self.chr == '8' || self.chr == '9' {
-				return token.ILLEGAL, self.str[offset:self.chrOffset]
+			p.scanMantissa(8)
+			if p.chr == '8' || p.chr == '9' {
+				return token.ILLEGAL, p.str[offset:p.chrOffset]
 			}
 			goto octal
 		}
 	}
 
-	self.scanMantissa(10)
+	p.scanMantissa(10)
 
 float:
-	if self.chr == '.' {
-		self.read()
-		self.scanMantissa(10)
+	if p.chr == '.' {
+		p.read()
+		p.scanMantissa(10)
 	}
 
 exponent:
-	if self.chr == 'e' || self.chr == 'E' {
-		self.read()
-		if self.chr == '-' || self.chr == '+' {
-			self.read()
+	if p.chr == 'e' || p.chr == 'E' {
+		p.read()
+		if p.chr == '-' || p.chr == '+' {
+			p.read()
 		}
-		if isDecimalDigit(self.chr) {
-			self.read()
-			self.scanMantissa(10)
+		if isDecimalDigit(p.chr) {
+			p.read()
+			p.scanMantissa(10)
 		} else {
-			return token.ILLEGAL, self.str[offset:self.chrOffset]
+			return token.ILLEGAL, p.str[offset:p.chrOffset]
 		}
 	}
 
 hexadecimal:
 octal:
-	if isIdentifierStart(self.chr) || isDecimalDigit(self.chr) {
-		return token.ILLEGAL, self.str[offset:self.chrOffset]
+	if isIdentifierStart(p.chr) || isDecimalDigit(p.chr) {
+		return token.ILLEGAL, p.str[offset:p.chrOffset]
 	}
 
-	return tkn, self.str[offset:self.chrOffset]
+	return tkn, p.str[offset:p.chrOffset]
 }

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -8,13 +8,15 @@ import (
 	"github.com/robertkrimen/otto/token"
 )
 
-var tt = terst.Terst
-var is = terst.Is
+var (
+	tt = terst.Terst
+	is = terst.Is
+)
 
 func TestLexer(t *testing.T) {
 	tt(t, func() {
 		setup := func(src string) *_parser {
-			parser := _newParser("", src, 1, nil)
+			parser := newParser("", src, 1, nil)
 			return parser
 		}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -35,9 +35,9 @@ package parser
 import (
 	"bytes"
 	"encoding/base64"
-	"errors"
+	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"github.com/robertkrimen/otto/ast"
 	"github.com/robertkrimen/otto/file"
@@ -49,11 +49,14 @@ import (
 type Mode uint
 
 const (
-	IgnoreRegExpErrors Mode = 1 << iota // Ignore RegExp compatibility errors (allow backtracking)
-	StoreComments                       // Store the comments from source to the comments map
+	// IgnoreRegExpErrors ignores RegExp compatibility errors (allow backtracking).
+	IgnoreRegExpErrors Mode = 1 << iota
+
+	// StoreComments stores the comments from source to the comments map.
+	StoreComments
 )
 
-type _parser struct {
+type _parser struct { //nolint: maligned
 	str    string
 	length int
 	base   int
@@ -66,7 +69,7 @@ type _parser struct {
 	token   token.Token // The token
 	literal string      // The literal of the token, if any
 
-	scope             *_scope
+	scope             *scope
 	insertSemicolon   bool // If we see a newline, then insert an implicit semicolon
 	implicitSemicolon bool // An implicit semicolon exists
 
@@ -85,11 +88,12 @@ type _parser struct {
 	comments *ast.Comments
 }
 
+// Parser is implemented by types which can parse JavaScript Code.
 type Parser interface {
 	Scan() (tkn token.Token, literal string, idx file.Idx)
 }
 
-func _newParser(filename, src string, base int, sm *sourcemap.Consumer) *_parser {
+func newParser(filename, src string, base int, sm *sourcemap.Consumer) *_parser {
 	return &_parser{
 		chr:      ' ', // This is set so we can start scanning by skipping whitespace
 		str:      src,
@@ -100,11 +104,12 @@ func _newParser(filename, src string, base int, sm *sourcemap.Consumer) *_parser
 	}
 }
 
-// Returns a new Parser.
+// NewParser returns a new Parser.
 func NewParser(filename, src string) Parser {
-	return _newParser(filename, src, 1, nil)
+	return newParser(filename, src, 1, nil)
 }
 
+// ReadSource reads code from src if not nil, otherwise reads from filename.
 func ReadSource(filename string, src interface{}) ([]byte, error) {
 	if src != nil {
 		switch src := src.(type) {
@@ -122,12 +127,14 @@ func ReadSource(filename string, src interface{}) ([]byte, error) {
 				return nil, err
 			}
 			return bfr.Bytes(), nil
+		default:
+			return nil, fmt.Errorf("invalid src type %T", src)
 		}
-		return nil, errors.New("invalid source")
 	}
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename) //nolint: gosec
 }
 
+// ReadSourceMap reads the source map from src if not nil, otherwise is a noop.
 func ReadSourceMap(filename string, src interface{}) (*sourcemap.Consumer, error) {
 	if src == nil {
 		return nil, nil //nolint: nilnil
@@ -139,9 +146,7 @@ func ReadSourceMap(filename string, src interface{}) (*sourcemap.Consumer, error
 	case []byte:
 		return sourcemap.Parse(filename, src)
 	case *bytes.Buffer:
-		if src != nil {
-			return sourcemap.Parse(filename, src.Bytes())
-		}
+		return sourcemap.Parse(filename, src.Bytes())
 	case io.Reader:
 		var bfr bytes.Buffer
 		if _, err := io.Copy(&bfr, src); err != nil {
@@ -150,11 +155,12 @@ func ReadSourceMap(filename string, src interface{}) (*sourcemap.Consumer, error
 		return sourcemap.Parse(filename, bfr.Bytes())
 	case *sourcemap.Consumer:
 		return src, nil
+	default:
+		return nil, fmt.Errorf("invalid sourcemap type %T", src)
 	}
-
-	return nil, errors.New("invalid sourcemap type")
 }
 
+// ParseFileWithSourceMap parses the sourcemap returning the resulting Program.
 func ParseFileWithSourceMap(fileSet *file.FileSet, filename string, javascriptSource, sourcemapSource interface{}, mode Mode) (*ast.Program, error) {
 	src, err := ReadSource(filename, javascriptSource)
 	if err != nil {
@@ -184,7 +190,7 @@ func ParseFileWithSourceMap(fileSet *file.FileSet, filename string, javascriptSo
 		base = fileSet.AddFile(filename, string(src))
 	}
 
-	parser := _newParser(filename, string(src), base, sm)
+	parser := newParser(filename, string(src), base, sm)
 	parser.mode = mode
 	program, err := parser.parse()
 	program.Comments = parser.comments.CommentMap
@@ -215,7 +221,7 @@ func ParseFile(fileSet *file.FileSet, filename string, src interface{}, mode Mod
 func ParseFunction(parameterList, body string) (*ast.FunctionLiteral, error) {
 	src := "(function(" + parameterList + ") {\n" + body + "\n})"
 
-	parser := _newParser("", src, 1, nil)
+	parser := newParser("", src, 1, nil)
 	program, err := parser.parse()
 	if err != nil {
 		return nil, err
@@ -227,75 +233,75 @@ func ParseFunction(parameterList, body string) (*ast.FunctionLiteral, error) {
 // Scan reads a single token from the source at the current offset, increments the offset and
 // returns the token.Token token, a string literal representing the value of the token (if applicable)
 // and it's current file.Idx index.
-func (self *_parser) Scan() (tkn token.Token, literal string, idx file.Idx) {
-	return self.scan()
+func (p *_parser) Scan() (token.Token, string, file.Idx) {
+	return p.scan()
 }
 
-func (self *_parser) slice(idx0, idx1 file.Idx) string {
-	from := int(idx0) - self.base
-	to := int(idx1) - self.base
-	if from >= 0 && to <= len(self.str) {
-		return self.str[from:to]
+func (p *_parser) slice(idx0, idx1 file.Idx) string {
+	from := int(idx0) - p.base
+	to := int(idx1) - p.base
+	if from >= 0 && to <= len(p.str) {
+		return p.str[from:to]
 	}
 
 	return ""
 }
 
-func (self *_parser) parse() (*ast.Program, error) {
-	self.next()
-	program := self.parseProgram()
+func (p *_parser) parse() (*ast.Program, error) {
+	p.next()
+	program := p.parseProgram()
 	if false {
-		self.errors.Sort()
+		p.errors.Sort()
 	}
 
-	if self.mode&StoreComments != 0 {
-		self.comments.CommentMap.AddComments(program, self.comments.FetchAll(), ast.TRAILING)
+	if p.mode&StoreComments != 0 {
+		p.comments.CommentMap.AddComments(program, p.comments.FetchAll(), ast.TRAILING)
 	}
 
-	return program, self.errors.Err()
+	return program, p.errors.Err()
 }
 
-func (self *_parser) next() {
-	self.token, self.literal, self.idx = self.scan()
+func (p *_parser) next() {
+	p.token, p.literal, p.idx = p.scan()
 }
 
-func (self *_parser) optionalSemicolon() {
-	if self.token == token.SEMICOLON {
-		self.next()
+func (p *_parser) optionalSemicolon() {
+	if p.token == token.SEMICOLON {
+		p.next()
 		return
 	}
 
-	if self.implicitSemicolon {
-		self.implicitSemicolon = false
+	if p.implicitSemicolon {
+		p.implicitSemicolon = false
 		return
 	}
 
-	if self.token != token.EOF && self.token != token.RIGHT_BRACE {
-		self.expect(token.SEMICOLON)
+	if p.token != token.EOF && p.token != token.RIGHT_BRACE {
+		p.expect(token.SEMICOLON)
 	}
 }
 
-func (self *_parser) semicolon() {
-	if self.token != token.RIGHT_PARENTHESIS && self.token != token.RIGHT_BRACE {
-		if self.implicitSemicolon {
-			self.implicitSemicolon = false
+func (p *_parser) semicolon() {
+	if p.token != token.RIGHT_PARENTHESIS && p.token != token.RIGHT_BRACE {
+		if p.implicitSemicolon {
+			p.implicitSemicolon = false
 			return
 		}
 
-		self.expect(token.SEMICOLON)
+		p.expect(token.SEMICOLON)
 	}
 }
 
-func (self *_parser) idxOf(offset int) file.Idx {
-	return file.Idx(self.base + offset)
+func (p *_parser) idxOf(offset int) file.Idx {
+	return file.Idx(p.base + offset)
 }
 
-func (self *_parser) expect(value token.Token) file.Idx {
-	idx := self.idx
-	if self.token != value {
-		self.errorUnexpectedToken(self.token)
+func (p *_parser) expect(value token.Token) file.Idx {
+	idx := p.idx
+	if p.token != value {
+		p.errorUnexpectedToken(p.token)
 	}
-	self.next()
+	p.next()
 	return idx
 }
 
@@ -305,17 +311,17 @@ func lineCount(str string) (int, int) {
 	for index, chr := range str {
 		switch chr {
 		case '\r':
-			line += 1
+			line++
 			last = index
 			pair = true
 			continue
 		case '\n':
 			if !pair {
-				line += 1
+				line++
 			}
 			last = index
 		case '\u2028', '\u2029':
-			line += 1
+			line++
 			last = index + 2
 		}
 		pair = false
@@ -323,11 +329,11 @@ func lineCount(str string) (int, int) {
 	return line, last
 }
 
-func (self *_parser) position(idx file.Idx) file.Position {
+func (p *_parser) position(idx file.Idx) file.Position {
 	position := file.Position{}
-	offset := int(idx) - self.base
-	str := self.str[:offset]
-	position.Filename = self.file.Name()
+	offset := int(idx) - p.base
+	str := p.str[:offset]
+	position.Filename = p.file.Name()
 	line, last := lineCount(str)
 	position.Line = 1 + line
 	if last >= 0 {

--- a/parser/regexp.go
+++ b/parser/regexp.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-type _RegExp_parser struct {
+type regExpParser struct { //nolint: maligned
 	str    string
 	length int
 
@@ -40,7 +40,7 @@ func TransformRegExp(pattern string) (string, error) {
 
 	// TODO If without \, if without (?=, (?!, then another shortcut
 
-	parser := _RegExp_parser{
+	parser := regExpParser{
 		str:      pattern,
 		length:   len(pattern),
 		goRegexp: bytes.NewBuffer(make([]byte, 0, 3*len(pattern)/2)),
@@ -59,109 +59,109 @@ func TransformRegExp(pattern string) (string, error) {
 	return parser.goRegexp.String(), err
 }
 
-func (self *_RegExp_parser) scan() {
-	for self.chr != -1 {
-		switch self.chr {
+func (p *regExpParser) scan() {
+	for p.chr != -1 {
+		switch p.chr {
 		case '\\':
-			self.read()
-			self.scanEscape(false)
+			p.read()
+			p.scanEscape(false)
 		case '(':
-			self.pass()
-			self.scanGroup()
+			p.pass()
+			p.scanGroup()
 		case '[':
-			self.pass()
-			self.scanBracket()
+			p.pass()
+			p.scanBracket()
 		case ')':
-			self.error(-1, "Unmatched ')'")
-			self.invalid = true
-			self.pass()
+			p.error(-1, "Unmatched ')'")
+			p.invalid = true
+			p.pass()
 		default:
-			self.pass()
+			p.pass()
 		}
 	}
 }
 
 // (...)
-func (self *_RegExp_parser) scanGroup() {
-	str := self.str[self.chrOffset:]
+func (p *regExpParser) scanGroup() {
+	str := p.str[p.chrOffset:]
 	if len(str) > 1 { // A possibility of (?= or (?!
 		if str[0] == '?' {
 			if str[1] == '=' || str[1] == '!' {
-				self.error(-1, "re2: Invalid (%s) <lookahead>", self.str[self.chrOffset:self.chrOffset+2])
+				p.error(-1, "re2: Invalid (%s) <lookahead>", p.str[p.chrOffset:p.chrOffset+2])
 			}
 		}
 	}
-	for self.chr != -1 && self.chr != ')' {
-		switch self.chr {
+	for p.chr != -1 && p.chr != ')' {
+		switch p.chr {
 		case '\\':
-			self.read()
-			self.scanEscape(false)
+			p.read()
+			p.scanEscape(false)
 		case '(':
-			self.pass()
-			self.scanGroup()
+			p.pass()
+			p.scanGroup()
 		case '[':
-			self.pass()
-			self.scanBracket()
+			p.pass()
+			p.scanBracket()
 		default:
-			self.pass()
+			p.pass()
 			continue
 		}
 	}
-	if self.chr != ')' {
-		self.error(-1, "Unterminated group")
-		self.invalid = true
+	if p.chr != ')' {
+		p.error(-1, "Unterminated group")
+		p.invalid = true
 		return
 	}
-	self.pass()
+	p.pass()
 }
 
-// [...]
-func (self *_RegExp_parser) scanBracket() {
-	for self.chr != -1 {
-		if self.chr == ']' {
+// [...].
+func (p *regExpParser) scanBracket() {
+	for p.chr != -1 {
+		if p.chr == ']' {
 			break
-		} else if self.chr == '\\' {
-			self.read()
-			self.scanEscape(true)
+		} else if p.chr == '\\' {
+			p.read()
+			p.scanEscape(true)
 			continue
 		}
-		self.pass()
+		p.pass()
 	}
-	if self.chr != ']' {
-		self.error(-1, "Unterminated character class")
-		self.invalid = true
+	if p.chr != ']' {
+		p.error(-1, "Unterminated character class")
+		p.invalid = true
 		return
 	}
-	self.pass()
+	p.pass()
 }
 
 // \...
-func (self *_RegExp_parser) scanEscape(inClass bool) {
-	offset := self.chrOffset
+func (p *regExpParser) scanEscape(inClass bool) {
+	offset := p.chrOffset
 
 	var length, base uint32
-	switch self.chr {
+	switch p.chr {
 	case '0', '1', '2', '3', '4', '5', '6', '7':
 		var value int64
 		size := 0
 		for {
-			digit := int64(digitValue(self.chr))
+			digit := int64(digitValue(p.chr))
 			if digit >= 8 {
 				// Not a valid digit
 				break
 			}
 			value = value*8 + digit
-			self.read()
-			size += 1
+			p.read()
+			size++
 		}
 		if size == 1 { // The number of characters read
-			_, err := self.goRegexp.Write([]byte{'\\', byte(value) + '0'})
+			_, err := p.goRegexp.Write([]byte{'\\', byte(value) + '0'})
 			if err != nil {
-				self.errors = append(self.errors, err)
+				p.errors = append(p.errors, err)
 			}
 			if value != 0 {
 				// An invalid backreference
-				self.error(-1, "re2: Invalid \\%d <backreference>", value)
+				p.error(-1, "re2: Invalid \\%d <backreference>", value)
 			}
 			return
 		}
@@ -172,49 +172,49 @@ func (self *_RegExp_parser) scanEscape(inClass bool) {
 			tmp = tmp[0:3]
 		}
 		tmp = strconv.AppendInt(tmp, value, 16)
-		_, err := self.goRegexp.Write(tmp)
+		_, err := p.goRegexp.Write(tmp)
 		if err != nil {
-			self.errors = append(self.errors, err)
+			p.errors = append(p.errors, err)
 		}
 		return
 
 	case '8', '9':
 		size := 0
 		for {
-			digit := digitValue(self.chr)
+			digit := digitValue(p.chr)
 			if digit >= 10 {
 				// Not a valid digit
 				break
 			}
-			self.read()
-			size += 1
+			p.read()
+			size++
 		}
-		err := self.goRegexp.WriteByte('\\')
+		err := p.goRegexp.WriteByte('\\')
 		if err != nil {
-			self.errors = append(self.errors, err)
+			p.errors = append(p.errors, err)
 		}
-		_, err = self.goRegexp.WriteString(self.str[offset:self.chrOffset])
+		_, err = p.goRegexp.WriteString(p.str[offset:p.chrOffset])
 		if err != nil {
-			self.errors = append(self.errors, err)
+			p.errors = append(p.errors, err)
 		}
-		self.error(-1, "re2: Invalid \\%s <backreference>", self.str[offset:self.chrOffset])
+		p.error(-1, "re2: Invalid \\%s <backreference>", p.str[offset:p.chrOffset])
 		return
 
 	case 'x':
-		self.read()
+		p.read()
 		length, base = 2, 16
 
 	case 'u':
-		self.read()
+		p.read()
 		length, base = 4, 16
 
 	case 'b':
 		if inClass {
-			_, err := self.goRegexp.Write([]byte{'\\', 'x', '0', '8'})
+			_, err := p.goRegexp.Write([]byte{'\\', 'x', '0', '8'})
 			if err != nil {
-				self.errors = append(self.errors, err)
+				p.errors = append(p.errors, err)
 			}
-			self.read()
+			p.read()
 			return
 		}
 		fallthrough
@@ -231,24 +231,25 @@ func (self *_RegExp_parser) scanEscape(inClass bool) {
 		fallthrough
 
 	case 'f', 'n', 'r', 't', 'v':
-		err := self.goRegexp.WriteByte('\\')
+		err := p.goRegexp.WriteByte('\\')
 		if err != nil {
-			self.errors = append(self.errors, err)
+			p.errors = append(p.errors, err)
 		}
-		self.pass()
+		p.pass()
 		return
 
 	case 'c':
-		self.read()
+		p.read()
 		var value int64
-		if 'a' <= self.chr && self.chr <= 'z' {
-			value = int64(self.chr) - 'a' + 1
-		} else if 'A' <= self.chr && self.chr <= 'Z' {
-			value = int64(self.chr) - 'A' + 1
-		} else {
-			err := self.goRegexp.WriteByte('c')
+		switch {
+		case 'a' <= p.chr && p.chr <= 'z':
+			value = int64(p.chr) - 'a' + 1
+		case 'A' <= p.chr && p.chr <= 'Z':
+			value = int64(p.chr) - 'A' + 1
+		default:
+			err := p.goRegexp.WriteByte('c')
 			if err != nil {
-				self.errors = append(self.errors, err)
+				p.errors = append(p.errors, err)
 			}
 			return
 		}
@@ -259,98 +260,93 @@ func (self *_RegExp_parser) scanEscape(inClass bool) {
 			tmp = tmp[0:3]
 		}
 		tmp = strconv.AppendInt(tmp, value, 16)
-		_, err := self.goRegexp.Write(tmp)
+		_, err := p.goRegexp.Write(tmp)
 		if err != nil {
-			self.errors = append(self.errors, err)
+			p.errors = append(p.errors, err)
 		}
-		self.read()
+		p.read()
 		return
 
 	default:
 		// $ is an identifier character, so we have to have
 		// a special case for it here
-		if self.chr == '$' || !isIdentifierPart(self.chr) {
+		if p.chr == '$' || !isIdentifierPart(p.chr) {
 			// A non-identifier character needs escaping
-			err := self.goRegexp.WriteByte('\\')
+			err := p.goRegexp.WriteByte('\\')
 			if err != nil {
-				self.errors = append(self.errors, err)
+				p.errors = append(p.errors, err)
 			}
-		} else {
+		} else { //nolint: staticcheck
 			// Unescape the character for re2
 		}
-		self.pass()
+		p.pass()
 		return
 	}
 
 	// Otherwise, we're a \u.... or \x...
-	valueOffset := self.chrOffset
+	valueOffset := p.chrOffset
 
 	var value uint32
-	{
-		length := length
-		for ; length > 0; length-- {
-			digit := uint32(digitValue(self.chr))
-			if digit >= base {
-				// Not a valid digit
-				goto skip
-			}
-			value = value*base + digit
-			self.read()
+	for length := length; length > 0; length-- {
+		digit := uint32(digitValue(p.chr))
+		if digit >= base {
+			// Not a valid digit
+			goto skip
 		}
+		value = value*base + digit
+		p.read()
 	}
 
-	if length == 4 {
-		_, err := self.goRegexp.Write([]byte{
+	switch length {
+	case 4:
+		if _, err := p.goRegexp.Write([]byte{
 			'\\',
 			'x',
 			'{',
-			self.str[valueOffset+0],
-			self.str[valueOffset+1],
-			self.str[valueOffset+2],
-			self.str[valueOffset+3],
+			p.str[valueOffset+0],
+			p.str[valueOffset+1],
+			p.str[valueOffset+2],
+			p.str[valueOffset+3],
 			'}',
-		})
-		if err != nil {
-			self.errors = append(self.errors, err)
+		}); err != nil {
+			p.errors = append(p.errors, err)
 		}
-	} else if length == 2 {
-		_, err := self.goRegexp.Write([]byte{
+	case 2:
+		if _, err := p.goRegexp.Write([]byte{
 			'\\',
 			'x',
-			self.str[valueOffset+0],
-			self.str[valueOffset+1],
-		})
-		if err != nil {
-			self.errors = append(self.errors, err)
+			p.str[valueOffset+0],
+			p.str[valueOffset+1],
+		}); err != nil {
+			p.errors = append(p.errors, err)
 		}
-	} else {
+	default:
 		// Should never, ever get here...
-		self.error(-1, "re2: Illegal branch in scanEscape")
+		p.error(-1, "re2: Illegal branch in scanEscape")
 		goto skip
 	}
 
 	return
 
 skip:
-	_, err := self.goRegexp.WriteString(self.str[offset:self.chrOffset])
+	_, err := p.goRegexp.WriteString(p.str[offset:p.chrOffset])
 	if err != nil {
-		self.errors = append(self.errors, err)
+		p.errors = append(p.errors, err)
 	}
 }
 
-func (self *_RegExp_parser) pass() {
-	if self.chr != -1 {
-		_, err := self.goRegexp.WriteRune(self.chr)
+func (p *regExpParser) pass() {
+	if p.chr != -1 {
+		_, err := p.goRegexp.WriteRune(p.chr)
 		if err != nil {
-			self.errors = append(self.errors, err)
+			p.errors = append(p.errors, err)
 		}
 	}
-	self.read()
+	p.read()
 }
 
 // TODO Better error reporting, use the offset, etc.
-func (self *_RegExp_parser) error(offset int, msg string, msgValues ...interface{}) error {
+func (p *regExpParser) error(offset int, msg string, msgValues ...interface{}) { //nolint: unparam
 	err := fmt.Errorf(msg, msgValues...)
-	self.errors = append(self.errors, err)
-	return err
+	p.errors = append(p.errors, err)
 }

--- a/parser/scope.go
+++ b/parser/scope.go
@@ -4,8 +4,8 @@ import (
 	"github.com/robertkrimen/otto/ast"
 )
 
-type _scope struct {
-	outer           *_scope
+type scope struct {
+	outer           *scope
 	allowIn         bool
 	inIteration     bool
 	inSwitch        bool
@@ -15,30 +15,30 @@ type _scope struct {
 	labels []string
 }
 
-func (self *_parser) openScope() {
-	self.scope = &_scope{
-		outer:   self.scope,
+func (p *_parser) openScope() {
+	p.scope = &scope{
+		outer:   p.scope,
 		allowIn: true,
 	}
 }
 
-func (self *_parser) closeScope() {
-	self.scope = self.scope.outer
+func (p *_parser) closeScope() {
+	p.scope = p.scope.outer
 }
 
-func (self *_scope) declare(declaration ast.Declaration) {
-	self.declarationList = append(self.declarationList, declaration)
+func (p *scope) declare(declaration ast.Declaration) {
+	p.declarationList = append(p.declarationList, declaration)
 }
 
-func (self *_scope) hasLabel(name string) bool {
-	for _, label := range self.labels {
+func (p *scope) hasLabel(name string) bool {
+	for _, label := range p.labels {
 		if label == name {
 			return true
 		}
 	}
-	if self.outer != nil && !self.inFunction {
+	if p.outer != nil && !p.inFunction {
 		// Crossing a function boundary to look for a label is verboten
-		return self.outer.hasLabel(name)
+		return p.outer.hasLabel(name)
 	}
 	return false
 }

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -5,233 +5,233 @@ import (
 	"github.com/robertkrimen/otto/token"
 )
 
-func (self *_parser) parseBlockStatement() *ast.BlockStatement {
+func (p *_parser) parseBlockStatement() *ast.BlockStatement {
 	node := &ast.BlockStatement{}
 
 	// Find comments before the leading brace
-	if self.mode&StoreComments != 0 {
-		self.comments.CommentMap.AddComments(node, self.comments.FetchAll(), ast.LEADING)
-		self.comments.Unset()
+	if p.mode&StoreComments != 0 {
+		p.comments.CommentMap.AddComments(node, p.comments.FetchAll(), ast.LEADING)
+		p.comments.Unset()
 	}
 
-	node.LeftBrace = self.expect(token.LEFT_BRACE)
-	node.List = self.parseStatementList()
+	node.LeftBrace = p.expect(token.LEFT_BRACE)
+	node.List = p.parseStatementList()
 
-	if self.mode&StoreComments != 0 {
-		self.comments.Unset()
-		self.comments.CommentMap.AddComments(node, self.comments.FetchAll(), ast.FINAL)
-		self.comments.AfterBlock()
+	if p.mode&StoreComments != 0 {
+		p.comments.Unset()
+		p.comments.CommentMap.AddComments(node, p.comments.FetchAll(), ast.FINAL)
+		p.comments.AfterBlock()
 	}
 
-	node.RightBrace = self.expect(token.RIGHT_BRACE)
+	node.RightBrace = p.expect(token.RIGHT_BRACE)
 
 	// Find comments after the trailing brace
-	if self.mode&StoreComments != 0 {
-		self.comments.ResetLineBreak()
-		self.comments.CommentMap.AddComments(node, self.comments.Fetch(), ast.TRAILING)
+	if p.mode&StoreComments != 0 {
+		p.comments.ResetLineBreak()
+		p.comments.CommentMap.AddComments(node, p.comments.Fetch(), ast.TRAILING)
 	}
 
 	return node
 }
 
-func (self *_parser) parseEmptyStatement() ast.Statement {
-	idx := self.expect(token.SEMICOLON)
+func (p *_parser) parseEmptyStatement() ast.Statement {
+	idx := p.expect(token.SEMICOLON)
 	return &ast.EmptyStatement{Semicolon: idx}
 }
 
-func (self *_parser) parseStatementList() (list []ast.Statement) {
-	for self.token != token.RIGHT_BRACE && self.token != token.EOF {
-		statement := self.parseStatement()
+func (p *_parser) parseStatementList() (list []ast.Statement) { //nolint: nonamedreturns
+	for p.token != token.RIGHT_BRACE && p.token != token.EOF {
+		statement := p.parseStatement()
 		list = append(list, statement)
 	}
 
-	return
+	return list
 }
 
-func (self *_parser) parseStatement() ast.Statement {
-	if self.token == token.EOF {
-		self.errorUnexpectedToken(self.token)
-		return &ast.BadStatement{From: self.idx, To: self.idx + 1}
+func (p *_parser) parseStatement() ast.Statement {
+	if p.token == token.EOF {
+		p.errorUnexpectedToken(p.token)
+		return &ast.BadStatement{From: p.idx, To: p.idx + 1}
 	}
 
-	if self.mode&StoreComments != 0 {
-		self.comments.ResetLineBreak()
+	if p.mode&StoreComments != 0 {
+		p.comments.ResetLineBreak()
 	}
 
-	switch self.token {
+	switch p.token {
 	case token.SEMICOLON:
-		return self.parseEmptyStatement()
+		return p.parseEmptyStatement()
 	case token.LEFT_BRACE:
-		return self.parseBlockStatement()
+		return p.parseBlockStatement()
 	case token.IF:
-		return self.parseIfStatement()
+		return p.parseIfStatement()
 	case token.DO:
-		statement := self.parseDoWhileStatement()
-		self.comments.PostProcessNode(statement)
+		statement := p.parseDoWhileStatement()
+		p.comments.PostProcessNode(statement)
 		return statement
 	case token.WHILE:
-		return self.parseWhileStatement()
+		return p.parseWhileStatement()
 	case token.FOR:
-		return self.parseForOrForInStatement()
+		return p.parseForOrForInStatement()
 	case token.BREAK:
-		return self.parseBreakStatement()
+		return p.parseBreakStatement()
 	case token.CONTINUE:
-		return self.parseContinueStatement()
+		return p.parseContinueStatement()
 	case token.DEBUGGER:
-		return self.parseDebuggerStatement()
+		return p.parseDebuggerStatement()
 	case token.WITH:
-		return self.parseWithStatement()
+		return p.parseWithStatement()
 	case token.VAR:
-		return self.parseVariableStatement()
+		return p.parseVariableStatement()
 	case token.FUNCTION:
-		return self.parseFunctionStatement()
+		return p.parseFunctionStatement()
 	case token.SWITCH:
-		return self.parseSwitchStatement()
+		return p.parseSwitchStatement()
 	case token.RETURN:
-		return self.parseReturnStatement()
+		return p.parseReturnStatement()
 	case token.THROW:
-		return self.parseThrowStatement()
+		return p.parseThrowStatement()
 	case token.TRY:
-		return self.parseTryStatement()
+		return p.parseTryStatement()
 	}
 
 	var comments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		comments = self.comments.FetchAll()
+	if p.mode&StoreComments != 0 {
+		comments = p.comments.FetchAll()
 	}
 
-	expression := self.parseExpression()
+	expression := p.parseExpression()
 
-	if identifier, isIdentifier := expression.(*ast.Identifier); isIdentifier && self.token == token.COLON {
+	if identifier, isIdentifier := expression.(*ast.Identifier); isIdentifier && p.token == token.COLON {
 		// LabelledStatement
-		colon := self.idx
-		if self.mode&StoreComments != 0 {
-			self.comments.Unset()
+		colon := p.idx
+		if p.mode&StoreComments != 0 {
+			p.comments.Unset()
 		}
-		self.next() // :
+		p.next() // :
 
 		label := identifier.Name
-		for _, value := range self.scope.labels {
+		for _, value := range p.scope.labels {
 			if label == value {
-				self.error(identifier.Idx0(), "Label '%s' already exists", label)
+				p.error(identifier.Idx0(), "Label '%s' already exists", label)
 			}
 		}
 		var labelComments []*ast.Comment
-		if self.mode&StoreComments != 0 {
-			labelComments = self.comments.FetchAll()
+		if p.mode&StoreComments != 0 {
+			labelComments = p.comments.FetchAll()
 		}
-		self.scope.labels = append(self.scope.labels, label) // Push the label
-		statement := self.parseStatement()
-		self.scope.labels = self.scope.labels[:len(self.scope.labels)-1] // Pop the label
+		p.scope.labels = append(p.scope.labels, label) // Push the label
+		statement := p.parseStatement()
+		p.scope.labels = p.scope.labels[:len(p.scope.labels)-1] // Pop the label
 		exp := &ast.LabelledStatement{
 			Label:     identifier,
 			Colon:     colon,
 			Statement: statement,
 		}
-		if self.mode&StoreComments != 0 {
-			self.comments.CommentMap.AddComments(exp, labelComments, ast.LEADING)
+		if p.mode&StoreComments != 0 {
+			p.comments.CommentMap.AddComments(exp, labelComments, ast.LEADING)
 		}
 
 		return exp
 	}
 
-	self.optionalSemicolon()
+	p.optionalSemicolon()
 
 	statement := &ast.ExpressionStatement{
 		Expression: expression,
 	}
 
-	if self.mode&StoreComments != 0 {
-		self.comments.CommentMap.AddComments(statement, comments, ast.LEADING)
+	if p.mode&StoreComments != 0 {
+		p.comments.CommentMap.AddComments(statement, comments, ast.LEADING)
 	}
 	return statement
 }
 
-func (self *_parser) parseTryStatement() ast.Statement {
+func (p *_parser) parseTryStatement() ast.Statement {
 	var tryComments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		tryComments = self.comments.FetchAll()
+	if p.mode&StoreComments != 0 {
+		tryComments = p.comments.FetchAll()
 	}
 	node := &ast.TryStatement{
-		Try:  self.expect(token.TRY),
-		Body: self.parseBlockStatement(),
+		Try:  p.expect(token.TRY),
+		Body: p.parseBlockStatement(),
 	}
-	if self.mode&StoreComments != 0 {
-		self.comments.CommentMap.AddComments(node, tryComments, ast.LEADING)
-		self.comments.CommentMap.AddComments(node.Body, self.comments.FetchAll(), ast.TRAILING)
-	}
-
-	if self.token == token.CATCH {
-		catch := self.idx
-		if self.mode&StoreComments != 0 {
-			self.comments.Unset()
-		}
-		self.next()
-		self.expect(token.LEFT_PARENTHESIS)
-		if self.token != token.IDENTIFIER {
-			self.expect(token.IDENTIFIER)
-			self.nextStatement()
-			return &ast.BadStatement{From: catch, To: self.idx}
-		} else {
-			identifier := self.parseIdentifier()
-			self.expect(token.RIGHT_PARENTHESIS)
-			node.Catch = &ast.CatchStatement{
-				Catch:     catch,
-				Parameter: identifier,
-				Body:      self.parseBlockStatement(),
-			}
-
-			if self.mode&StoreComments != 0 {
-				self.comments.CommentMap.AddComments(node.Catch.Body, self.comments.FetchAll(), ast.TRAILING)
-			}
-		}
+	if p.mode&StoreComments != 0 {
+		p.comments.CommentMap.AddComments(node, tryComments, ast.LEADING)
+		p.comments.CommentMap.AddComments(node.Body, p.comments.FetchAll(), ast.TRAILING)
 	}
 
-	if self.token == token.FINALLY {
-		if self.mode&StoreComments != 0 {
-			self.comments.Unset()
+	if p.token == token.CATCH {
+		catch := p.idx
+		if p.mode&StoreComments != 0 {
+			p.comments.Unset()
 		}
-		self.next()
-		if self.mode&StoreComments != 0 {
-			tryComments = self.comments.FetchAll()
+		p.next()
+		p.expect(token.LEFT_PARENTHESIS)
+		if p.token != token.IDENTIFIER {
+			p.expect(token.IDENTIFIER)
+			p.nextStatement()
+			return &ast.BadStatement{From: catch, To: p.idx}
 		}
 
-		node.Finally = self.parseBlockStatement()
+		identifier := p.parseIdentifier()
+		p.expect(token.RIGHT_PARENTHESIS)
+		node.Catch = &ast.CatchStatement{
+			Catch:     catch,
+			Parameter: identifier,
+			Body:      p.parseBlockStatement(),
+		}
 
-		if self.mode&StoreComments != 0 {
-			self.comments.CommentMap.AddComments(node.Finally, tryComments, ast.LEADING)
+		if p.mode&StoreComments != 0 {
+			p.comments.CommentMap.AddComments(node.Catch.Body, p.comments.FetchAll(), ast.TRAILING)
+		}
+	}
+
+	if p.token == token.FINALLY {
+		if p.mode&StoreComments != 0 {
+			p.comments.Unset()
+		}
+		p.next()
+		if p.mode&StoreComments != 0 {
+			tryComments = p.comments.FetchAll()
+		}
+
+		node.Finally = p.parseBlockStatement()
+
+		if p.mode&StoreComments != 0 {
+			p.comments.CommentMap.AddComments(node.Finally, tryComments, ast.LEADING)
 		}
 	}
 
 	if node.Catch == nil && node.Finally == nil {
-		self.error(node.Try, "Missing catch or finally after try")
+		p.error(node.Try, "Missing catch or finally after try")
 		return &ast.BadStatement{From: node.Try, To: node.Body.Idx1()}
 	}
 
 	return node
 }
 
-func (self *_parser) parseFunctionParameterList() *ast.ParameterList {
-	opening := self.expect(token.LEFT_PARENTHESIS)
-	if self.mode&StoreComments != 0 {
-		self.comments.Unset()
+func (p *_parser) parseFunctionParameterList() *ast.ParameterList {
+	opening := p.expect(token.LEFT_PARENTHESIS)
+	if p.mode&StoreComments != 0 {
+		p.comments.Unset()
 	}
 	var list []*ast.Identifier
-	for self.token != token.RIGHT_PARENTHESIS && self.token != token.EOF {
-		if self.token != token.IDENTIFIER {
-			self.expect(token.IDENTIFIER)
+	for p.token != token.RIGHT_PARENTHESIS && p.token != token.EOF {
+		if p.token != token.IDENTIFIER {
+			p.expect(token.IDENTIFIER)
 		} else {
-			identifier := self.parseIdentifier()
+			identifier := p.parseIdentifier()
 			list = append(list, identifier)
 		}
-		if self.token != token.RIGHT_PARENTHESIS {
-			if self.mode&StoreComments != 0 {
-				self.comments.Unset()
+		if p.token != token.RIGHT_PARENTHESIS {
+			if p.mode&StoreComments != 0 {
+				p.comments.Unset()
 			}
-			self.expect(token.COMMA)
+			p.expect(token.COMMA)
 		}
 	}
-	closing := self.expect(token.RIGHT_PARENTHESIS)
+	closing := p.expect(token.RIGHT_PARENTHESIS)
 
 	return &ast.ParameterList{
 		Opening: opening,
@@ -240,285 +240,269 @@ func (self *_parser) parseFunctionParameterList() *ast.ParameterList {
 	}
 }
 
-func (self *_parser) parseParameterList() (list []string) {
-	for self.token != token.EOF {
-		if self.token != token.IDENTIFIER {
-			self.expect(token.IDENTIFIER)
-		}
-		list = append(list, self.literal)
-		self.next()
-		if self.token != token.EOF {
-			self.expect(token.COMMA)
-		}
-	}
-	return
-}
-
-func (self *_parser) parseFunctionStatement() *ast.FunctionStatement {
+func (p *_parser) parseFunctionStatement() *ast.FunctionStatement {
 	var comments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		comments = self.comments.FetchAll()
+	if p.mode&StoreComments != 0 {
+		comments = p.comments.FetchAll()
 	}
 	function := &ast.FunctionStatement{
-		Function: self.parseFunction(true),
+		Function: p.parseFunction(true),
 	}
-	if self.mode&StoreComments != 0 {
-		self.comments.CommentMap.AddComments(function, comments, ast.LEADING)
+	if p.mode&StoreComments != 0 {
+		p.comments.CommentMap.AddComments(function, comments, ast.LEADING)
 	}
 
 	return function
 }
 
-func (self *_parser) parseFunction(declaration bool) *ast.FunctionLiteral {
+func (p *_parser) parseFunction(declaration bool) *ast.FunctionLiteral {
 	node := &ast.FunctionLiteral{
-		Function: self.expect(token.FUNCTION),
+		Function: p.expect(token.FUNCTION),
 	}
 
 	var name *ast.Identifier
-	if self.token == token.IDENTIFIER {
-		name = self.parseIdentifier()
+	if p.token == token.IDENTIFIER {
+		name = p.parseIdentifier()
 		if declaration {
-			self.scope.declare(&ast.FunctionDeclaration{
+			p.scope.declare(&ast.FunctionDeclaration{
 				Function: node,
 			})
 		}
 	} else if declaration {
 		// Use expect error handling
-		self.expect(token.IDENTIFIER)
+		p.expect(token.IDENTIFIER)
 	}
-	if self.mode&StoreComments != 0 {
-		self.comments.Unset()
+	if p.mode&StoreComments != 0 {
+		p.comments.Unset()
 	}
 	node.Name = name
-	node.ParameterList = self.parseFunctionParameterList()
-	self.parseFunctionBlock(node)
-	node.Source = self.slice(node.Idx0(), node.Idx1())
+	node.ParameterList = p.parseFunctionParameterList()
+	p.parseFunctionBlock(node)
+	node.Source = p.slice(node.Idx0(), node.Idx1())
 
 	return node
 }
 
-func (self *_parser) parseFunctionBlock(node *ast.FunctionLiteral) {
-	{
-		self.openScope()
-		inFunction := self.scope.inFunction
-		self.scope.inFunction = true
-		defer func() {
-			self.scope.inFunction = inFunction
-			self.closeScope()
-		}()
-		node.Body = self.parseBlockStatement()
-		node.DeclarationList = self.scope.declarationList
-	}
+func (p *_parser) parseFunctionBlock(node *ast.FunctionLiteral) {
+	p.openScope()
+	inFunction := p.scope.inFunction
+	p.scope.inFunction = true
+	defer func() {
+		p.scope.inFunction = inFunction
+		p.closeScope()
+	}()
+	node.Body = p.parseBlockStatement()
+	node.DeclarationList = p.scope.declarationList
 }
 
-func (self *_parser) parseDebuggerStatement() ast.Statement {
-	idx := self.expect(token.DEBUGGER)
+func (p *_parser) parseDebuggerStatement() ast.Statement {
+	idx := p.expect(token.DEBUGGER)
 
 	node := &ast.DebuggerStatement{
 		Debugger: idx,
 	}
-	if self.mode&StoreComments != 0 {
-		self.comments.CommentMap.AddComments(node, self.comments.FetchAll(), ast.TRAILING)
+	if p.mode&StoreComments != 0 {
+		p.comments.CommentMap.AddComments(node, p.comments.FetchAll(), ast.TRAILING)
 	}
 
-	self.semicolon()
+	p.semicolon()
 	return node
 }
 
-func (self *_parser) parseReturnStatement() ast.Statement {
-	idx := self.expect(token.RETURN)
+func (p *_parser) parseReturnStatement() ast.Statement {
+	idx := p.expect(token.RETURN)
 	var comments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		comments = self.comments.FetchAll()
+	if p.mode&StoreComments != 0 {
+		comments = p.comments.FetchAll()
 	}
 
-	if !self.scope.inFunction {
-		self.error(idx, "Illegal return statement")
-		self.nextStatement()
-		return &ast.BadStatement{From: idx, To: self.idx}
+	if !p.scope.inFunction {
+		p.error(idx, "Illegal return statement")
+		p.nextStatement()
+		return &ast.BadStatement{From: idx, To: p.idx}
 	}
 
 	node := &ast.ReturnStatement{
 		Return: idx,
 	}
 
-	if !self.implicitSemicolon && self.token != token.SEMICOLON && self.token != token.RIGHT_BRACE && self.token != token.EOF {
-		node.Argument = self.parseExpression()
+	if !p.implicitSemicolon && p.token != token.SEMICOLON && p.token != token.RIGHT_BRACE && p.token != token.EOF {
+		node.Argument = p.parseExpression()
 	}
-	if self.mode&StoreComments != 0 {
-		self.comments.CommentMap.AddComments(node, comments, ast.LEADING)
+	if p.mode&StoreComments != 0 {
+		p.comments.CommentMap.AddComments(node, comments, ast.LEADING)
 	}
 
-	self.semicolon()
+	p.semicolon()
 
 	return node
 }
 
-func (self *_parser) parseThrowStatement() ast.Statement {
+func (p *_parser) parseThrowStatement() ast.Statement {
 	var comments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		comments = self.comments.FetchAll()
+	if p.mode&StoreComments != 0 {
+		comments = p.comments.FetchAll()
 	}
-	idx := self.expect(token.THROW)
+	idx := p.expect(token.THROW)
 
-	if self.implicitSemicolon {
-		if self.chr == -1 { // Hackish
-			self.error(idx, "Unexpected end of input")
+	if p.implicitSemicolon {
+		if p.chr == -1 { // Hackish
+			p.error(idx, "Unexpected end of input")
 		} else {
-			self.error(idx, "Illegal newline after throw")
+			p.error(idx, "Illegal newline after throw")
 		}
-		self.nextStatement()
-		return &ast.BadStatement{From: idx, To: self.idx}
+		p.nextStatement()
+		return &ast.BadStatement{From: idx, To: p.idx}
 	}
 
 	node := &ast.ThrowStatement{
-		Throw:    self.idx,
-		Argument: self.parseExpression(),
+		Throw:    p.idx,
+		Argument: p.parseExpression(),
 	}
-	if self.mode&StoreComments != 0 {
-		self.comments.CommentMap.AddComments(node, comments, ast.LEADING)
+	if p.mode&StoreComments != 0 {
+		p.comments.CommentMap.AddComments(node, comments, ast.LEADING)
 	}
 
-	self.semicolon()
+	p.semicolon()
 
 	return node
 }
 
-func (self *_parser) parseSwitchStatement() ast.Statement {
+func (p *_parser) parseSwitchStatement() ast.Statement {
 	var comments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		comments = self.comments.FetchAll()
+	if p.mode&StoreComments != 0 {
+		comments = p.comments.FetchAll()
 	}
-	self.expect(token.SWITCH)
-	if self.mode&StoreComments != 0 {
-		comments = append(comments, self.comments.FetchAll()...)
+	p.expect(token.SWITCH)
+	if p.mode&StoreComments != 0 {
+		comments = append(comments, p.comments.FetchAll()...)
 	}
-	self.expect(token.LEFT_PARENTHESIS)
+	p.expect(token.LEFT_PARENTHESIS)
 	node := &ast.SwitchStatement{
-		Discriminant: self.parseExpression(),
+		Discriminant: p.parseExpression(),
 		Default:      -1,
 	}
-	self.expect(token.RIGHT_PARENTHESIS)
-	if self.mode&StoreComments != 0 {
-		comments = append(comments, self.comments.FetchAll()...)
+	p.expect(token.RIGHT_PARENTHESIS)
+	if p.mode&StoreComments != 0 {
+		comments = append(comments, p.comments.FetchAll()...)
 	}
 
-	self.expect(token.LEFT_BRACE)
+	p.expect(token.LEFT_BRACE)
 
-	inSwitch := self.scope.inSwitch
-	self.scope.inSwitch = true
+	inSwitch := p.scope.inSwitch
+	p.scope.inSwitch = true
 	defer func() {
-		self.scope.inSwitch = inSwitch
+		p.scope.inSwitch = inSwitch
 	}()
 
-	for index := 0; self.token != token.EOF; index++ {
-		if self.token == token.RIGHT_BRACE {
-			self.next()
+	for index := 0; p.token != token.EOF; index++ {
+		if p.token == token.RIGHT_BRACE {
+			p.next()
 			break
 		}
 
-		clause := self.parseCaseStatement()
+		clause := p.parseCaseStatement()
 		if clause.Test == nil {
 			if node.Default != -1 {
-				self.error(clause.Case, "Already saw a default in switch")
+				p.error(clause.Case, "Already saw a default in switch")
 			}
 			node.Default = index
 		}
 		node.Body = append(node.Body, clause)
 	}
 
-	if self.mode&StoreComments != 0 {
-		self.comments.CommentMap.AddComments(node, comments, ast.LEADING)
+	if p.mode&StoreComments != 0 {
+		p.comments.CommentMap.AddComments(node, comments, ast.LEADING)
 	}
 
 	return node
 }
 
-func (self *_parser) parseWithStatement() ast.Statement {
+func (p *_parser) parseWithStatement() ast.Statement {
 	var comments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		comments = self.comments.FetchAll()
+	if p.mode&StoreComments != 0 {
+		comments = p.comments.FetchAll()
 	}
-	self.expect(token.WITH)
+	p.expect(token.WITH)
 	var withComments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		withComments = self.comments.FetchAll()
+	if p.mode&StoreComments != 0 {
+		withComments = p.comments.FetchAll()
 	}
 
-	self.expect(token.LEFT_PARENTHESIS)
+	p.expect(token.LEFT_PARENTHESIS)
 
 	node := &ast.WithStatement{
-		Object: self.parseExpression(),
+		Object: p.parseExpression(),
 	}
-	self.expect(token.RIGHT_PARENTHESIS)
+	p.expect(token.RIGHT_PARENTHESIS)
 
-	if self.mode&StoreComments != 0 {
-		self.comments.CommentMap.AddComments(node, comments, ast.LEADING)
-		self.comments.CommentMap.AddComments(node, withComments, ast.WITH)
+	if p.mode&StoreComments != 0 {
+		p.comments.CommentMap.AddComments(node, comments, ast.LEADING)
+		p.comments.CommentMap.AddComments(node, withComments, ast.WITH)
 	}
 
-	node.Body = self.parseStatement()
+	node.Body = p.parseStatement()
 
 	return node
 }
 
-func (self *_parser) parseCaseStatement() *ast.CaseStatement {
+func (p *_parser) parseCaseStatement() *ast.CaseStatement {
 	node := &ast.CaseStatement{
-		Case: self.idx,
+		Case: p.idx,
 	}
 
 	var comments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		comments = self.comments.FetchAll()
-		self.comments.Unset()
+	if p.mode&StoreComments != 0 {
+		comments = p.comments.FetchAll()
+		p.comments.Unset()
 	}
 
-	if self.token == token.DEFAULT {
-		self.next()
+	if p.token == token.DEFAULT {
+		p.next()
 	} else {
-		self.expect(token.CASE)
-		node.Test = self.parseExpression()
+		p.expect(token.CASE)
+		node.Test = p.parseExpression()
 	}
 
-	if self.mode&StoreComments != 0 {
-		self.comments.Unset()
+	if p.mode&StoreComments != 0 {
+		p.comments.Unset()
 	}
-	self.expect(token.COLON)
+	p.expect(token.COLON)
 
 	for {
-		if self.token == token.EOF ||
-			self.token == token.RIGHT_BRACE ||
-			self.token == token.CASE ||
-			self.token == token.DEFAULT {
+		if p.token == token.EOF ||
+			p.token == token.RIGHT_BRACE ||
+			p.token == token.CASE ||
+			p.token == token.DEFAULT {
 			break
 		}
-		consequent := self.parseStatement()
+		consequent := p.parseStatement()
 		node.Consequent = append(node.Consequent, consequent)
 	}
 
 	// Link the comments to the case statement
-	if self.mode&StoreComments != 0 {
-		self.comments.CommentMap.AddComments(node, comments, ast.LEADING)
+	if p.mode&StoreComments != 0 {
+		p.comments.CommentMap.AddComments(node, comments, ast.LEADING)
 	}
 
 	return node
 }
 
-func (self *_parser) parseIterationStatement() ast.Statement {
-	inIteration := self.scope.inIteration
-	self.scope.inIteration = true
+func (p *_parser) parseIterationStatement() ast.Statement {
+	inIteration := p.scope.inIteration
+	p.scope.inIteration = true
 	defer func() {
-		self.scope.inIteration = inIteration
+		p.scope.inIteration = inIteration
 	}()
-	return self.parseStatement()
+	return p.parseStatement()
 }
 
-func (self *_parser) parseForIn(into ast.Expression) *ast.ForInStatement {
+func (p *_parser) parseForIn(into ast.Expression) *ast.ForInStatement {
 	// Already have consumed "<into> in"
 
-	source := self.parseExpression()
-	self.expect(token.RIGHT_PARENTHESIS)
-	body := self.parseIterationStatement()
+	source := p.parseExpression()
+	p.expect(token.RIGHT_PARENTHESIS)
+	body := p.parseIterationStatement()
 
 	forin := &ast.ForInStatement{
 		Into:   into,
@@ -529,24 +513,24 @@ func (self *_parser) parseForIn(into ast.Expression) *ast.ForInStatement {
 	return forin
 }
 
-func (self *_parser) parseFor(initializer ast.Expression) *ast.ForStatement {
+func (p *_parser) parseFor(initializer ast.Expression) *ast.ForStatement {
 	// Already have consumed "<initializer> ;"
 
 	var test, update ast.Expression
 
-	if self.token != token.SEMICOLON {
-		test = self.parseExpression()
+	if p.token != token.SEMICOLON {
+		test = p.parseExpression()
 	}
-	if self.mode&StoreComments != 0 {
-		self.comments.Unset()
+	if p.mode&StoreComments != 0 {
+		p.comments.Unset()
 	}
-	self.expect(token.SEMICOLON)
+	p.expect(token.SEMICOLON)
 
-	if self.token != token.RIGHT_PARENTHESIS {
-		update = self.parseExpression()
+	if p.token != token.RIGHT_PARENTHESIS {
+		update = p.parseExpression()
 	}
-	self.expect(token.RIGHT_PARENTHESIS)
-	body := self.parseIterationStatement()
+	p.expect(token.RIGHT_PARENTHESIS)
+	body := p.parseIterationStatement()
 
 	forstatement := &ast.ForStatement{
 		Initializer: initializer,
@@ -558,54 +542,54 @@ func (self *_parser) parseFor(initializer ast.Expression) *ast.ForStatement {
 	return forstatement
 }
 
-func (self *_parser) parseForOrForInStatement() ast.Statement {
+func (p *_parser) parseForOrForInStatement() ast.Statement {
 	var comments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		comments = self.comments.FetchAll()
+	if p.mode&StoreComments != 0 {
+		comments = p.comments.FetchAll()
 	}
-	idx := self.expect(token.FOR)
+	idx := p.expect(token.FOR)
 	var forComments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		forComments = self.comments.FetchAll()
+	if p.mode&StoreComments != 0 {
+		forComments = p.comments.FetchAll()
 	}
-	self.expect(token.LEFT_PARENTHESIS)
+	p.expect(token.LEFT_PARENTHESIS)
 
 	var left []ast.Expression
 
 	forIn := false
-	if self.token != token.SEMICOLON {
-		allowIn := self.scope.allowIn
-		self.scope.allowIn = false
-		if self.token == token.VAR {
-			var_ := self.idx
+	if p.token != token.SEMICOLON {
+		allowIn := p.scope.allowIn
+		p.scope.allowIn = false
+		if p.token == token.VAR {
+			idx := p.idx
 			var varComments []*ast.Comment
-			if self.mode&StoreComments != 0 {
-				varComments = self.comments.FetchAll()
-				self.comments.Unset()
+			if p.mode&StoreComments != 0 {
+				varComments = p.comments.FetchAll()
+				p.comments.Unset()
 			}
-			self.next()
-			list := self.parseVariableDeclarationList(var_)
-			if len(list) == 1 && self.token == token.IN {
-				if self.mode&StoreComments != 0 {
-					self.comments.Unset()
+			p.next()
+			list := p.parseVariableDeclarationList(idx)
+			if len(list) == 1 && p.token == token.IN {
+				if p.mode&StoreComments != 0 {
+					p.comments.Unset()
 				}
-				self.next() // in
+				p.next() // in
 				forIn = true
 				left = []ast.Expression{list[0]} // There is only one declaration
 			} else {
 				left = list
 			}
-			if self.mode&StoreComments != 0 {
-				self.comments.CommentMap.AddComments(left[0], varComments, ast.LEADING)
+			if p.mode&StoreComments != 0 {
+				p.comments.CommentMap.AddComments(left[0], varComments, ast.LEADING)
 			}
 		} else {
-			left = append(left, self.parseExpression())
-			if self.token == token.IN {
-				self.next()
+			left = append(left, p.parseExpression())
+			if p.token == token.IN {
+				p.next()
 				forIn = true
 			}
 		}
-		self.scope.allowIn = allowIn
+		p.scope.allowIn = allowIn
 	}
 
 	if forIn {
@@ -613,209 +597,209 @@ func (self *_parser) parseForOrForInStatement() ast.Statement {
 		case *ast.Identifier, *ast.DotExpression, *ast.BracketExpression, *ast.VariableExpression:
 			// These are all acceptable
 		default:
-			self.error(idx, "Invalid left-hand side in for-in")
-			self.nextStatement()
-			return &ast.BadStatement{From: idx, To: self.idx}
+			p.error(idx, "Invalid left-hand side in for-in")
+			p.nextStatement()
+			return &ast.BadStatement{From: idx, To: p.idx}
 		}
 
-		forin := self.parseForIn(left[0])
-		if self.mode&StoreComments != 0 {
-			self.comments.CommentMap.AddComments(forin, comments, ast.LEADING)
-			self.comments.CommentMap.AddComments(forin, forComments, ast.FOR)
+		forin := p.parseForIn(left[0])
+		if p.mode&StoreComments != 0 {
+			p.comments.CommentMap.AddComments(forin, comments, ast.LEADING)
+			p.comments.CommentMap.AddComments(forin, forComments, ast.FOR)
 		}
 		return forin
 	}
 
-	if self.mode&StoreComments != 0 {
-		self.comments.Unset()
+	if p.mode&StoreComments != 0 {
+		p.comments.Unset()
 	}
-	self.expect(token.SEMICOLON)
+	p.expect(token.SEMICOLON)
 	initializer := &ast.SequenceExpression{Sequence: left}
-	forstatement := self.parseFor(initializer)
-	if self.mode&StoreComments != 0 {
-		self.comments.CommentMap.AddComments(forstatement, comments, ast.LEADING)
-		self.comments.CommentMap.AddComments(forstatement, forComments, ast.FOR)
+	forstatement := p.parseFor(initializer)
+	if p.mode&StoreComments != 0 {
+		p.comments.CommentMap.AddComments(forstatement, comments, ast.LEADING)
+		p.comments.CommentMap.AddComments(forstatement, forComments, ast.FOR)
 	}
 	return forstatement
 }
 
-func (self *_parser) parseVariableStatement() *ast.VariableStatement {
+func (p *_parser) parseVariableStatement() *ast.VariableStatement {
 	var comments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		comments = self.comments.FetchAll()
+	if p.mode&StoreComments != 0 {
+		comments = p.comments.FetchAll()
 	}
-	idx := self.expect(token.VAR)
+	idx := p.expect(token.VAR)
 
-	list := self.parseVariableDeclarationList(idx)
+	list := p.parseVariableDeclarationList(idx)
 
 	statement := &ast.VariableStatement{
 		Var:  idx,
 		List: list,
 	}
-	if self.mode&StoreComments != 0 {
-		self.comments.CommentMap.AddComments(statement, comments, ast.LEADING)
-		self.comments.Unset()
+	if p.mode&StoreComments != 0 {
+		p.comments.CommentMap.AddComments(statement, comments, ast.LEADING)
+		p.comments.Unset()
 	}
-	self.semicolon()
+	p.semicolon()
 
 	return statement
 }
 
-func (self *_parser) parseDoWhileStatement() ast.Statement {
-	inIteration := self.scope.inIteration
-	self.scope.inIteration = true
+func (p *_parser) parseDoWhileStatement() ast.Statement {
+	inIteration := p.scope.inIteration
+	p.scope.inIteration = true
 	defer func() {
-		self.scope.inIteration = inIteration
+		p.scope.inIteration = inIteration
 	}()
 
 	var comments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		comments = self.comments.FetchAll()
+	if p.mode&StoreComments != 0 {
+		comments = p.comments.FetchAll()
 	}
-	self.expect(token.DO)
+	p.expect(token.DO)
 	var doComments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		doComments = self.comments.FetchAll()
+	if p.mode&StoreComments != 0 {
+		doComments = p.comments.FetchAll()
 	}
 
 	node := &ast.DoWhileStatement{}
-	if self.token == token.LEFT_BRACE {
-		node.Body = self.parseBlockStatement()
+	if p.token == token.LEFT_BRACE {
+		node.Body = p.parseBlockStatement()
 	} else {
-		node.Body = self.parseStatement()
+		node.Body = p.parseStatement()
 	}
 
-	self.expect(token.WHILE)
+	p.expect(token.WHILE)
 	var whileComments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		whileComments = self.comments.FetchAll()
+	if p.mode&StoreComments != 0 {
+		whileComments = p.comments.FetchAll()
 	}
-	self.expect(token.LEFT_PARENTHESIS)
-	node.Test = self.parseExpression()
-	self.expect(token.RIGHT_PARENTHESIS)
+	p.expect(token.LEFT_PARENTHESIS)
+	node.Test = p.parseExpression()
+	p.expect(token.RIGHT_PARENTHESIS)
 
-	self.implicitSemicolon = true
-	self.optionalSemicolon()
+	p.implicitSemicolon = true
+	p.optionalSemicolon()
 
-	if self.mode&StoreComments != 0 {
-		self.comments.CommentMap.AddComments(node, comments, ast.LEADING)
-		self.comments.CommentMap.AddComments(node, doComments, ast.DO)
-		self.comments.CommentMap.AddComments(node, whileComments, ast.WHILE)
+	if p.mode&StoreComments != 0 {
+		p.comments.CommentMap.AddComments(node, comments, ast.LEADING)
+		p.comments.CommentMap.AddComments(node, doComments, ast.DO)
+		p.comments.CommentMap.AddComments(node, whileComments, ast.WHILE)
 	}
 
 	return node
 }
 
-func (self *_parser) parseWhileStatement() ast.Statement {
+func (p *_parser) parseWhileStatement() ast.Statement {
 	var comments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		comments = self.comments.FetchAll()
+	if p.mode&StoreComments != 0 {
+		comments = p.comments.FetchAll()
 	}
-	self.expect(token.WHILE)
+	p.expect(token.WHILE)
 
 	var whileComments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		whileComments = self.comments.FetchAll()
+	if p.mode&StoreComments != 0 {
+		whileComments = p.comments.FetchAll()
 	}
 
-	self.expect(token.LEFT_PARENTHESIS)
+	p.expect(token.LEFT_PARENTHESIS)
 	node := &ast.WhileStatement{
-		Test: self.parseExpression(),
+		Test: p.parseExpression(),
 	}
-	self.expect(token.RIGHT_PARENTHESIS)
-	node.Body = self.parseIterationStatement()
+	p.expect(token.RIGHT_PARENTHESIS)
+	node.Body = p.parseIterationStatement()
 
-	if self.mode&StoreComments != 0 {
-		self.comments.CommentMap.AddComments(node, comments, ast.LEADING)
-		self.comments.CommentMap.AddComments(node, whileComments, ast.WHILE)
+	if p.mode&StoreComments != 0 {
+		p.comments.CommentMap.AddComments(node, comments, ast.LEADING)
+		p.comments.CommentMap.AddComments(node, whileComments, ast.WHILE)
 	}
 
 	return node
 }
 
-func (self *_parser) parseIfStatement() ast.Statement {
+func (p *_parser) parseIfStatement() ast.Statement {
 	var comments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		comments = self.comments.FetchAll()
+	if p.mode&StoreComments != 0 {
+		comments = p.comments.FetchAll()
 	}
-	self.expect(token.IF)
+	p.expect(token.IF)
 	var ifComments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		ifComments = self.comments.FetchAll()
+	if p.mode&StoreComments != 0 {
+		ifComments = p.comments.FetchAll()
 	}
 
-	self.expect(token.LEFT_PARENTHESIS)
+	p.expect(token.LEFT_PARENTHESIS)
 	node := &ast.IfStatement{
-		If:   self.idx,
-		Test: self.parseExpression(),
+		If:   p.idx,
+		Test: p.parseExpression(),
 	}
-	self.expect(token.RIGHT_PARENTHESIS)
-	if self.token == token.LEFT_BRACE {
-		node.Consequent = self.parseBlockStatement()
+	p.expect(token.RIGHT_PARENTHESIS)
+	if p.token == token.LEFT_BRACE {
+		node.Consequent = p.parseBlockStatement()
 	} else {
-		node.Consequent = self.parseStatement()
+		node.Consequent = p.parseStatement()
 	}
 
-	if self.token == token.ELSE {
-		self.next()
-		node.Alternate = self.parseStatement()
+	if p.token == token.ELSE {
+		p.next()
+		node.Alternate = p.parseStatement()
 	}
 
-	if self.mode&StoreComments != 0 {
-		self.comments.CommentMap.AddComments(node, comments, ast.LEADING)
-		self.comments.CommentMap.AddComments(node, ifComments, ast.IF)
+	if p.mode&StoreComments != 0 {
+		p.comments.CommentMap.AddComments(node, comments, ast.LEADING)
+		p.comments.CommentMap.AddComments(node, ifComments, ast.IF)
 	}
 
 	return node
 }
 
-func (self *_parser) parseSourceElement() ast.Statement {
-	statement := self.parseStatement()
+func (p *_parser) parseSourceElement() ast.Statement {
+	statement := p.parseStatement()
 	return statement
 }
 
-func (self *_parser) parseSourceElements() []ast.Statement {
+func (p *_parser) parseSourceElements() []ast.Statement {
 	body := []ast.Statement(nil)
 
 	for {
-		if self.token != token.STRING {
+		if p.token != token.STRING {
 			break
 		}
-		body = append(body, self.parseSourceElement())
+		body = append(body, p.parseSourceElement())
 	}
 
-	for self.token != token.EOF {
-		body = append(body, self.parseSourceElement())
+	for p.token != token.EOF {
+		body = append(body, p.parseSourceElement())
 	}
 
 	return body
 }
 
-func (self *_parser) parseProgram() *ast.Program {
-	self.openScope()
-	defer self.closeScope()
+func (p *_parser) parseProgram() *ast.Program {
+	p.openScope()
+	defer p.closeScope()
 	return &ast.Program{
-		Body:            self.parseSourceElements(),
-		DeclarationList: self.scope.declarationList,
-		File:            self.file,
+		Body:            p.parseSourceElements(),
+		DeclarationList: p.scope.declarationList,
+		File:            p.file,
 	}
 }
 
-func (self *_parser) parseBreakStatement() ast.Statement {
+func (p *_parser) parseBreakStatement() ast.Statement {
 	var comments []*ast.Comment
-	if self.mode&StoreComments != 0 {
-		comments = self.comments.FetchAll()
+	if p.mode&StoreComments != 0 {
+		comments = p.comments.FetchAll()
 	}
-	idx := self.expect(token.BREAK)
-	semicolon := self.implicitSemicolon
-	if self.token == token.SEMICOLON {
+	idx := p.expect(token.BREAK)
+	semicolon := p.implicitSemicolon
+	if p.token == token.SEMICOLON {
 		semicolon = true
-		self.next()
+		p.next()
 	}
 
-	if semicolon || self.token == token.RIGHT_BRACE {
-		self.implicitSemicolon = false
-		if !self.scope.inIteration && !self.scope.inSwitch {
+	if semicolon || p.token == token.RIGHT_BRACE {
+		p.implicitSemicolon = false
+		if !p.scope.inIteration && !p.scope.inSwitch {
 			goto illegal
 		}
 		breakStatement := &ast.BranchStatement{
@@ -823,52 +807,52 @@ func (self *_parser) parseBreakStatement() ast.Statement {
 			Token: token.BREAK,
 		}
 
-		if self.mode&StoreComments != 0 {
-			self.comments.CommentMap.AddComments(breakStatement, comments, ast.LEADING)
-			self.comments.CommentMap.AddComments(breakStatement, self.comments.FetchAll(), ast.TRAILING)
+		if p.mode&StoreComments != 0 {
+			p.comments.CommentMap.AddComments(breakStatement, comments, ast.LEADING)
+			p.comments.CommentMap.AddComments(breakStatement, p.comments.FetchAll(), ast.TRAILING)
 		}
 
 		return breakStatement
 	}
 
-	if self.token == token.IDENTIFIER {
-		identifier := self.parseIdentifier()
-		if !self.scope.hasLabel(identifier.Name) {
-			self.error(idx, "Undefined label '%s'", identifier.Name)
+	if p.token == token.IDENTIFIER {
+		identifier := p.parseIdentifier()
+		if !p.scope.hasLabel(identifier.Name) {
+			p.error(idx, "Undefined label '%s'", identifier.Name)
 			return &ast.BadStatement{From: idx, To: identifier.Idx1()}
 		}
-		self.semicolon()
+		p.semicolon()
 		breakStatement := &ast.BranchStatement{
 			Idx:   idx,
 			Token: token.BREAK,
 			Label: identifier,
 		}
-		if self.mode&StoreComments != 0 {
-			self.comments.CommentMap.AddComments(breakStatement, comments, ast.LEADING)
+		if p.mode&StoreComments != 0 {
+			p.comments.CommentMap.AddComments(breakStatement, comments, ast.LEADING)
 		}
 
 		return breakStatement
 	}
 
-	self.expect(token.IDENTIFIER)
+	p.expect(token.IDENTIFIER)
 
 illegal:
-	self.error(idx, "Illegal break statement")
-	self.nextStatement()
-	return &ast.BadStatement{From: idx, To: self.idx}
+	p.error(idx, "Illegal break statement")
+	p.nextStatement()
+	return &ast.BadStatement{From: idx, To: p.idx}
 }
 
-func (self *_parser) parseContinueStatement() ast.Statement {
-	idx := self.expect(token.CONTINUE)
-	semicolon := self.implicitSemicolon
-	if self.token == token.SEMICOLON {
+func (p *_parser) parseContinueStatement() ast.Statement {
+	idx := p.expect(token.CONTINUE)
+	semicolon := p.implicitSemicolon
+	if p.token == token.SEMICOLON {
 		semicolon = true
-		self.next()
+		p.next()
 	}
 
-	if semicolon || self.token == token.RIGHT_BRACE {
-		self.implicitSemicolon = false
-		if !self.scope.inIteration {
+	if semicolon || p.token == token.RIGHT_BRACE {
+		p.implicitSemicolon = false
+		if !p.scope.inIteration {
 			goto illegal
 		}
 		return &ast.BranchStatement{
@@ -877,16 +861,16 @@ func (self *_parser) parseContinueStatement() ast.Statement {
 		}
 	}
 
-	if self.token == token.IDENTIFIER {
-		identifier := self.parseIdentifier()
-		if !self.scope.hasLabel(identifier.Name) {
-			self.error(idx, "Undefined label '%s'", identifier.Name)
+	if p.token == token.IDENTIFIER {
+		identifier := p.parseIdentifier()
+		if !p.scope.hasLabel(identifier.Name) {
+			p.error(idx, "Undefined label '%s'", identifier.Name)
 			return &ast.BadStatement{From: idx, To: identifier.Idx1()}
 		}
-		if !self.scope.inIteration {
+		if !p.scope.inIteration {
 			goto illegal
 		}
-		self.semicolon()
+		p.semicolon()
 		return &ast.BranchStatement{
 			Idx:   idx,
 			Token: token.CONTINUE,
@@ -894,18 +878,18 @@ func (self *_parser) parseContinueStatement() ast.Statement {
 		}
 	}
 
-	self.expect(token.IDENTIFIER)
+	p.expect(token.IDENTIFIER)
 
 illegal:
-	self.error(idx, "Illegal continue statement")
-	self.nextStatement()
-	return &ast.BadStatement{From: idx, To: self.idx}
+	p.error(idx, "Illegal continue statement")
+	p.nextStatement()
+	return &ast.BadStatement{From: idx, To: p.idx}
 }
 
-// Find the next statement after an error (recover)
-func (self *_parser) nextStatement() {
+// Find the next statement after an error (recover).
+func (p *_parser) nextStatement() {
 	for {
-		switch self.token {
+		switch p.token {
 		case token.BREAK, token.CONTINUE,
 			token.FOR, token.IF, token.RETURN, token.SWITCH,
 			token.VAR, token.DO, token.TRY, token.WITH,
@@ -914,13 +898,13 @@ func (self *_parser) nextStatement() {
 			// sync or if it has not reached 10 next calls without
 			// progress. Otherwise consume at least one token to
 			// avoid an endless parser loop
-			if self.idx == self.recover.idx && self.recover.count < 10 {
-				self.recover.count++
+			if p.idx == p.recover.idx && p.recover.count < 10 {
+				p.recover.count++
 				return
 			}
-			if self.idx > self.recover.idx {
-				self.recover.idx = self.idx
-				self.recover.count = 0
+			if p.idx > p.recover.idx {
+				p.recover.idx = p.idx
+				p.recover.count = 0
 				return
 			}
 			// Reaching here indicates a parser bug, likely an
@@ -931,6 +915,6 @@ func (self *_parser) nextStatement() {
 		case token.EOF:
 			return
 		}
-		self.next()
+		p.next()
 	}
 }

--- a/property.go
+++ b/property.go
@@ -2,87 +2,87 @@ package otto
 
 // property
 
-type _propertyMode int
+type propertyMode int
 
 const (
-	modeWriteMask     _propertyMode = 0700
-	modeEnumerateMask               = 0070
-	modeConfigureMask               = 0007
-	modeOnMask                      = 0111
-	modeSetMask                     = 0222 // If value is 2, then mode is neither "On" nor "Off"
+	modeWriteMask     propertyMode = 0o700
+	modeEnumerateMask propertyMode = 0o070
+	modeConfigureMask propertyMode = 0o007
+	modeOnMask        propertyMode = 0o111
+	modeSetMask       propertyMode = 0o222 // If value is 2, then mode is neither "On" nor "Off"
 )
 
-type _propertyGetSet [2]*_object
+type propertyGetSet [2]*object
 
-var _nilGetSetObject _object = _object{}
+var nilGetSetObject = object{}
 
-type _property struct {
+type property struct {
 	value interface{}
-	mode  _propertyMode
+	mode  propertyMode
 }
 
-func (self _property) writable() bool {
-	return self.mode&modeWriteMask == modeWriteMask&modeOnMask
+func (p property) writable() bool {
+	return p.mode&modeWriteMask == modeWriteMask&modeOnMask
 }
 
-func (self *_property) writeOn() {
-	self.mode = (self.mode & ^modeWriteMask) | (modeWriteMask & modeOnMask)
+func (p *property) writeOn() {
+	p.mode = (p.mode & ^modeWriteMask) | (modeWriteMask & modeOnMask)
 }
 
-func (self *_property) writeOff() {
-	self.mode &= ^modeWriteMask
+func (p *property) writeOff() {
+	p.mode &= ^modeWriteMask
 }
 
-func (self *_property) writeClear() {
-	self.mode = (self.mode & ^modeWriteMask) | (modeWriteMask & modeSetMask)
+func (p *property) writeClear() {
+	p.mode = (p.mode & ^modeWriteMask) | (modeWriteMask & modeSetMask)
 }
 
-func (self _property) writeSet() bool {
-	return 0 == self.mode&modeWriteMask&modeSetMask
+func (p property) writeSet() bool {
+	return p.mode&modeWriteMask&modeSetMask == 0
 }
 
-func (self _property) enumerable() bool {
-	return self.mode&modeEnumerateMask == modeEnumerateMask&modeOnMask
+func (p property) enumerable() bool {
+	return p.mode&modeEnumerateMask == modeEnumerateMask&modeOnMask
 }
 
-func (self *_property) enumerateOn() {
-	self.mode = (self.mode & ^modeEnumerateMask) | (modeEnumerateMask & modeOnMask)
+func (p *property) enumerateOn() {
+	p.mode = (p.mode & ^modeEnumerateMask) | (modeEnumerateMask & modeOnMask)
 }
 
-func (self *_property) enumerateOff() {
-	self.mode &= ^modeEnumerateMask
+func (p *property) enumerateOff() {
+	p.mode &= ^modeEnumerateMask
 }
 
-func (self _property) enumerateSet() bool {
-	return 0 == self.mode&modeEnumerateMask&modeSetMask
+func (p property) enumerateSet() bool {
+	return p.mode&modeEnumerateMask&modeSetMask == 0
 }
 
-func (self _property) configurable() bool {
-	return self.mode&modeConfigureMask == modeConfigureMask&modeOnMask
+func (p property) configurable() bool {
+	return p.mode&modeConfigureMask == modeConfigureMask&modeOnMask
 }
 
-func (self *_property) configureOn() {
-	self.mode = (self.mode & ^modeConfigureMask) | (modeConfigureMask & modeOnMask)
+func (p *property) configureOn() {
+	p.mode = (p.mode & ^modeConfigureMask) | (modeConfigureMask & modeOnMask)
 }
 
-func (self *_property) configureOff() {
-	self.mode &= ^modeConfigureMask
+func (p *property) configureOff() {
+	p.mode &= ^modeConfigureMask
 }
 
-func (self _property) configureSet() bool {
-	return 0 == self.mode&modeConfigureMask&modeSetMask
+func (p property) configureSet() bool { //nolint: unused
+	return p.mode&modeConfigureMask&modeSetMask == 0
 }
 
-func (self _property) copy() *_property {
-	property := self
-	return &property
+func (p property) copy() *property { //nolint: unused
+	cpy := p
+	return &cpy
 }
 
-func (self _property) get(this *_object) Value {
-	switch value := self.value.(type) {
+func (p property) get(this *object) Value {
+	switch value := p.value.(type) {
 	case Value:
 		return value
-	case _propertyGetSet:
+	case propertyGetSet:
 		if value[0] != nil {
 			return value[0].call(toValue(this), nil, false, nativeFrame)
 		}
@@ -90,64 +90,63 @@ func (self _property) get(this *_object) Value {
 	return Value{}
 }
 
-func (self _property) isAccessorDescriptor() bool {
-	setGet, test := self.value.(_propertyGetSet)
+func (p property) isAccessorDescriptor() bool {
+	setGet, test := p.value.(propertyGetSet)
 	return test && (setGet[0] != nil || setGet[1] != nil)
 }
 
-func (self _property) isDataDescriptor() bool {
-	if self.writeSet() { // Either "On" or "Off"
+func (p property) isDataDescriptor() bool {
+	if p.writeSet() { // Either "On" or "Off"
 		return true
 	}
-	value, valid := self.value.(Value)
+	value, valid := p.value.(Value)
 	return valid && !value.isEmpty()
 }
 
-func (self _property) isGenericDescriptor() bool {
-	return !(self.isDataDescriptor() || self.isAccessorDescriptor())
+func (p property) isGenericDescriptor() bool {
+	return !(p.isDataDescriptor() || p.isAccessorDescriptor())
 }
 
-func (self _property) isEmpty() bool {
-	return self.mode == 0222 && self.isGenericDescriptor()
+func (p property) isEmpty() bool {
+	return p.mode == 0o222 && p.isGenericDescriptor()
 }
 
 // _enumerableValue, _enumerableTrue, _enumerableFalse?
 // .enumerableValue() .enumerableExists()
 
-func toPropertyDescriptor(rt *_runtime, value Value) (descriptor _property) {
-	objectDescriptor := value._object()
+func toPropertyDescriptor(rt *runtime, value Value) property {
+	objectDescriptor := value.object()
 	if objectDescriptor == nil {
 		panic(rt.panicTypeError())
 	}
 
-	{
-		descriptor.mode = modeSetMask // Initially nothing is set
-		if objectDescriptor.hasProperty("enumerable") {
-			if objectDescriptor.get("enumerable").bool() {
-				descriptor.enumerateOn()
-			} else {
-				descriptor.enumerateOff()
-			}
-		}
-
-		if objectDescriptor.hasProperty("configurable") {
-			if objectDescriptor.get("configurable").bool() {
-				descriptor.configureOn()
-			} else {
-				descriptor.configureOff()
-			}
-		}
-
-		if objectDescriptor.hasProperty("writable") {
-			if objectDescriptor.get("writable").bool() {
-				descriptor.writeOn()
-			} else {
-				descriptor.writeOff()
-			}
+	var descriptor property
+	descriptor.mode = modeSetMask // Initially nothing is set
+	if objectDescriptor.hasProperty("enumerable") {
+		if objectDescriptor.get("enumerable").bool() {
+			descriptor.enumerateOn()
+		} else {
+			descriptor.enumerateOff()
 		}
 	}
 
-	var getter, setter *_object
+	if objectDescriptor.hasProperty("configurable") {
+		if objectDescriptor.get("configurable").bool() {
+			descriptor.configureOn()
+		} else {
+			descriptor.configureOff()
+		}
+	}
+
+	if objectDescriptor.hasProperty("writable") {
+		if objectDescriptor.get("writable").bool() {
+			descriptor.writeOn()
+		} else {
+			descriptor.writeOff()
+		}
+	}
+
+	var getter, setter *object
 	getterSetter := false
 
 	if objectDescriptor.hasProperty("get") {
@@ -156,10 +155,10 @@ func toPropertyDescriptor(rt *_runtime, value Value) (descriptor _property) {
 			if !value.isCallable() {
 				panic(rt.panicTypeError())
 			}
-			getter = value._object()
+			getter = value.object()
 			getterSetter = true
 		} else {
-			getter = &_nilGetSetObject
+			getter = &nilGetSetObject
 			getterSetter = true
 		}
 	}
@@ -170,10 +169,10 @@ func toPropertyDescriptor(rt *_runtime, value Value) (descriptor _property) {
 			if !value.isCallable() {
 				panic(rt.panicTypeError())
 			}
-			setter = value._object()
+			setter = value.object()
 			getterSetter = true
 		} else {
-			setter = &_nilGetSetObject
+			setter = &nilGetSetObject
 			getterSetter = true
 		}
 	}
@@ -182,7 +181,7 @@ func toPropertyDescriptor(rt *_runtime, value Value) (descriptor _property) {
 		if descriptor.writeSet() {
 			panic(rt.panicTypeError())
 		}
-		descriptor.value = _propertyGetSet{getter, setter}
+		descriptor.value = propertyGetSet{getter, setter}
 	}
 
 	if objectDescriptor.hasProperty("value") {
@@ -192,28 +191,28 @@ func toPropertyDescriptor(rt *_runtime, value Value) (descriptor _property) {
 		descriptor.value = objectDescriptor.get("value")
 	}
 
-	return
+	return descriptor
 }
 
-func (self *_runtime) fromPropertyDescriptor(descriptor _property) *_object {
-	object := self.newObject()
+func (rt *runtime) fromPropertyDescriptor(descriptor property) *object {
+	obj := rt.newObject()
 	if descriptor.isDataDescriptor() {
-		object.defineProperty("value", descriptor.value.(Value), 0111, false)
-		object.defineProperty("writable", toValue_bool(descriptor.writable()), 0111, false)
+		obj.defineProperty("value", descriptor.value.(Value), 0o111, false)
+		obj.defineProperty("writable", boolValue(descriptor.writable()), 0o111, false)
 	} else if descriptor.isAccessorDescriptor() {
-		getSet := descriptor.value.(_propertyGetSet)
+		getSet := descriptor.value.(propertyGetSet)
 		get := Value{}
 		if getSet[0] != nil {
-			get = toValue_object(getSet[0])
+			get = objectValue(getSet[0])
 		}
 		set := Value{}
 		if getSet[1] != nil {
-			set = toValue_object(getSet[1])
+			set = objectValue(getSet[1])
 		}
-		object.defineProperty("get", get, 0111, false)
-		object.defineProperty("set", set, 0111, false)
+		obj.defineProperty("get", get, 0o111, false)
+		obj.defineProperty("set", set, 0o111, false)
 	}
-	object.defineProperty("enumerable", toValue_bool(descriptor.enumerable()), 0111, false)
-	object.defineProperty("configurable", toValue_bool(descriptor.configurable()), 0111, false)
-	return object
+	obj.defineProperty("enumerable", boolValue(descriptor.enumerable()), 0o111, false)
+	obj.defineProperty("configurable", boolValue(descriptor.configurable()), 0o111, false)
+	return obj
 }

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type _abcStruct struct {
+type abcStruct struct {
 	Abc bool
 	Def int
 	Ghi string
@@ -21,91 +21,90 @@ type _abcStruct struct {
 	Pqr map[string]int8
 }
 
-func (abc _abcStruct) String() string {
+func (abc abcStruct) String() string {
 	return abc.Ghi
 }
 
-func (abc *_abcStruct) FuncPointer() string {
+func (abc *abcStruct) FuncPointer() string {
 	return "abc"
 }
 
-func (abc _abcStruct) Func() {
-	return
+func (abc abcStruct) Func() {
 }
 
-func (abc _abcStruct) FuncReturn1() string {
+func (abc abcStruct) FuncReturn1() string {
 	return "abc"
 }
 
-func (abc _abcStruct) FuncReturn2() (string, error) {
+func (abc abcStruct) FuncReturn2() (string, error) {
 	return "def", nil
 }
 
-func (abc _abcStruct) Func1Return1(a string) string {
+func (abc abcStruct) Func1Return1(a string) string {
 	return a
 }
 
-func (abc _abcStruct) Func2Return1(x, y string) string {
+func (abc abcStruct) Func2Return1(x, y string) string {
 	return x + y
 }
 
-func (abc _abcStruct) FuncEllipsis(xyz ...string) int {
+func (abc abcStruct) FuncEllipsis(xyz ...string) int {
 	return len(xyz)
 }
 
-func (abc _abcStruct) FuncReturnStruct() _mnoStruct {
+func (abc abcStruct) FuncReturnStruct() _mnoStruct {
 	return _mnoStruct{}
 }
 
-func (abs _abcStruct) Func1Int(i int) int {
+func (abc abcStruct) Func1Int(i int) int {
 	return i + 1
 }
 
-func (abs _abcStruct) Func1Int8(i int8) int8 {
+func (abc abcStruct) Func1Int8(i int8) int8 {
 	return i + 1
 }
 
-func (abs _abcStruct) Func1Int16(i int16) int16 {
+func (abc abcStruct) Func1Int16(i int16) int16 {
 	return i + 1
 }
 
-func (abs _abcStruct) Func1Int32(i int32) int32 {
+func (abc abcStruct) Func1Int32(i int32) int32 {
 	return i + 1
 }
 
-func (abs _abcStruct) Func1Int64(i int64) int64 {
+func (abc abcStruct) Func1Int64(i int64) int64 {
 	return i + 1
 }
 
-func (abs _abcStruct) Func1Uint(i uint) uint {
+func (abc abcStruct) Func1Uint(i uint) uint {
 	return i + 1
 }
 
-func (abs _abcStruct) Func1Uint8(i uint8) uint8 {
+func (abc abcStruct) Func1Uint8(i uint8) uint8 {
 	return i + 1
 }
 
-func (abs _abcStruct) Func1Uint16(i uint16) uint16 {
+func (abc abcStruct) Func1Uint16(i uint16) uint16 {
 	return i + 1
 }
 
-func (abs _abcStruct) Func1Uint32(i uint32) uint32 {
+func (abc abcStruct) Func1Uint32(i uint32) uint32 {
 	return i + 1
 }
 
-func (abs _abcStruct) Func1Uint64(i uint64) uint64 {
+func (abc abcStruct) Func1Uint64(i uint64) uint64 {
 	return i + 1
 }
 
-func (abs _abcStruct) Func2Int(i, j int) int {
+func (abc abcStruct) Func2Int(i, j int) int {
 	return i + j
 }
 
-func (abs _abcStruct) Func2StringInt(s string, i int) string {
+func (abc abcStruct) Func2StringInt(s string, i int) string {
 	return fmt.Sprintf("%v:%v", s, i)
 }
 
-func (abs _abcStruct) Func1IntVariadic(a ...int) int {
+func (abc abcStruct) Func1IntVariadic(a ...int) int {
 	t := 0
 	for _, i := range a {
 		t += i
@@ -113,7 +112,7 @@ func (abs _abcStruct) Func1IntVariadic(a ...int) int {
 	return t
 }
 
-func (abs _abcStruct) Func2IntVariadic(s string, a ...int) string {
+func (abc abcStruct) Func2IntVariadic(s string, a ...int) string {
 	t := 0
 	for _, i := range a {
 		t += i
@@ -121,7 +120,7 @@ func (abs _abcStruct) Func2IntVariadic(s string, a ...int) string {
 	return fmt.Sprintf("%v:%v", s, t)
 }
 
-func (abs _abcStruct) Func2IntArrayVariadic(s string, a ...[]int) string {
+func (abc abcStruct) Func2IntArrayVariadic(s string, a ...[]int) string {
 	t := 0
 	for _, i := range a {
 		for _, j := range i {
@@ -145,10 +144,12 @@ func TestReflect(t *testing.T) {
 		// These should panic
 		str := "test"
 		require.Panics(t, func() {
-			toValue("Xyzzy").toReflectValue(reflect.ValueOf(&str).Type())
+			_, err := toValue("Xyzzy").toReflectValue(reflect.ValueOf(&str).Type())
+			require.NoError(t, err)
 		})
 		require.Panics(t, func() {
-			stringToReflectValue("Xyzzy", reflect.Ptr)
+			_, err := stringToReflectValue("Xyzzy", reflect.Ptr)
+			require.NoError(t, err)
 		})
 	})
 }
@@ -159,7 +160,7 @@ func Test_reflectStruct(t *testing.T) {
 
 		// _abcStruct
 		{
-			abc := &_abcStruct{}
+			abc := &abcStruct{}
 			vm.Set("abc", abc)
 
 			test(`
@@ -173,7 +174,7 @@ func Test_reflectStruct(t *testing.T) {
                 [ abc.Abc, abc.Ghi ];
             `, "true,Nothing happens.")
 
-			*abc = _abcStruct{}
+			*abc = abcStruct{}
 
 			test(`
                 [ abc.Abc, abc.Ghi ];
@@ -699,7 +700,7 @@ func Test_reflectMapInterface(t *testing.T) {
 				"jkl":   "jkl",
 			}
 			vm.Set("abc", abc)
-			vm.Set("mno", &_abcStruct{})
+			vm.Set("mno", &abcStruct{})
 
 			test(`
                 abc.xyz = "pqr";
@@ -714,7 +715,7 @@ func Test_reflectMapInterface(t *testing.T) {
 			is(abc["xyz"], "pqr")
 			is(abc["ghi"], map[string]interface{}{})
 			is(abc["jkl"], float64(3.14159))
-			mno, valid := abc["mno"].(*_abcStruct)
+			mno, valid := abc["mno"].(*abcStruct)
 			is(valid, true)
 			is(mno.Abc, true)
 			is(mno.Ghi, "Something happens.")
@@ -727,7 +728,7 @@ func TestPassthrough(t *testing.T) {
 		test, vm := test()
 
 		{
-			abc := &_abcStruct{
+			abc := &abcStruct{
 				Mno: _mnoStruct{
 					Ghi: "<Mno.Ghi>",
 				},
@@ -762,13 +763,13 @@ func TestPassthrough(t *testing.T) {
 	})
 }
 
-type TestDynamicFunctionReturningInterface_MyStruct1 struct{} //nolint: errname
+type TestDynamicFunctionReturningInterfaceMyStruct1 struct{} //nolint: errname
 
-func (m *TestDynamicFunctionReturningInterface_MyStruct1) Error() string { return "MyStruct1" }
+func (m *TestDynamicFunctionReturningInterfaceMyStruct1) Error() string { return "MyStruct1" }
 
-type TestDynamicFunctionReturningInterface_MyStruct2 struct{} //nolint: errname
+type TestDynamicFunctionReturningInterfaceMyStruct2 struct{} //nolint: errname
 
-func (m *TestDynamicFunctionReturningInterface_MyStruct2) Error() string { return "MyStruct2" }
+func (m *TestDynamicFunctionReturningInterfaceMyStruct2) Error() string { return "MyStruct2" }
 
 func TestDynamicFunctionReturningInterface(t *testing.T) {
 	tt(t, func() {
@@ -777,8 +778,8 @@ func TestDynamicFunctionReturningInterface(t *testing.T) {
 		var l []func() error
 
 		vm.Set("r", func(cb func() error) { l = append(l, cb) })
-		vm.Set("e1", func() error { return &TestDynamicFunctionReturningInterface_MyStruct1{} })
-		vm.Set("e2", func() error { return &TestDynamicFunctionReturningInterface_MyStruct2{} })
+		vm.Set("e1", func() error { return &TestDynamicFunctionReturningInterfaceMyStruct1{} })
+		vm.Set("e2", func() error { return &TestDynamicFunctionReturningInterfaceMyStruct2{} })
 		vm.Set("e3", func() error { return nil })
 
 		test("r(function() { return e1(); })", UndefinedValue())
@@ -848,9 +849,9 @@ func TestStructCallParameterConversion(t *testing.T) {
 	})
 }
 
-type TestTextUnmarshallerCallParameterConversion_MyStruct struct{}
+type TestTextUnmarshallerCallParameterConversionMyStruct struct{}
 
-func (m *TestTextUnmarshallerCallParameterConversion_MyStruct) UnmarshalText(b []byte) error {
+func (m *TestTextUnmarshallerCallParameterConversionMyStruct) UnmarshalText(b []byte) error {
 	if string(b) == "good" {
 		return nil
 	}
@@ -862,7 +863,7 @@ func TestTextUnmarshallerCallParameterConversion(t *testing.T) {
 	tt(t, func() {
 		test, vm := test()
 
-		vm.Set("f", func(t TestTextUnmarshallerCallParameterConversion_MyStruct) bool { return true })
+		vm.Set("f", func(t TestTextUnmarshallerCallParameterConversionMyStruct) bool { return true })
 
 		// success
 		test("f('good')", true)
@@ -900,7 +901,8 @@ func TestJSONRawMessageCallParameterConversion(t *testing.T) {
 	} {
 		t.Run(e.c, func(t *testing.T) {
 			vm := New()
-			vm.Set("f", func(m json.RawMessage) json.RawMessage { return m })
+			err := vm.Set("f", func(m json.RawMessage) json.RawMessage { return m })
+			require.NoError(t, err)
 			r, err := vm.Run(e.c)
 			if err != nil {
 				if !e.e {

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -34,15 +34,15 @@ func TestRegExp(t *testing.T) {
 		test(`new RegExp("abc", "mig").toString()`, "/abc/gim")
 
 		result := test(`/(a)?/.exec('b')`, ",")
-		is(result._object().get("0"), "")
-		is(result._object().get("1"), "undefined")
-		is(result._object().get(propertyLength), 2)
+		is(result.object().get("0"), "")
+		is(result.object().get("1"), "undefined")
+		is(result.object().get(propertyLength), 2)
 
 		result = test(`/(a)?(b)?/.exec('b')`, "b,,b")
-		is(result._object().get("0"), "b")
-		is(result._object().get("1"), "undefined")
-		is(result._object().get("2"), "b")
-		is(result._object().get(propertyLength), 3)
+		is(result.object().get("0"), "b")
+		is(result.object().get("1"), "undefined")
+		is(result.object().get("2"), "b")
+		is(result.object().get(propertyLength), 3)
 
 		test(`/\u0041/.source`, "\\u0041")
 		test(`/\a/.source`, "\\a")
@@ -276,13 +276,13 @@ func TestRegExp_controlCharacter(t *testing.T) {
 		test, _ := test()
 
 		for code := 0x41; code < 0x5a; code++ {
-			string_ := string(rune(code - 64))
+			val := string(rune(code - 64))
 			test(fmt.Sprintf(`
                 var code = 0x%x;
                 var string = String.fromCharCode(code %% 32);
                 var result = (new RegExp("\\c" + String.fromCharCode(code))).exec(string);
                 [ code, string, result ];
-            `, code), fmt.Sprintf("%d,%s,%s", code, string_, string_))
+            `, code), fmt.Sprintf("%d,%s,%s", code, val, val))
 		}
 	})
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,17 +1,17 @@
-/*
-Package registry is an expirmental package to facillitate altering the otto runtime via import.
-
-This interface can change at any time.
-*/
+// Package registry is an experimental package to facilitate altering the otto runtime via import.
+//
+// This interface can change at any time.
 package registry
 
 var registry []*Entry = make([]*Entry, 0)
 
+// Entry represents a registry entry.
 type Entry struct {
 	active bool
 	source func() string
 }
 
+// newEntry returns a new Entry for source.
 func newEntry(source func() string) *Entry {
 	return &Entry{
 		active: true,
@@ -19,18 +19,22 @@ func newEntry(source func() string) *Entry {
 	}
 }
 
-func (self *Entry) Enable() {
-	self.active = true
+// Enable enables the entry.
+func (e *Entry) Enable() {
+	e.active = true
 }
 
-func (self *Entry) Disable() {
-	self.active = false
+// Disable disables the entry.
+func (e *Entry) Disable() {
+	e.active = false
 }
 
-func (self Entry) Source() string {
-	return self.source()
+// Source returns the source of the entry.
+func (e Entry) Source() string {
+	return e.source()
 }
 
+// Apply applies callback to all registry entries.
 func Apply(callback func(Entry)) {
 	for _, entry := range registry {
 		if !entry.active {
@@ -40,6 +44,7 @@ func Apply(callback func(Entry)) {
 	}
 }
 
+// Register registers a new Entry for source.
 func Register(source func() string) *Entry {
 	entry := newEntry(source)
 	registry = append(registry, entry)

--- a/repl/autocompleter.go
+++ b/repl/autocompleter.go
@@ -18,12 +18,8 @@ func (a *autoCompleter) Do(line []rune, pos int) ([][]rune, int) {
 
 	bits := strings.Split(lastExpression, ".")
 
-	first := bits[:len(bits)-1]
-	last := bits[len(bits)-1]
-
 	var l []string
-
-	if len(first) == 0 {
+	if first := bits[:len(bits)-1]; len(first) == 0 {
 		c := a.vm.Context()
 
 		l = make([]string, len(c.Symbols))
@@ -46,6 +42,7 @@ func (a *autoCompleter) Do(line []rune, pos int) ([][]rune, int) {
 		}
 	}
 
+	last := bits[len(bits)-1]
 	var r [][]rune
 	for _, s := range l {
 		if strings.HasPrefix(s, last) {

--- a/result.go
+++ b/result.go
@@ -1,28 +1,28 @@
 package otto
 
-type _resultKind int
+type resultKind int
 
 const (
-	_ _resultKind = iota
+	_ resultKind = iota
 	resultReturn
 	resultBreak
 	resultContinue
 )
 
-type _result struct {
-	kind   _resultKind
+type result struct {
+	kind   resultKind
 	value  Value
 	target string
 }
 
-func newReturnResult(value Value) _result {
-	return _result{resultReturn, value, ""}
+func newReturnResult(value Value) result {
+	return result{resultReturn, value, ""}
 }
 
-func newContinueResult(target string) _result {
-	return _result{resultContinue, emptyValue, target}
+func newContinueResult(target string) result {
+	return result{resultContinue, emptyValue, target}
 }
 
-func newBreakResult(target string) _result {
-	return _result{resultBreak, emptyValue, target}
+func newBreakResult(target string) result {
+	return result{resultBreak, emptyValue, target}
 }

--- a/runtime.go
+++ b/runtime.go
@@ -8,7 +8,7 @@ import (
 	"math"
 	"path"
 	"reflect"
-	"runtime"
+	goruntime "runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -17,49 +17,49 @@ import (
 	"github.com/robertkrimen/otto/parser"
 )
 
-type _global struct {
-	Object         *_object // Object( ... ), new Object( ... ) - 1 (length)
-	Function       *_object // Function( ... ), new Function( ... ) - 1
-	Array          *_object // Array( ... ), new Array( ... ) - 1
-	String         *_object // String( ... ), new String( ... ) - 1
-	Boolean        *_object // Boolean( ... ), new Boolean( ... ) - 1
-	Number         *_object // Number( ... ), new Number( ... ) - 1
-	Math           *_object
-	Date           *_object // Date( ... ), new Date( ... ) - 7
-	RegExp         *_object // RegExp( ... ), new RegExp( ... ) - 2
-	Error          *_object // Error( ... ), new Error( ... ) - 1
-	EvalError      *_object
-	TypeError      *_object
-	RangeError     *_object
-	ReferenceError *_object
-	SyntaxError    *_object
-	URIError       *_object
-	JSON           *_object
+type global struct {
+	Object         *object // Object( ... ), new Object( ... ) - 1 (length)
+	Function       *object // Function( ... ), new Function( ... ) - 1
+	Array          *object // Array( ... ), new Array( ... ) - 1
+	String         *object // String( ... ), new String( ... ) - 1
+	Boolean        *object // Boolean( ... ), new Boolean( ... ) - 1
+	Number         *object // Number( ... ), new Number( ... ) - 1
+	Math           *object
+	Date           *object // Date( ... ), new Date( ... ) - 7
+	RegExp         *object // RegExp( ... ), new RegExp( ... ) - 2
+	Error          *object // Error( ... ), new Error( ... ) - 1
+	EvalError      *object
+	TypeError      *object
+	RangeError     *object
+	ReferenceError *object
+	SyntaxError    *object
+	URIError       *object
+	JSON           *object
 
-	ObjectPrototype         *_object // Object.prototype
-	FunctionPrototype       *_object // Function.prototype
-	ArrayPrototype          *_object // Array.prototype
-	StringPrototype         *_object // String.prototype
-	BooleanPrototype        *_object // Boolean.prototype
-	NumberPrototype         *_object // Number.prototype
-	DatePrototype           *_object // Date.prototype
-	RegExpPrototype         *_object // RegExp.prototype
-	ErrorPrototype          *_object // Error.prototype
-	EvalErrorPrototype      *_object
-	TypeErrorPrototype      *_object
-	RangeErrorPrototype     *_object
-	ReferenceErrorPrototype *_object
-	SyntaxErrorPrototype    *_object
-	URIErrorPrototype       *_object
+	ObjectPrototype         *object // Object.prototype
+	FunctionPrototype       *object // Function.prototype
+	ArrayPrototype          *object // Array.prototype
+	StringPrototype         *object // String.prototype
+	BooleanPrototype        *object // Boolean.prototype
+	NumberPrototype         *object // Number.prototype
+	DatePrototype           *object // Date.prototype
+	RegExpPrototype         *object // RegExp.prototype
+	ErrorPrototype          *object // Error.prototype
+	EvalErrorPrototype      *object
+	TypeErrorPrototype      *object
+	RangeErrorPrototype     *object
+	ReferenceErrorPrototype *object
+	SyntaxErrorPrototype    *object
+	URIErrorPrototype       *object
 }
 
-type _runtime struct {
-	global       _global
-	globalObject *_object
-	globalStash  *_objectStash
-	scope        *_scope
+type runtime struct {
+	global       global
+	globalObject *object
+	globalStash  *objectStash
+	scope        *scope
 	otto         *Otto
-	eval         *_object // The builtin eval, for determine indirect versus direct invocation
+	eval         *object // The builtin eval, for determine indirect versus direct invocation
 	debugger     func(*Otto)
 	random       func() float64
 	stackLimit   int
@@ -69,54 +69,54 @@ type _runtime struct {
 	lck    sync.Mutex
 }
 
-func (self *_runtime) enterScope(scope *_scope) {
-	scope.outer = self.scope
-	if self.scope != nil {
-		if self.stackLimit != 0 && self.scope.depth+1 >= self.stackLimit {
-			panic(self.panicRangeError("Maximum call stack size exceeded"))
+func (rt *runtime) enterScope(scop *scope) {
+	scop.outer = rt.scope
+	if rt.scope != nil {
+		if rt.stackLimit != 0 && rt.scope.depth+1 >= rt.stackLimit {
+			panic(rt.panicRangeError("Maximum call stack size exceeded"))
 		}
 
-		scope.depth = self.scope.depth + 1
+		scop.depth = rt.scope.depth + 1
 	}
 
-	self.scope = scope
+	rt.scope = scop
 }
 
-func (self *_runtime) leaveScope() {
-	self.scope = self.scope.outer
+func (rt *runtime) leaveScope() {
+	rt.scope = rt.scope.outer
 }
 
-// FIXME This is used in two places (cloning)
-func (self *_runtime) enterGlobalScope() {
-	self.enterScope(newScope(self.globalStash, self.globalStash, self.globalObject))
+// FIXME This is used in two places (cloning).
+func (rt *runtime) enterGlobalScope() {
+	rt.enterScope(newScope(rt.globalStash, rt.globalStash, rt.globalObject))
 }
 
-func (self *_runtime) enterFunctionScope(outer _stash, this Value) *_fnStash {
+func (rt *runtime) enterFunctionScope(outer stasher, this Value) *fnStash {
 	if outer == nil {
-		outer = self.globalStash
+		outer = rt.globalStash
 	}
-	stash := self.newFunctionStash(outer)
-	var thisObject *_object
+	stash := rt.newFunctionStash(outer)
+	var thisObject *object
 	switch this.kind {
 	case valueUndefined, valueNull:
-		thisObject = self.globalObject
+		thisObject = rt.globalObject
 	default:
-		thisObject = self.toObject(this)
+		thisObject = rt.toObject(this)
 	}
-	self.enterScope(newScope(stash, stash, thisObject))
+	rt.enterScope(newScope(stash, stash, thisObject))
 	return stash
 }
 
-func (self *_runtime) putValue(reference _reference, value Value) {
+func (rt *runtime) putValue(reference referencer, value Value) {
 	name := reference.putValue(value)
 	if name != "" {
 		// Why? -- If reference.base == nil
 		// strict = false
-		self.globalObject.defineProperty(name, value, 0111, false)
+		rt.globalObject.defineProperty(name, value, 0o111, false)
 	}
 }
 
-func (self *_runtime) tryCatchEvaluate(inner func() Value) (tryValue Value, exception bool) {
+func (rt *runtime) tryCatchEvaluate(inner func() Value) (tryValue Value, isException bool) { //nolint: nonamedreturns
 	// resultValue = The value of the block (e.g. the last statement)
 	// throw = Something was thrown
 	// throwValue = The value of what was thrown
@@ -124,18 +124,18 @@ func (self *_runtime) tryCatchEvaluate(inner func() Value) (tryValue Value, exce
 	// Otherwise, some sort of unknown panic happened, we'll just propagate it.
 	defer func() {
 		if caught := recover(); caught != nil {
-			if exception, ok := caught.(*_exception); ok {
-				caught = exception.eject()
+			if excep, ok := caught.(*exception); ok {
+				caught = excep.eject()
 			}
 			switch caught := caught.(type) {
-			case _error:
-				exception = true
-				tryValue = toValue_object(self.newErrorObjectError(caught))
+			case ottoError:
+				isException = true
+				tryValue = objectValue(rt.newErrorObjectError(caught))
 			case Value:
-				exception = true
+				isException = true
 				tryValue = caught
 			default:
-				exception = true
+				isException = true
 				tryValue = toValue(caught)
 			}
 		}
@@ -144,43 +144,43 @@ func (self *_runtime) tryCatchEvaluate(inner func() Value) (tryValue Value, exce
 	return inner(), false
 }
 
-// toObject
-
-func (self *_runtime) toObject(value Value) *_object {
+func (rt *runtime) toObject(value Value) *object {
 	switch value.kind {
 	case valueEmpty, valueUndefined, valueNull:
-		panic(self.panicTypeError())
+		panic(rt.panicTypeError())
 	case valueBoolean:
-		return self.newBoolean(value)
+		return rt.newBoolean(value)
 	case valueString:
-		return self.newString(value)
+		return rt.newString(value)
 	case valueNumber:
-		return self.newNumber(value)
+		return rt.newNumber(value)
 	case valueObject:
-		return value._object()
+		return value.object()
+	default:
+		panic(rt.panicTypeError())
 	}
-	panic(self.panicTypeError())
 }
 
-func (self *_runtime) objectCoerce(value Value) (*_object, error) {
+func (rt *runtime) objectCoerce(value Value) (*object, error) {
 	switch value.kind {
 	case valueUndefined:
 		return nil, errors.New("undefined")
 	case valueNull:
 		return nil, errors.New("null")
 	case valueBoolean:
-		return self.newBoolean(value), nil
+		return rt.newBoolean(value), nil
 	case valueString:
-		return self.newString(value), nil
+		return rt.newString(value), nil
 	case valueNumber:
-		return self.newNumber(value), nil
+		return rt.newNumber(value), nil
 	case valueObject:
-		return value._object(), nil
+		return value.object(), nil
+	default:
+		panic(rt.panicTypeError())
 	}
-	panic(self.panicTypeError())
 }
 
-func checkObjectCoercible(rt *_runtime, value Value) {
+func checkObjectCoercible(rt *runtime, value Value) {
 	isObject, mustCoerce := testObjectCoercible(value)
 	if !isObject && !mustCoerce {
 		panic(rt.panicTypeError())
@@ -189,7 +189,7 @@ func checkObjectCoercible(rt *_runtime, value Value) {
 
 // testObjectCoercible
 
-func testObjectCoercible(value Value) (isObject bool, mustCoerce bool) {
+func testObjectCoercible(value Value) (isObject, mustCoerce bool) { //nolint: nonamedreturns
 	switch value.kind {
 	case valueReference, valueEmpty, valueNull, valueUndefined:
 		return false, false
@@ -202,17 +202,17 @@ func testObjectCoercible(value Value) (isObject bool, mustCoerce bool) {
 	}
 }
 
-func (self *_runtime) safeToValue(value interface{}) (Value, error) {
+func (rt *runtime) safeToValue(value interface{}) (Value, error) {
 	result := Value{}
 	err := catchPanic(func() {
-		result = self.toValue(value)
+		result = rt.toValue(value)
 	})
 	return result, err
 }
 
 // convertNumeric converts numeric parameter val from js to that of type t if it is safe to do so, otherwise it panics.
 // This allows literals (int64), bitwise values (int32) and the general form (float64) of javascript numerics to be passed as parameters to go functions easily.
-func (self *_runtime) convertNumeric(v Value, t reflect.Type) reflect.Value {
+func (rt *runtime) convertNumeric(v Value, t reflect.Type) reflect.Value {
 	val := reflect.ValueOf(v.export())
 
 	if val.Kind() == t.Kind() {
@@ -231,20 +231,20 @@ func (self *_runtime) convertNumeric(v Value, t reflect.Type) reflect.Value {
 			return reflect.ValueOf(f64)
 		case reflect.Float32:
 			if reflect.Zero(t).OverflowFloat(f64) {
-				panic(self.panicRangeError("converting float64 to float32 would overflow"))
+				panic(rt.panicRangeError("converting float64 to float32 would overflow"))
 			}
 
 			return val.Convert(t)
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 			i64 := int64(f64)
 			if float64(i64) != f64 {
-				panic(self.panicRangeError(fmt.Sprintf("converting %v to %v would cause loss of precision", val.Type(), t)))
+				panic(rt.panicRangeError(fmt.Sprintf("converting %v to %v would cause loss of precision", val.Type(), t)))
 			}
 
 			// The float represents an integer
 			val = reflect.ValueOf(i64)
 		default:
-			panic(self.panicTypeError(fmt.Sprintf("cannot convert %v to %v", val.Type(), t)))
+			panic(rt.panicTypeError(fmt.Sprintf("cannot convert %v to %v", val.Type(), t)))
 		}
 	}
 
@@ -254,15 +254,15 @@ func (self *_runtime) convertNumeric(v Value, t reflect.Type) reflect.Value {
 		switch t.Kind() {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			if reflect.Zero(t).OverflowInt(i64) {
-				panic(self.panicRangeError(fmt.Sprintf("converting %v to %v would overflow", val.Type(), t)))
+				panic(rt.panicRangeError(fmt.Sprintf("converting %v to %v would overflow", val.Type(), t)))
 			}
 			return val.Convert(t)
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 			if i64 < 0 {
-				panic(self.panicRangeError(fmt.Sprintf("converting %v to %v would underflow", val.Type(), t)))
+				panic(rt.panicRangeError(fmt.Sprintf("converting %v to %v would underflow", val.Type(), t)))
 			}
 			if reflect.Zero(t).OverflowUint(uint64(i64)) {
-				panic(self.panicRangeError(fmt.Sprintf("converting %v to %v would overflow", val.Type(), t)))
+				panic(rt.panicRangeError(fmt.Sprintf("converting %v to %v would overflow", val.Type(), t)))
 			}
 			return val.Convert(t)
 		case reflect.Float32, reflect.Float64:
@@ -274,12 +274,12 @@ func (self *_runtime) convertNumeric(v Value, t reflect.Type) reflect.Value {
 		switch t.Kind() {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			if u64 > math.MaxInt64 || reflect.Zero(t).OverflowInt(int64(u64)) {
-				panic(self.panicRangeError(fmt.Sprintf("converting %v to %v would overflow", val.Type(), t)))
+				panic(rt.panicRangeError(fmt.Sprintf("converting %v to %v would overflow", val.Type(), t)))
 			}
 			return val.Convert(t)
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 			if reflect.Zero(t).OverflowUint(u64) {
-				panic(self.panicRangeError(fmt.Sprintf("converting %v to %v would overflow", val.Type(), t)))
+				panic(rt.panicRangeError(fmt.Sprintf("converting %v to %v would overflow", val.Type(), t)))
 			}
 			return val.Convert(t)
 		case reflect.Float32, reflect.Float64:
@@ -287,7 +287,7 @@ func (self *_runtime) convertNumeric(v Value, t reflect.Type) reflect.Value {
 		}
 	}
 
-	panic(self.panicTypeError(fmt.Sprintf("unsupported type %v -> %v for numeric conversion", val.Type(), t)))
+	panic(rt.panicTypeError(fmt.Sprintf("unsupported type %v -> %v for numeric conversion", val.Type(), t)))
 }
 
 func fieldIndexByName(t reflect.Type, name string) []int {
@@ -332,13 +332,15 @@ func fieldIndexByName(t reflect.Type, name string) []int {
 	return nil
 }
 
-var typeOfValue = reflect.TypeOf(Value{})
-var typeOfJSONRawMessage = reflect.TypeOf(json.RawMessage{})
+var (
+	typeOfValue          = reflect.TypeOf(Value{})
+	typeOfJSONRawMessage = reflect.TypeOf(json.RawMessage{})
+)
 
 // convertCallParameter converts request val to type t if possible.
 // If the conversion fails due to overflow or type miss-match then it panics.
 // If no conversion is known then the original value is returned.
-func (self *_runtime) convertCallParameter(v Value, t reflect.Type) (reflect.Value, error) {
+func (rt *runtime) convertCallParameter(v Value, t reflect.Type) (reflect.Value, error) {
 	if t == typeOfValue {
 		return reflect.ValueOf(v), nil
 	}
@@ -350,25 +352,23 @@ func (self *_runtime) convertCallParameter(v Value, t reflect.Type) (reflect.Val
 	}
 
 	if v.kind == valueObject {
-		if gso, ok := v._object().value.(*_goStructObject); ok {
+		if gso, ok := v.object().value.(*goStructObject); ok {
 			if gso.value.Type().AssignableTo(t) {
 				// please see TestDynamicFunctionReturningInterface for why this exists
 				if t.Kind() == reflect.Interface && gso.value.Type().ConvertibleTo(t) {
 					return gso.value.Convert(t), nil
-				} else {
-					return gso.value, nil
 				}
+				return gso.value, nil
 			}
 		}
 
-		if gao, ok := v._object().value.(*_goArrayObject); ok {
+		if gao, ok := v.object().value.(*goArrayObject); ok {
 			if gao.value.Type().AssignableTo(t) {
 				// please see TestDynamicFunctionReturningInterface for why this exists
 				if t.Kind() == reflect.Interface && gao.value.Type().ConvertibleTo(t) {
 					return gao.value.Convert(t), nil
-				} else {
-					return gao.value, nil
 				}
+				return gao.value, nil
 			}
 		}
 	}
@@ -392,9 +392,9 @@ func (self *_runtime) convertCallParameter(v Value, t reflect.Type) (reflect.Val
 			return reflect.Zero(t), nil
 		default:
 			var vv reflect.Value
-			vv, err := self.convertCallParameter(v, t.Elem())
+			vv, err := rt.convertCallParameter(v, t.Elem())
 			if err != nil {
-				return reflect.Zero(t), fmt.Errorf("can't convert to %s: %s", t, err.Error())
+				return reflect.Zero(t), fmt.Errorf("can't convert to %s: %w", t, err)
 			}
 
 			if vv.CanAddr() {
@@ -418,12 +418,11 @@ func (self *_runtime) convertCallParameter(v Value, t reflect.Type) (reflect.Val
 			return reflect.ValueOf(fmt.Sprintf("%v", v.value)), nil
 		}
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Float32, reflect.Float64:
-		switch v.kind {
-		case valueNumber:
-			return self.convertNumeric(v, t), nil
+		if v.kind == valueNumber {
+			return rt.convertNumeric(v, t), nil
 		}
 	case reflect.Slice:
-		if o := v._object(); o != nil {
+		if o := v.object(); o != nil {
 			if lv := o.get(propertyLength); lv.IsNumber() {
 				l := lv.number().int64
 
@@ -432,7 +431,7 @@ func (self *_runtime) convertCallParameter(v Value, t reflect.Type) (reflect.Val
 				tt := t.Elem()
 
 				switch o.class {
-				case classArray:
+				case classArrayName:
 					for i := int64(0); i < l; i++ {
 						p, ok := o.property[strconv.FormatInt(i, 10)]
 						if !ok {
@@ -444,24 +443,24 @@ func (self *_runtime) convertCallParameter(v Value, t reflect.Type) (reflect.Val
 							continue
 						}
 
-						ev, err := self.convertCallParameter(e, tt)
+						ev, err := rt.convertCallParameter(e, tt)
 						if err != nil {
-							return reflect.Zero(t), fmt.Errorf("couldn't convert element %d of %s: %s", i, t, err.Error())
+							return reflect.Zero(t), fmt.Errorf("couldn't convert element %d of %s: %w", i, t, err)
 						}
 
 						s.Index(int(i)).Set(ev)
 					}
-				case classGoArray, classGoSlice:
+				case classGoArrayName, classGoSliceName:
 					var gslice bool
 					switch o.value.(type) {
-					case *_goSliceObject:
+					case *goSliceObject:
 						gslice = true
-					case *_goArrayObject:
+					case *goArrayObject:
 						gslice = false
 					}
 
 					for i := int64(0); i < l; i++ {
-						var p *_property
+						var p *property
 						if gslice {
 							p = goSliceGetOwnProperty(o, strconv.FormatInt(i, 10))
 						} else {
@@ -476,9 +475,9 @@ func (self *_runtime) convertCallParameter(v Value, t reflect.Type) (reflect.Val
 							continue
 						}
 
-						ev, err := self.convertCallParameter(e, tt)
+						ev, err := rt.convertCallParameter(e, tt)
 						if err != nil {
-							return reflect.Zero(t), fmt.Errorf("couldn't convert element %d of %s: %s", i, t, err.Error())
+							return reflect.Zero(t), fmt.Errorf("couldn't convert element %d of %s: %w", i, t, err)
 						}
 
 						s.Index(int(i)).Set(ev)
@@ -489,15 +488,15 @@ func (self *_runtime) convertCallParameter(v Value, t reflect.Type) (reflect.Val
 			}
 		}
 	case reflect.Map:
-		if o := v._object(); o != nil && t.Key().Kind() == reflect.String {
+		if o := v.object(); o != nil && t.Key().Kind() == reflect.String {
 			m := reflect.MakeMap(t)
 
 			var err error
 
 			o.enumerate(false, func(k string) bool {
-				v, verr := self.convertCallParameter(o.get(k), t.Elem())
+				v, verr := rt.convertCallParameter(o.get(k), t.Elem())
 				if verr != nil {
-					err = fmt.Errorf("couldn't convert property %q of %s: %s", k, t, verr.Error())
+					err = fmt.Errorf("couldn't convert property %q of %s: %w", k, t, verr)
 					return false
 				}
 				m.SetMapIndex(reflect.ValueOf(k), v)
@@ -515,7 +514,7 @@ func (self *_runtime) convertCallParameter(v Value, t reflect.Type) (reflect.Val
 			return reflect.Zero(t), fmt.Errorf("converting JavaScript values to Go functions with more than one return value is currently not supported")
 		}
 
-		if o := v._object(); o != nil && o.class == classFunction {
+		if o := v.object(); o != nil && o.class == classFunctionName {
 			return reflect.MakeFunc(t, func(args []reflect.Value) []reflect.Value {
 				l := make([]interface{}, len(args))
 				for i, a := range args {
@@ -533,16 +532,16 @@ func (self *_runtime) convertCallParameter(v Value, t reflect.Type) (reflect.Val
 					return nil
 				}
 
-				r, err := self.convertCallParameter(rv, t.Out(0))
+				r, err := rt.convertCallParameter(rv, t.Out(0))
 				if err != nil {
-					panic(self.panicTypeError(err.Error()))
+					panic(rt.panicTypeError(err.Error()))
 				}
 
 				return []reflect.Value{r}
 			}), nil
 		}
 	case reflect.Struct:
-		if o := v._object(); o != nil && o.class == classObject {
+		if o := v.object(); o != nil && o.class == classObjectName {
 			s := reflect.New(t)
 
 			for _, k := range o.propertyOrder {
@@ -570,9 +569,9 @@ func (self *_runtime) convertCallParameter(v Value, t reflect.Type) (reflect.Val
 					ss = ss.Field(i)
 				}
 
-				v, err := self.convertCallParameter(o.get(k), ss.Type())
+				v, err := rt.convertCallParameter(o.get(k), ss.Type())
 				if err != nil {
-					return reflect.Zero(t), fmt.Errorf("couldn't convert property %q of %s: %s", k, t, err.Error())
+					return reflect.Zero(t), fmt.Errorf("couldn't convert property %q of %s: %w", k, t, err)
 				}
 
 				ss.Set(v)
@@ -583,16 +582,16 @@ func (self *_runtime) convertCallParameter(v Value, t reflect.Type) (reflect.Val
 	}
 
 	if tk == reflect.String {
-		if o := v._object(); o != nil && o.hasProperty("toString") {
+		if o := v.object(); o != nil && o.hasProperty("toString") {
 			if fn := o.get("toString"); fn.IsFunction() {
 				sv, err := fn.Call(v)
 				if err != nil {
-					return reflect.Zero(t), fmt.Errorf("couldn't call toString: %s", err.Error())
+					return reflect.Zero(t), fmt.Errorf("couldn't call toString: %w", err)
 				}
 
-				r, err := self.convertCallParameter(sv, t)
+				r, err := rt.convertCallParameter(sv, t)
 				if err != nil {
-					return reflect.Zero(t), fmt.Errorf("couldn't convert toString result: %s", err.Error())
+					return reflect.Zero(t), fmt.Errorf("couldn't convert toString result: %w", err)
 				}
 				return r, nil
 			}
@@ -608,7 +607,7 @@ func (self *_runtime) convertCallParameter(v Value, t reflect.Type) (reflect.Val
 			r := reflect.New(t)
 
 			if err := r.Interface().(encoding.TextUnmarshaler).UnmarshalText([]byte(v.string())); err != nil {
-				return reflect.Zero(t), fmt.Errorf("can't convert to %s as TextUnmarshaller: %s", t.String(), err.Error())
+				return reflect.Zero(t), fmt.Errorf("can't convert to %s as TextUnmarshaller: %w", t.String(), err)
 			}
 
 			return r.Elem(), nil
@@ -634,7 +633,7 @@ func (self *_runtime) convertCallParameter(v Value, t reflect.Type) (reflect.Val
 	return reflect.Zero(t), fmt.Errorf("can't convert from %q to %q", s, t)
 }
 
-func (self *_runtime) toValue(value interface{}) Value {
+func (rt *runtime) toValue(value interface{}) Value {
 	rv, ok := value.(reflect.Value)
 	if ok {
 		value = rv.Interface()
@@ -647,173 +646,171 @@ func (self *_runtime) toValue(value interface{}) Value {
 		var name, file string
 		var line int
 		pc := reflect.ValueOf(value).Pointer()
-		fn := runtime.FuncForPC(pc)
+		fn := goruntime.FuncForPC(pc)
 		if fn != nil {
 			name = fn.Name()
 			file, line = fn.FileLine(pc)
 			file = path.Base(file)
 		}
-		return toValue_object(self.newNativeFunction(name, file, line, value))
-	case _nativeFunction:
+		return objectValue(rt.newNativeFunction(name, file, line, value))
+	case nativeFunction:
 		var name, file string
 		var line int
 		pc := reflect.ValueOf(value).Pointer()
-		fn := runtime.FuncForPC(pc)
+		fn := goruntime.FuncForPC(pc)
 		if fn != nil {
 			name = fn.Name()
 			file, line = fn.FileLine(pc)
 			file = path.Base(file)
 		}
-		return toValue_object(self.newNativeFunction(name, file, line, value))
-	case Object, *Object, _object, *_object:
+		return objectValue(rt.newNativeFunction(name, file, line, value))
+	case Object, *Object, object, *object:
 		// Nothing happens.
 		// FIXME We should really figure out what can come here.
 		// This catch-all is ugly.
 	default:
-		{
-			value := reflect.ValueOf(value)
-			if ok && value.Kind() == rv.Kind() {
-				// Use passed in rv which may be writable.
-				value = rv
-			}
+		val := reflect.ValueOf(value)
+		if ok && val.Kind() == rv.Kind() {
+			// Use passed in rv which may be writable.
+			val = rv
+		}
 
-			switch value.Kind() {
-			case reflect.Ptr:
-				switch reflect.Indirect(value).Kind() {
-				case reflect.Struct:
-					return toValue_object(self.newGoStructObject(value))
-				case reflect.Array:
-					return toValue_object(self.newGoArray(value))
-				}
+		switch val.Kind() {
+		case reflect.Ptr:
+			switch reflect.Indirect(val).Kind() {
 			case reflect.Struct:
-				return toValue_object(self.newGoStructObject(value))
-			case reflect.Map:
-				return toValue_object(self.newGoMapObject(value))
-			case reflect.Slice:
-				return toValue_object(self.newGoSlice(value))
+				return objectValue(rt.newGoStructObject(val))
 			case reflect.Array:
-				return toValue_object(self.newGoArray(value))
-			case reflect.Func:
-				var name, file string
-				var line int
-				if v := reflect.ValueOf(value); v.Kind() == reflect.Ptr {
-					pc := v.Pointer()
-					fn := runtime.FuncForPC(pc)
-					if fn != nil {
-						name = fn.Name()
-						file, line = fn.FileLine(pc)
-						file = path.Base(file)
+				return objectValue(rt.newGoArray(val))
+			}
+		case reflect.Struct:
+			return objectValue(rt.newGoStructObject(val))
+		case reflect.Map:
+			return objectValue(rt.newGoMapObject(val))
+		case reflect.Slice:
+			return objectValue(rt.newGoSlice(val))
+		case reflect.Array:
+			return objectValue(rt.newGoArray(val))
+		case reflect.Func:
+			var name, file string
+			var line int
+			if v := reflect.ValueOf(val); v.Kind() == reflect.Ptr {
+				pc := v.Pointer()
+				fn := goruntime.FuncForPC(pc)
+				if fn != nil {
+					name = fn.Name()
+					file, line = fn.FileLine(pc)
+					file = path.Base(file)
+				}
+			}
+
+			typ := val.Type()
+
+			return objectValue(rt.newNativeFunction(name, file, line, func(c FunctionCall) Value {
+				nargs := typ.NumIn()
+
+				if len(c.ArgumentList) != nargs {
+					if typ.IsVariadic() {
+						if len(c.ArgumentList) < nargs-1 {
+							panic(rt.panicRangeError(fmt.Sprintf("expected at least %d arguments; got %d", nargs-1, len(c.ArgumentList))))
+						}
+					} else {
+						panic(rt.panicRangeError(fmt.Sprintf("expected %d argument(s); got %d", nargs, len(c.ArgumentList))))
 					}
 				}
 
-				typ := value.Type()
+				in := make([]reflect.Value, len(c.ArgumentList))
 
-				return toValue_object(self.newNativeFunction(name, file, line, func(c FunctionCall) Value {
-					nargs := typ.NumIn()
+				callSlice := false
 
-					if len(c.ArgumentList) != nargs {
-						if typ.IsVariadic() {
-							if len(c.ArgumentList) < nargs-1 {
-								panic(self.panicRangeError(fmt.Sprintf("expected at least %d arguments; got %d", nargs-1, len(c.ArgumentList))))
-							}
-						} else {
-							panic(self.panicRangeError(fmt.Sprintf("expected %d argument(s); got %d", nargs, len(c.ArgumentList))))
-						}
-					}
+				for i, a := range c.ArgumentList {
+					var t reflect.Type
 
-					in := make([]reflect.Value, len(c.ArgumentList))
-
-					callSlice := false
-
-					for i, a := range c.ArgumentList {
-						var t reflect.Type
-
-						n := i
-						if n >= nargs-1 && typ.IsVariadic() {
-							if n > nargs-1 {
-								n = nargs - 1
-							}
-
-							t = typ.In(n).Elem()
-						} else {
-							t = typ.In(n)
+					n := i
+					if n >= nargs-1 && typ.IsVariadic() {
+						if n > nargs-1 {
+							n = nargs - 1
 						}
 
-						// if this is a variadic Go function, and the caller has supplied
-						// exactly the number of JavaScript arguments required, and this
-						// is the last JavaScript argument, try treating the it as the
-						// actual set of variadic Go arguments. if that succeeds, break
-						// out of the loop.
-						if typ.IsVariadic() && len(c.ArgumentList) == nargs && i == nargs-1 {
-							if v, err := self.convertCallParameter(a, typ.In(n)); err == nil {
-								in[i] = v
-								callSlice = true
-								break
-							}
-						}
-
-						v, err := self.convertCallParameter(a, t)
-						if err != nil {
-							panic(self.panicTypeError(err.Error()))
-						}
-
-						in[i] = v
-					}
-
-					var out []reflect.Value
-					if callSlice {
-						out = value.CallSlice(in)
+						t = typ.In(n).Elem()
 					} else {
-						out = value.Call(in)
+						t = typ.In(n)
 					}
 
-					switch len(out) {
-					case 0:
-						return Value{}
-					case 1:
-						return self.toValue(out[0].Interface())
-					default:
-						s := make([]interface{}, len(out))
-						for i, v := range out {
-							s[i] = self.toValue(v.Interface())
+					// if this is a variadic Go function, and the caller has supplied
+					// exactly the number of JavaScript arguments required, and this
+					// is the last JavaScript argument, try treating the it as the
+					// actual set of variadic Go arguments. if that succeeds, break
+					// out of the loop.
+					if typ.IsVariadic() && len(c.ArgumentList) == nargs && i == nargs-1 {
+						if v, err := rt.convertCallParameter(a, typ.In(n)); err == nil {
+							in[i] = v
+							callSlice = true
+							break
 						}
-
-						return self.toValue(s)
 					}
-				}))
-			}
+
+					v, err := rt.convertCallParameter(a, t)
+					if err != nil {
+						panic(rt.panicTypeError(err.Error()))
+					}
+
+					in[i] = v
+				}
+
+				var out []reflect.Value
+				if callSlice {
+					out = val.CallSlice(in)
+				} else {
+					out = val.Call(in)
+				}
+
+				switch len(out) {
+				case 0:
+					return Value{}
+				case 1:
+					return rt.toValue(out[0].Interface())
+				default:
+					s := make([]interface{}, len(out))
+					for i, v := range out {
+						s[i] = rt.toValue(v.Interface())
+					}
+
+					return rt.toValue(s)
+				}
+			}))
 		}
 	}
 
 	return toValue(value)
 }
 
-func (runtime *_runtime) newGoSlice(value reflect.Value) *_object {
-	self := runtime.newGoSliceObject(value)
-	self.prototype = runtime.global.ArrayPrototype
-	return self
+func (rt *runtime) newGoSlice(value reflect.Value) *object {
+	obj := rt.newGoSliceObject(value)
+	obj.prototype = rt.global.ArrayPrototype
+	return obj
 }
 
-func (runtime *_runtime) newGoArray(value reflect.Value) *_object {
-	self := runtime.newGoArrayObject(value)
-	self.prototype = runtime.global.ArrayPrototype
-	return self
+func (rt *runtime) newGoArray(value reflect.Value) *object {
+	obj := rt.newGoArrayObject(value)
+	obj.prototype = rt.global.ArrayPrototype
+	return obj
 }
 
-func (runtime *_runtime) parse(filename string, src, sm interface{}) (*ast.Program, error) {
+func (rt *runtime) parse(filename string, src, sm interface{}) (*ast.Program, error) {
 	return parser.ParseFileWithSourceMap(nil, filename, src, sm, 0)
 }
 
-func (runtime *_runtime) cmpl_parse(filename string, src, sm interface{}) (*_nodeProgram, error) {
+func (rt *runtime) cmplParse(filename string, src, sm interface{}) (*nodeProgram, error) {
 	program, err := parser.ParseFileWithSourceMap(nil, filename, src, sm, 0)
 	if err != nil {
 		return nil, err
 	}
 
-	return cmpl_parse(program), nil
+	return cmplParse(program), nil
 }
 
-func (self *_runtime) parseSource(src, sm interface{}) (*_nodeProgram, *ast.Program, error) {
+func (rt *runtime) parseSource(src, sm interface{}) (*nodeProgram, *ast.Program, error) {
 	switch src := src.(type) {
 	case *ast.Program:
 		return nil, src, nil
@@ -821,22 +818,22 @@ func (self *_runtime) parseSource(src, sm interface{}) (*_nodeProgram, *ast.Prog
 		return src.program, nil, nil
 	}
 
-	program, err := self.parse("", src, sm)
+	program, err := rt.parse("", src, sm)
 
 	return nil, program, err
 }
 
-func (self *_runtime) cmpl_runOrEval(src, sm interface{}, eval bool) (Value, error) {
+func (rt *runtime) cmplRunOrEval(src, sm interface{}, eval bool) (Value, error) {
 	result := Value{}
-	cmpl_program, program, err := self.parseSource(src, sm)
+	node, program, err := rt.parseSource(src, sm)
 	if err != nil {
 		return result, err
 	}
-	if cmpl_program == nil {
-		cmpl_program = cmpl_parse(program)
+	if node == nil {
+		node = cmplParse(program)
 	}
 	err = catchPanic(func() {
-		result = self.cmpl_evaluate_nodeProgram(cmpl_program, eval)
+		result = rt.cmplEvaluateNodeProgram(node, eval)
 	})
 	switch result.kind {
 	case valueEmpty:
@@ -847,33 +844,32 @@ func (self *_runtime) cmpl_runOrEval(src, sm interface{}, eval bool) (Value, err
 	return result, err
 }
 
-func (self *_runtime) cmpl_run(src, sm interface{}) (Value, error) {
-	return self.cmpl_runOrEval(src, sm, false)
+func (rt *runtime) cmplRun(src, sm interface{}) (Value, error) {
+	return rt.cmplRunOrEval(src, sm, false)
 }
 
-func (self *_runtime) cmpl_eval(src, sm interface{}) (Value, error) {
-	return self.cmpl_runOrEval(src, sm, true)
+func (rt *runtime) cmplEval(src, sm interface{}) (Value, error) {
+	return rt.cmplRunOrEval(src, sm, true)
 }
 
-func (self *_runtime) parseThrow(err error) {
+func (rt *runtime) parseThrow(err error) {
 	if err == nil {
 		return
 	}
-	switch err := err.(type) {
-	case parser.ErrorList:
-		{
-			err := err[0]
-			if err.Message == "Invalid left-hand side in assignment" {
-				panic(self.panicReferenceError(err.Message))
-			}
-			panic(self.panicSyntaxError(err.Message))
+
+	var errl parser.ErrorList
+	if errors.Is(err, &errl) {
+		err := errl[0]
+		if err.Message == "invalid left-hand side in assignment" {
+			panic(rt.panicReferenceError(err.Message))
 		}
+		panic(rt.panicSyntaxError(err.Message))
 	}
-	panic(self.panicSyntaxError(err.Error()))
+	panic(rt.panicSyntaxError(err.Error()))
 }
 
-func (self *_runtime) cmpl_parseOrThrow(src, sm interface{}) *_nodeProgram {
-	program, err := self.cmpl_parse("", src, sm)
-	self.parseThrow(err) // Will panic/throw appropriately
+func (rt *runtime) cmplParseOrThrow(src, sm interface{}) *nodeProgram {
+	program, err := rt.cmplParse("", src, sm)
+	rt.parseThrow(err) // Will panic/throw appropriately
 	return program
 }

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -3,6 +3,8 @@ package otto
 import (
 	"math"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // FIXME terst, Review tests
@@ -314,12 +316,12 @@ func TestPositiveNegativeZero(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()
 
-		test(`1/0`, _Infinity)
-		test(`1/-0`, -_Infinity)
+		test(`1/0`, infinity)
+		test(`1/-0`, -infinity)
 		test(`
             abc = -0
             1/abc
-        `, -_Infinity)
+        `, -infinity)
 	})
 }
 
@@ -341,10 +343,10 @@ func TestComparison(t *testing.T) {
 
 		test("0 == 1", false)
 
-		is(negativeZero(), -0)
-		is(positiveZero(), 0)
-		is(math.Signbit(negativeZero()), true)
-		is(positiveZero() == negativeZero(), true)
+		is(negativeZero, -0)
+		is(positiveZero, 0)
+		is(math.Signbit(negativeZero), true)
+		is(positiveZero == negativeZero, true)
 
 		test("1 == 1", true)
 
@@ -748,17 +750,20 @@ func TestEvaluationOrder(t *testing.T) {
 func TestClone(t *testing.T) {
 	tt(t, func() {
 		vm1 := New()
-		vm1.Run(`
+		_, err := vm1.Run(`
             var abc = 1;
         `)
+		require.NoError(t, err)
 
 		vm2 := vm1.clone()
-		vm1.Run(`
+		_, err = vm1.Run(`
             abc += 2;
         `)
-		vm2.Run(`
+		require.NoError(t, err)
+		_, err = vm2.Run(`
             abc += 4;
         `)
+		require.NoError(t, err)
 
 		is(vm1.getValue("abc"), 3)
 		is(vm2.getValue("abc"), 5)
@@ -776,7 +781,7 @@ func Test_debugger(t *testing.T) {
 		})
 
 		_, err := vm.Run(`debugger`)
-		is(err, nil)
+		require.NoError(t, err)
 		is(called, true)
 	})
 
@@ -790,7 +795,7 @@ func Test_debugger(t *testing.T) {
 		})
 
 		_, err := vm.Run(`null`)
-		is(err, nil)
+		require.NoError(t, err)
 		is(called, false)
 	})
 
@@ -798,7 +803,7 @@ func Test_debugger(t *testing.T) {
 		vm := New()
 
 		_, err := vm.Run(`debugger`)
-		is(err, nil)
+		require.NoError(t, err)
 	})
 }
 
@@ -808,9 +813,9 @@ func Test_random(t *testing.T) {
 		vm.SetRandomSource(func() float64 { return 1 })
 
 		r, err := vm.Run(`Math.random()`)
-		is(err, nil)
+		require.NoError(t, err)
 		f, err := r.ToFloat()
-		is(err, nil)
+		require.NoError(t, err)
 		is(f, 1)
 	})
 
@@ -818,14 +823,14 @@ func Test_random(t *testing.T) {
 		vm := New()
 
 		r1, err := vm.Run(`Math.random()`)
-		is(err, nil)
+		require.NoError(t, err)
 		f1, err := r1.ToFloat()
-		is(err, nil)
+		require.NoError(t, err)
 
 		r2, err := vm.Run(`Math.random()`)
-		is(err, nil)
+		require.NoError(t, err)
 		f2, err := r2.ToFloat()
-		is(err, nil)
+		require.NoError(t, err)
 
 		is(f1 == f2, false)
 	})
@@ -848,10 +853,12 @@ func Test_stringArray(t *testing.T) {
 	}
 	tt(t, func() {
 		vm := New()
-		vm.Set("getStrings", getStrings)
-		vm.Set("concatStrings", concatStrings)
+		err := vm.Set("getStrings", getStrings)
+		require.NoError(t, err)
+		err = vm.Set("concatStrings", concatStrings)
+		require.NoError(t, err)
 		r1, err := vm.Run(`var a = getStrings(); concatStrings(a)`)
-		is(err, nil)
+		require.NoError(t, err)
 		is(r1, "these are strings")
 	})
 }

--- a/scope.go
+++ b/scope.go
@@ -1,33 +1,19 @@
 package otto
 
-// _scope:
-// entryFile
-// entryIdx
-// top?
-// outer => nil
-
-// _stash:
-// lexical
-// variable
-//
-// _thisStash (ObjectEnvironment)
-// _fnStash
-// _dclStash
-
-// An ECMA-262 ExecutionContext
-type _scope struct {
-	lexical  _stash
-	variable _stash
-	this     *_object
+// An ECMA-262 ExecutionContext.
+type scope struct {
+	lexical  stasher
+	variable stasher
+	this     *object
 	eval     bool // Replace this with kind?
-	outer    *_scope
+	outer    *scope
 	depth    int
 
-	frame _frame
+	frame frame
 }
 
-func newScope(lexical _stash, variable _stash, this *_object) *_scope {
-	return &_scope{
+func newScope(lexical stasher, variable stasher, this *object) *scope {
+	return &scope{
 		lexical:  lexical,
 		variable: variable,
 		this:     this,

--- a/script_test.go
+++ b/script_test.go
@@ -2,6 +2,8 @@ package otto
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestScript(t *testing.T) {
@@ -9,52 +11,53 @@ func TestScript(t *testing.T) {
 		vm := New()
 
 		script, err := vm.Compile("xyzzy", `var abc; if (!abc) abc = 0; abc += 2; abc;`)
-		is(err, nil)
+		require.NoError(t, err)
 
 		str := script.String()
 		is(str, "// xyzzy\nvar abc; if (!abc) abc = 0; abc += 2; abc;")
 
 		value, err := vm.Run(script)
-		is(err, nil)
+		require.NoError(t, err)
 		is(value, 2)
 
+		// TODO(steve): Fix the underlying issues as to why this returns early.
 		if true {
 			return
 		}
 
 		tmp, err := script.marshalBinary()
-		is(err, nil)
+		require.NoError(t, err)
 		is(len(tmp), 1228)
 
 		{
 			script := &Script{}
 			err = script.unmarshalBinary(tmp)
-			is(err, nil)
+			require.NoError(t, err)
 
 			is(script.String(), str)
 
 			value, err = vm.Run(script)
-			is(err, nil)
+			require.NoError(t, err)
 			is(value, 4)
 
 			tmp, err = script.marshalBinary()
-			is(err, nil)
+			require.NoError(t, err)
 			is(len(tmp), 1228)
 		}
 
 		{
 			script := &Script{}
 			err = script.unmarshalBinary(tmp)
-			is(err, nil)
+			require.NoError(t, err)
 
 			is(script.String(), str)
 
 			value, err := vm.Run(script)
-			is(err, nil)
+			require.NoError(t, err)
 			is(value, 6)
 
 			tmp, err = script.marshalBinary()
-			is(err, nil)
+			require.NoError(t, err)
 			is(len(tmp), 1228)
 		}
 
@@ -80,15 +83,16 @@ func TestScript(t *testing.T) {
 func TestFunctionCall_CallerLocation(t *testing.T) {
 	tt(t, func() {
 		vm := New()
-		vm.Set("loc", func(call FunctionCall) Value {
+		err := vm.Set("loc", func(call FunctionCall) Value {
 			return toValue(call.CallerLocation())
 		})
+		require.NoError(t, err)
 		script, err := vm.Compile("somefile.js", `var where = loc();`)
-		is(err, nil)
+		require.NoError(t, err)
 		_, err = vm.Run(script)
-		is(err, nil)
+		require.NoError(t, err)
 		where, err := vm.Get("where")
-		is(err, nil)
+		require.NoError(t, err)
 		is(where, "somefile.js:1:13")
 	})
 }

--- a/sourcemap_test.go
+++ b/sourcemap_test.go
@@ -1,7 +1,10 @@
 package otto
 
 import (
+	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -19,20 +22,16 @@ func TestSourceMapOriginalWithNoSourcemap(t *testing.T) {
 		vm := New()
 
 		s, err := vm.Compile("hello.js", testSourcemapCodeOriginal)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
-		if _, err := vm.Run(s); err != nil {
-			panic(err)
-		}
+		_, err = vm.Run(s)
+		require.NoError(t, err)
 
 		_, err = vm.Run(`functionA()`)
-		if err == nil {
-			panic("error should not be nil")
-		}
-
-		is(err.(*Error).String(), testSourcemapOriginalStack)
+		require.Error(t, err)
+		var oerr *Error
+		require.True(t, errors.As(err, &oerr))
+		require.Equal(t, oerr.String(), testSourcemapOriginalStack)
 	})
 }
 
@@ -41,20 +40,16 @@ func TestSourceMapMangledWithNoSourcemap(t *testing.T) {
 		vm := New()
 
 		s, err := vm.Compile("hello.js", testSourcemapCodeMangled)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
-		if _, err := vm.Run(s); err != nil {
-			panic(err)
-		}
+		_, err = vm.Run(s)
+		require.NoError(t, err)
 
 		_, err = vm.Run(`functionA()`)
-		if err == nil {
-			panic("error should not be nil")
-		}
-
-		is(err.(*Error).String(), testSourcemapMangledStack)
+		require.Error(t, err)
+		var oerr *Error
+		require.True(t, errors.As(err, &oerr))
+		require.Equal(t, oerr.String(), testSourcemapMangledStack)
 	})
 }
 
@@ -63,20 +58,16 @@ func TestSourceMapMangledWithSourcemap(t *testing.T) {
 		vm := New()
 
 		s, err := vm.CompileWithSourceMap("hello.js", testSourcemapCodeMangled, testSourcemapContent)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
-		if _, err := vm.Run(s); err != nil {
-			panic(err)
-		}
+		_, err = vm.Run(s)
+		require.NoError(t, err)
 
 		_, err = vm.Run(`functionA()`)
-		if err == nil {
-			panic("error should not be nil")
-		}
-
-		is(err.(*Error).String(), testSourcemapMappedStack)
+		require.Error(t, err)
+		var oerr *Error
+		require.True(t, errors.As(err, &oerr))
+		require.Equal(t, oerr.String(), testSourcemapMappedStack)
 	})
 }
 
@@ -85,20 +76,16 @@ func TestSourceMapMangledWithInlineSourcemap(t *testing.T) {
 		vm := New()
 
 		s, err := vm.CompileWithSourceMap("hello.js", testSourcemapInline, nil)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
-		if _, err := vm.Run(s); err != nil {
-			panic(err)
-		}
+		_, err = vm.Run(s)
+		require.NoError(t, err)
 
 		_, err = vm.Run(`functionA()`)
-		if err == nil {
-			panic("error should not be nil")
-		}
-
-		is(err.(*Error).String(), testSourcemapMappedStack)
+		require.Error(t, err)
+		var oerr *Error
+		require.True(t, errors.As(err, &oerr))
+		require.Equal(t, oerr.String(), testSourcemapMappedStack)
 	})
 }
 
@@ -107,15 +94,12 @@ func TestSourceMapContextPosition(t *testing.T) {
 		vm := New()
 
 		s, err := vm.CompileWithSourceMap("hello.js", testSourcemapCodeMangled, testSourcemapContent)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
-		if _, err := vm.Run(s); err != nil {
-			panic(err)
-		}
+		_, err = vm.Run(s)
+		require.NoError(t, err)
 
-		vm.Set("functionExternal", func(c FunctionCall) Value {
+		err = vm.Set("functionExternal", func(c FunctionCall) Value {
 			ctx := c.Otto.Context()
 
 			is(ctx.Filename, "hello.js")
@@ -124,10 +108,10 @@ func TestSourceMapContextPosition(t *testing.T) {
 
 			return UndefinedValue()
 		})
+		require.NoError(t, err)
 
-		if _, err := vm.Run(`functionA()`); err != nil {
-			panic(err)
-		}
+		_, err = vm.Run(`functionA()`)
+		require.NoError(t, err)
 	})
 }
 
@@ -136,15 +120,12 @@ func TestSourceMapContextStacktrace(t *testing.T) {
 		vm := New()
 
 		s, err := vm.CompileWithSourceMap("hello.js", testSourcemapCodeMangled, testSourcemapContent)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
-		if _, err := vm.Run(s); err != nil {
-			panic(err)
-		}
+		_, err = vm.Run(s)
+		require.NoError(t, err)
 
-		vm.Set("functionExternal", func(c FunctionCall) Value {
+		err = vm.Set("functionExternal", func(c FunctionCall) Value {
 			ctx := c.Otto.Context()
 
 			is(ctx.Stacktrace, []string{
@@ -155,9 +136,9 @@ func TestSourceMapContextStacktrace(t *testing.T) {
 
 			return UndefinedValue()
 		})
+		require.NoError(t, err)
 
-		if _, err := vm.Run(`functionA()`); err != nil {
-			panic(err)
-		}
+		_, err = vm.Run(`functionA()`)
+		require.NoError(t, err)
 	})
 }

--- a/string_test.go
+++ b/string_test.go
@@ -2,6 +2,8 @@ package otto
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestString(t *testing.T) {
@@ -51,7 +53,7 @@ func TestString_charCodeAt(t *testing.T) {
             def = "xyzzy".charCodeAt(11)
         `)
 		test("abc", 120)
-		test("def", _NaN)
+		test("def", naN)
 	})
 }
 
@@ -275,25 +277,25 @@ func TestString_split(t *testing.T) {
 
 func BenchmarkString_splitWithString(b *testing.B) {
 	vm := New()
-	vm.Set("data", "Lorem ipsum dolor sit amet, blandit nec elit. Ridiculus tortor wisi fusce vivamus")
-	s, _ := vm.Compile("test.js", `data.split(" ")`)
+	err := vm.Set("data", "Lorem ipsum dolor sit amet, blandit nec elit. Ridiculous tortor wisi fusce vivamus")
+	require.NoError(b, err)
+	s, err := vm.Compile("test.js", `data.split(" ")`)
+	require.NoError(b, err)
 	for i := 0; i < b.N; i++ {
-		_, e := vm.Run(s)
-		if e != nil {
-			b.Error(e.Error())
-		}
+		_, err = vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 
 func BenchmarkString_splitWithRegex(b *testing.B) {
 	vm := New()
-	vm.Set("data", "Lorem ipsum dolor sit amet, blandit nec elit. Ridiculus tortor wisi fusce vivamus")
-	s, _ := vm.Compile("test.js", `data.split(/ /)`)
+	err := vm.Set("data", "Lorem ipsum dolor sit amet, blandit nec elit. Ridiculous tortor wisi fusce vivamus")
+	require.NoError(b, err)
+	s, err := vm.Compile("test.js", `data.split(/ /)`)
+	require.NoError(b, err)
 	for i := 0; i < b.N; i++ {
-		_, e := vm.Run(s)
-		if e != nil {
-			b.Error(e.Error())
-		}
+		_, err = vm.Run(s)
+		require.NoError(b, err)
 	}
 }
 

--- a/testing_test.go
+++ b/testing_test.go
@@ -77,29 +77,29 @@ func newTester() *_tester {
 	}
 }
 
-func (self *_tester) Get(name string) (Value, error) {
-	return self.vm.Get(name)
+func (te *_tester) Get(name string) (Value, error) {
+	return te.vm.Get(name)
 }
 
-func (self *_tester) Set(name string, value interface{}) Value {
-	err := self.vm.Set(name, value)
+func (te *_tester) Set(name string, value interface{}) Value {
+	err := te.vm.Set(name, value)
 	is(err, nil)
 	if err != nil {
 		terst.Caller().T().FailNow()
 	}
-	return self.vm.getValue(name)
+	return te.vm.getValue(name)
 }
 
-func (self *_tester) Run(src interface{}) (Value, error) {
-	return self.vm.Run(src)
+func (te *_tester) Run(src interface{}) (Value, error) {
+	return te.vm.Run(src)
 }
 
-func (self *_tester) test(name string, expect ...interface{}) Value {
-	vm := self.vm
+func (te *_tester) test(name string, expect ...interface{}) Value {
+	vm := te.vm
 	raise := false
 	defer func() {
 		if caught := recover(); caught != nil {
-			if exception, ok := caught.(*_exception); ok {
+			if exception, ok := caught.(*exception); ok {
 				caught = exception.eject()
 			}
 			if raise {
@@ -124,7 +124,7 @@ func (self *_tester) test(name string, expect ...interface{}) Value {
 			source = source[6:]
 			source = strings.TrimLeft(source, " ")
 		}
-		value, err = vm.runtime.cmpl_run(source, nil)
+		value, err = vm.runtime.cmplRun(source, nil)
 		if err != nil {
 			panic(err)
 		}

--- a/token/token.go
+++ b/token/token.go
@@ -14,63 +14,17 @@ type Token int
 // "+"). For all other tokens the string corresponds to the token
 // name (e.g. for the token IDENTIFIER, the string is "IDENTIFIER").
 func (tkn Token) String() string {
-	if 0 == tkn {
+	switch {
+	case tkn == 0:
 		return "UNKNOWN"
-	}
-	if tkn < Token(len(token2string)) {
+	case tkn < Token(len(token2string)):
 		return token2string[tkn]
+	default:
+		return "token(" + strconv.Itoa(int(tkn)) + ")"
 	}
-	return "token(" + strconv.Itoa(int(tkn)) + ")"
 }
 
-// This is not used for anything
-func (tkn Token) precedence(in bool) int {
-	switch tkn {
-	case LOGICAL_OR:
-		return 1
-
-	case LOGICAL_AND:
-		return 2
-
-	case OR, OR_ASSIGN:
-		return 3
-
-	case EXCLUSIVE_OR:
-		return 4
-
-	case AND, AND_ASSIGN, AND_NOT, AND_NOT_ASSIGN:
-		return 5
-
-	case EQUAL,
-		NOT_EQUAL,
-		STRICT_EQUAL,
-		STRICT_NOT_EQUAL:
-		return 6
-
-	case LESS, GREATER, LESS_OR_EQUAL, GREATER_OR_EQUAL, INSTANCEOF:
-		return 7
-
-	case IN:
-		if in {
-			return 7
-		}
-		return 0
-
-	case SHIFT_LEFT, SHIFT_RIGHT, UNSIGNED_SHIFT_RIGHT:
-		fallthrough
-	case SHIFT_LEFT_ASSIGN, SHIFT_RIGHT_ASSIGN, UNSIGNED_SHIFT_RIGHT_ASSIGN:
-		return 8
-
-	case PLUS, MINUS, ADD_ASSIGN, SUBTRACT_ASSIGN:
-		return 9
-
-	case MULTIPLY, SLASH, REMAINDER, MULTIPLY_ASSIGN, QUOTIENT_ASSIGN, REMAINDER_ASSIGN:
-		return 11
-	}
-	return 0
-}
-
-type _keyword struct {
+type keyword struct {
 	token         Token
 	futureKeyword bool
 	strict        bool

--- a/token/token_const.go
+++ b/token/token_const.go
@@ -74,7 +74,7 @@ const (
 	COLON             // :
 	QUESTION_MARK     // ?
 
-	firstKeyword //nolint: deadcode
+	_
 	IF
 	IN
 	DO
@@ -108,7 +108,6 @@ const (
 	DEBUGGER
 
 	INSTANCEOF
-	lastKeyword //nolint: deadcode
 )
 
 var token2string = [...]string{
@@ -199,149 +198,149 @@ var token2string = [...]string{
 	INSTANCEOF:                  "instanceof",
 }
 
-var keywordTable = map[string]_keyword{
-	"if": _keyword{
+var keywordTable = map[string]keyword{
+	"if": {
 		token: IF,
 	},
-	"in": _keyword{
+	"in": {
 		token: IN,
 	},
-	"do": _keyword{
+	"do": {
 		token: DO,
 	},
-	"var": _keyword{
+	"var": {
 		token: VAR,
 	},
-	"for": _keyword{
+	"for": {
 		token: FOR,
 	},
-	"new": _keyword{
+	"new": {
 		token: NEW,
 	},
-	"try": _keyword{
+	"try": {
 		token: TRY,
 	},
-	"this": _keyword{
+	"this": {
 		token: THIS,
 	},
-	"else": _keyword{
+	"else": {
 		token: ELSE,
 	},
-	"case": _keyword{
+	"case": {
 		token: CASE,
 	},
-	"void": _keyword{
+	"void": {
 		token: VOID,
 	},
-	"with": _keyword{
+	"with": {
 		token: WITH,
 	},
-	"while": _keyword{
+	"while": {
 		token: WHILE,
 	},
-	"break": _keyword{
+	"break": {
 		token: BREAK,
 	},
-	"catch": _keyword{
+	"catch": {
 		token: CATCH,
 	},
-	"throw": _keyword{
+	"throw": {
 		token: THROW,
 	},
-	"return": _keyword{
+	"return": {
 		token: RETURN,
 	},
-	"typeof": _keyword{
+	"typeof": {
 		token: TYPEOF,
 	},
-	"delete": _keyword{
+	"delete": {
 		token: DELETE,
 	},
-	"switch": _keyword{
+	"switch": {
 		token: SWITCH,
 	},
-	"default": _keyword{
+	"default": {
 		token: DEFAULT,
 	},
-	"finally": _keyword{
+	"finally": {
 		token: FINALLY,
 	},
-	"function": _keyword{
+	"function": {
 		token: FUNCTION,
 	},
-	"continue": _keyword{
+	"continue": {
 		token: CONTINUE,
 	},
-	"debugger": _keyword{
+	"debugger": {
 		token: DEBUGGER,
 	},
-	"instanceof": _keyword{
+	"instanceof": {
 		token: INSTANCEOF,
 	},
-	"const": _keyword{
+	"const": {
 		token:         KEYWORD,
 		futureKeyword: true,
 	},
-	"class": _keyword{
+	"class": {
 		token:         KEYWORD,
 		futureKeyword: true,
 	},
-	"enum": _keyword{
+	"enum": {
 		token:         KEYWORD,
 		futureKeyword: true,
 	},
-	"export": _keyword{
+	"export": {
 		token:         KEYWORD,
 		futureKeyword: true,
 	},
-	"extends": _keyword{
+	"extends": {
 		token:         KEYWORD,
 		futureKeyword: true,
 	},
-	"import": _keyword{
+	"import": {
 		token:         KEYWORD,
 		futureKeyword: true,
 	},
-	"super": _keyword{
+	"super": {
 		token:         KEYWORD,
 		futureKeyword: true,
 	},
-	"implements": _keyword{
-		token:         KEYWORD,
-		futureKeyword: true,
-		strict:        true,
-	},
-	"interface": _keyword{
+	"implements": {
 		token:         KEYWORD,
 		futureKeyword: true,
 		strict:        true,
 	},
-	"let": _keyword{
+	"interface": {
 		token:         KEYWORD,
 		futureKeyword: true,
 		strict:        true,
 	},
-	"package": _keyword{
+	"let": {
 		token:         KEYWORD,
 		futureKeyword: true,
 		strict:        true,
 	},
-	"private": _keyword{
+	"package": {
 		token:         KEYWORD,
 		futureKeyword: true,
 		strict:        true,
 	},
-	"protected": _keyword{
+	"private": {
 		token:         KEYWORD,
 		futureKeyword: true,
 		strict:        true,
 	},
-	"public": _keyword{
+	"protected": {
 		token:         KEYWORD,
 		futureKeyword: true,
 		strict:        true,
 	},
-	"static": _keyword{
+	"public": {
+		token:         KEYWORD,
+		futureKeyword: true,
+		strict:        true,
+	},
+	"static": {
 		token:         KEYWORD,
 		futureKeyword: true,
 		strict:        true,

--- a/type_boolean.go
+++ b/type_boolean.go
@@ -1,5 +1,5 @@
 package otto
 
-func (runtime *_runtime) newBooleanObject(value Value) *_object {
-	return runtime.newPrimitiveObject(classBoolean, toValue_bool(value.bool()))
+func (rt *runtime) newBooleanObject(value Value) *object {
+	return rt.newPrimitiveObject(classBooleanName, boolValue(value.bool()))
 }

--- a/type_date.go
+++ b/type_date.go
@@ -7,23 +7,21 @@ import (
 	Time "time"
 )
 
-type _dateObject struct {
+type dateObject struct {
 	time  Time.Time // Time from the "time" package, a cached version of time
 	epoch int64
 	value Value
 	isNaN bool
 }
 
-var (
-	invalidDateObject = _dateObject{
-		time:  Time.Time{},
-		epoch: -1,
-		value: NaNValue(),
-		isNaN: true,
-	}
-)
+var invalidDateObject = dateObject{
+	time:  Time.Time{},
+	epoch: -1,
+	value: NaNValue(),
+	isNaN: true,
+}
 
-type _ecmaTime struct {
+type ecmaTime struct {
 	year        int
 	month       int
 	day         int
@@ -34,8 +32,8 @@ type _ecmaTime struct {
 	location    *Time.Location // Basically, either local or UTC
 }
 
-func ecmaTime(goTime Time.Time) _ecmaTime {
-	return _ecmaTime{
+func newEcmaTime(goTime Time.Time) ecmaTime {
+	return ecmaTime{
 		goTime.Year(),
 		dateFromGoMonth(goTime.Month()),
 		goTime.Day(),
@@ -47,58 +45,58 @@ func ecmaTime(goTime Time.Time) _ecmaTime {
 	}
 }
 
-func (self *_ecmaTime) goTime() Time.Time {
+func (t *ecmaTime) goTime() Time.Time {
 	return Time.Date(
-		self.year,
-		dateToGoMonth(self.month),
-		self.day,
-		self.hour,
-		self.minute,
-		self.second,
-		self.millisecond*(100*100*100),
-		self.location,
+		t.year,
+		dateToGoMonth(t.month),
+		t.day,
+		t.hour,
+		t.minute,
+		t.second,
+		t.millisecond*(100*100*100),
+		t.location,
 	)
 }
 
-func (self *_dateObject) Time() Time.Time {
-	return self.time
+func (d *dateObject) Time() Time.Time {
+	return d.time
 }
 
-func (self *_dateObject) Epoch() int64 {
-	return self.epoch
+func (d *dateObject) Epoch() int64 {
+	return d.epoch
 }
 
-func (self *_dateObject) Value() Value {
-	return self.value
+func (d *dateObject) Value() Value {
+	return d.value
 }
 
-// FIXME A date should only be in the range of -100,000,000 to +100,000,000 (1970): 15.9.1.1
-func (self *_dateObject) SetNaN() {
-	self.time = Time.Time{}
-	self.epoch = -1
-	self.value = NaNValue()
-	self.isNaN = true
+// FIXME A date should only be in the range of -100,000,000 to +100,000,000 (1970): 15.9.1.1.
+func (d *dateObject) SetNaN() {
+	d.time = Time.Time{}
+	d.epoch = -1
+	d.value = NaNValue()
+	d.isNaN = true
 }
 
-func (self *_dateObject) SetTime(time Time.Time) {
-	self.Set(timeToEpoch(time))
+func (d *dateObject) SetTime(time Time.Time) {
+	d.Set(timeToEpoch(time))
 }
 
-func (self *_dateObject) Set(epoch float64) {
+func (d *dateObject) Set(epoch float64) {
 	// epoch
-	self.epoch = epochToInteger(epoch)
+	d.epoch = epochToInteger(epoch)
 
 	// time
 	time, err := epochToTime(epoch)
-	self.time = time // Is either a valid time, or the zero-value for time.Time
+	d.time = time // Is either a valid time, or the zero-value for time.Time
 
 	// value & isNaN
 	if err != nil {
-		self.isNaN = true
-		self.epoch = -1
-		self.value = NaNValue()
+		d.isNaN = true
+		d.epoch = -1
+		d.value = NaNValue()
 	} else {
-		self.value = toValue_int64(self.epoch)
+		d.value = int64Value(d.epoch)
 	}
 }
 
@@ -109,48 +107,46 @@ func epochToInteger(value float64) int64 {
 	return int64(math.Ceil(value))
 }
 
-func epochToTime(value float64) (time Time.Time, err error) {
+func epochToTime(value float64) (Time.Time, error) {
 	epochWithMilli := value
 	if math.IsNaN(epochWithMilli) || math.IsInf(epochWithMilli, 0) {
-		err = fmt.Errorf("Invalid time %v", value)
-		return
+		return Time.Time{}, fmt.Errorf("invalid time %v", value)
 	}
 
 	epoch := int64(epochWithMilli / 1000)
 	milli := int64(epochWithMilli) % 1000
 
-	time = Time.Unix(int64(epoch), milli*1000000).In(utcTimeZone)
-	return
+	return Time.Unix(epoch, milli*1000000).In(utcTimeZone), nil
 }
 
 func timeToEpoch(time Time.Time) float64 {
 	return float64(time.UnixMilli())
 }
 
-func (runtime *_runtime) newDateObject(epoch float64) *_object {
-	self := runtime.newObject()
-	self.class = classDate
+func (rt *runtime) newDateObject(epoch float64) *object {
+	obj := rt.newObject()
+	obj.class = classDateName
 
 	// FIXME This is ugly...
-	date := _dateObject{}
+	date := dateObject{}
 	date.Set(epoch)
-	self.value = date
-	return self
+	obj.value = date
+	return obj
 }
 
-func (self *_object) dateValue() _dateObject {
-	value, _ := self.value.(_dateObject)
+func (o *object) dateValue() dateObject {
+	value, _ := o.value.(dateObject)
 	return value
 }
 
-func dateObjectOf(rt *_runtime, _dateObject *_object) _dateObject {
-	if _dateObject == nil || _dateObject.class != classDate {
+func dateObjectOf(rt *runtime, date *object) dateObject {
+	if date == nil || date.class != classDateName {
 		panic(rt.panicTypeError())
 	}
-	return _dateObject.dateValue()
+	return date.dateValue()
 }
 
-// JavaScript is 0-based, Go is 1-based (15.9.1.4)
+// JavaScript is 0-based, Go is 1-based (15.9.1.4).
 func dateToGoMonth(month int) Time.Month {
 	return Time.Month(month + 1)
 }
@@ -163,7 +159,8 @@ func dateFromGoDay(day Time.Weekday) int {
 	return int(day)
 }
 
-func newDateTime(argumentList []Value, location *Time.Location) (epoch float64) {
+// newDateTime returns the epoch of date contained in argumentList for location.
+func newDateTime(argumentList []Value, location *Time.Location) float64 {
 	pick := func(index int, default_ float64) (float64, bool) {
 		if index >= len(argumentList) {
 			return default_, false
@@ -175,29 +172,41 @@ func newDateTime(argumentList []Value, location *Time.Location) (epoch float64) 
 		return value, false
 	}
 
-	if len(argumentList) >= 2 { // 2-argument, 3-argument, ...
+	switch len(argumentList) {
+	case 0: // 0-argument
+		time := Time.Now().In(utcTimeZone)
+		return timeToEpoch(time)
+	case 1: // 1-argument
+		value := valueOfArrayIndex(argumentList, 0)
+		value = toPrimitiveValue(value)
+		if value.IsString() {
+			return dateParse(value.string())
+		}
+
+		return value.float64()
+	default: // 2-argument, 3-argument, ...
 		var year, month, day, hour, minute, second, millisecond float64
 		var invalid bool
 		if year, invalid = pick(0, 1900.0); invalid {
-			goto INVALID
+			return math.NaN()
 		}
 		if month, invalid = pick(1, 0.0); invalid {
-			goto INVALID
+			return math.NaN()
 		}
 		if day, invalid = pick(2, 1.0); invalid {
-			goto INVALID
+			return math.NaN()
 		}
 		if hour, invalid = pick(3, 0.0); invalid {
-			goto INVALID
+			return math.NaN()
 		}
 		if minute, invalid = pick(4, 0.0); invalid {
-			goto INVALID
+			return math.NaN()
 		}
 		if second, invalid = pick(5, 0.0); invalid {
-			goto INVALID
+			return math.NaN()
 		}
 		if millisecond, invalid = pick(6, 0.0); invalid {
-			goto INVALID
+			return math.NaN()
 		}
 
 		if year >= 0 && year <= 99 {
@@ -206,22 +215,7 @@ func newDateTime(argumentList []Value, location *Time.Location) (epoch float64) 
 
 		time := Time.Date(int(year), dateToGoMonth(int(month)), int(day), int(hour), int(minute), int(second), int(millisecond)*1000*1000, location)
 		return timeToEpoch(time)
-	} else if len(argumentList) == 0 { // 0-argument
-		time := Time.Now().In(utcTimeZone)
-		return timeToEpoch(time)
-	} else { // 1-argument
-		value := valueOfArrayIndex(argumentList, 0)
-		value = toPrimitive(value)
-		if value.IsString() {
-			return dateParse(value.string())
-		}
-
-		return value.float64()
 	}
-
-INVALID:
-	epoch = math.NaN()
-	return
 }
 
 var (
@@ -259,7 +253,8 @@ var (
 	matchDateTimeZone = regexp.MustCompile(`^(.*)(?:(Z)|([\+\-]\d{2}):(\d{2}))$`)
 )
 
-func dateParse(date string) (epoch float64) {
+// dateParse returns the epoch of the parsed date.
+func dateParse(date string) float64 {
 	// YYYY-MM-DDTHH:mm:ss.sssZ
 	var time Time.Time
 	var err error

--- a/type_error.go
+++ b/type_error.go
@@ -1,58 +1,58 @@
 package otto
 
-func (rt *_runtime) newErrorObject(name string, message Value, stackFramesToPop int) *_object {
-	self := rt.newClassObject(classError)
+func (rt *runtime) newErrorObject(name string, message Value, stackFramesToPop int) *object {
+	obj := rt.newClassObject(classErrorName)
 	if message.IsDefined() {
 		msg := message.string()
-		self.defineProperty("message", toValue_string(msg), 0111, false)
-		self.value = newError(rt, name, stackFramesToPop, msg)
+		obj.defineProperty("message", stringValue(msg), 0o111, false)
+		obj.value = newError(rt, name, stackFramesToPop, msg)
 	} else {
-		self.value = newError(rt, name, stackFramesToPop)
+		obj.value = newError(rt, name, stackFramesToPop)
 	}
 
-	self.defineOwnProperty("stack", _property{
-		value: _propertyGetSet{
+	obj.defineOwnProperty("stack", property{
+		value: propertyGetSet{
 			rt.newNativeFunction("get", "internal", 0, func(FunctionCall) Value {
-				return toValue_string(self.value.(_error).formatWithStack())
+				return stringValue(obj.value.(ottoError).formatWithStack())
 			}),
-			&_nilGetSetObject,
+			&nilGetSetObject,
 		},
 		mode: modeConfigureMask & modeOnMask,
 	}, false)
 
-	return self
+	return obj
 }
 
-func (rt *_runtime) newErrorObjectError(err _error) *_object {
-	self := rt.newClassObject(classError)
-	self.defineProperty("message", err.messageValue(), 0111, false)
-	self.value = err
+func (rt *runtime) newErrorObjectError(err ottoError) *object {
+	obj := rt.newClassObject(classErrorName)
+	obj.defineProperty("message", err.messageValue(), 0o111, false)
+	obj.value = err
 	switch err.name {
 	case "EvalError":
-		self.prototype = rt.global.EvalErrorPrototype
+		obj.prototype = rt.global.EvalErrorPrototype
 	case "TypeError":
-		self.prototype = rt.global.TypeErrorPrototype
+		obj.prototype = rt.global.TypeErrorPrototype
 	case "RangeError":
-		self.prototype = rt.global.RangeErrorPrototype
+		obj.prototype = rt.global.RangeErrorPrototype
 	case "ReferenceError":
-		self.prototype = rt.global.ReferenceErrorPrototype
+		obj.prototype = rt.global.ReferenceErrorPrototype
 	case "SyntaxError":
-		self.prototype = rt.global.SyntaxErrorPrototype
+		obj.prototype = rt.global.SyntaxErrorPrototype
 	case "URIError":
-		self.prototype = rt.global.URIErrorPrototype
+		obj.prototype = rt.global.URIErrorPrototype
 	default:
-		self.prototype = rt.global.ErrorPrototype
+		obj.prototype = rt.global.ErrorPrototype
 	}
 
-	self.defineOwnProperty("stack", _property{
-		value: _propertyGetSet{
+	obj.defineOwnProperty("stack", property{
+		value: propertyGetSet{
 			rt.newNativeFunction("get", "internal", 0, func(FunctionCall) Value {
-				return toValue_string(self.value.(_error).formatWithStack())
+				return stringValue(obj.value.(ottoError).formatWithStack())
 			}),
-			&_nilGetSetObject,
+			&nilGetSetObject,
 		},
 		mode: modeConfigureMask & modeOnMask,
 	}, false)
 
-	return self
+	return obj
 }

--- a/type_go_array.go
+++ b/type_go_array.go
@@ -5,51 +5,51 @@ import (
 	"strconv"
 )
 
-func (runtime *_runtime) newGoArrayObject(value reflect.Value) *_object {
-	self := runtime.newObject()
-	self.class = classGoArray
-	self.objectClass = _classGoArray
-	self.value = _newGoArrayObject(value)
-	return self
+func (rt *runtime) newGoArrayObject(value reflect.Value) *object {
+	o := rt.newObject()
+	o.class = classGoArrayName
+	o.objectClass = classGoArray
+	o.value = newGoArrayObject(value)
+	return o
 }
 
-type _goArrayObject struct {
+type goArrayObject struct {
 	value        reflect.Value
 	writable     bool
-	propertyMode _propertyMode
+	propertyMode propertyMode
 }
 
-func _newGoArrayObject(value reflect.Value) *_goArrayObject {
+func newGoArrayObject(value reflect.Value) *goArrayObject {
 	writable := value.Kind() == reflect.Ptr || value.CanSet() // The Array is addressable (like a Slice)
-	mode := _propertyMode(0010)
+	mode := propertyMode(0o010)
 	if writable {
-		mode = 0110
+		mode = 0o110
 	}
-	self := &_goArrayObject{
+
+	return &goArrayObject{
 		value:        value,
 		writable:     writable,
 		propertyMode: mode,
 	}
-	return self
 }
 
-func (self _goArrayObject) getValue(name string) (reflect.Value, bool) {
+func (o goArrayObject) getValue(name string) (reflect.Value, bool) { //nolint: unused
 	if index, err := strconv.ParseInt(name, 10, 64); err != nil {
-		v, ok := self.getValueIndex(index)
+		v, ok := o.getValueIndex(index)
 		if ok {
 			return v, ok
 		}
 	}
 
-	if m := self.value.MethodByName(name); m != (reflect.Value{}) {
+	if m := o.value.MethodByName(name); m != (reflect.Value{}) {
 		return m, true
 	}
 
 	return reflect.Value{}, false
 }
 
-func (self _goArrayObject) getValueIndex(index int64) (reflect.Value, bool) {
-	value := reflect.Indirect(self.value)
+func (o goArrayObject) getValueIndex(index int64) (reflect.Value, bool) {
+	value := reflect.Indirect(o.value)
 	if index < int64(value.Len()) {
 		return value.Index(int(index)), true
 	}
@@ -57,12 +57,12 @@ func (self _goArrayObject) getValueIndex(index int64) (reflect.Value, bool) {
 	return reflect.Value{}, false
 }
 
-func (self _goArrayObject) setValue(index int64, value Value) bool {
-	indexValue, exists := self.getValueIndex(index)
+func (o goArrayObject) setValue(index int64, value Value) bool {
+	indexValue, exists := o.getValueIndex(index)
 	if !exists {
 		return false
 	}
-	reflectValue, err := value.toReflectValue(reflect.Indirect(self.value).Type().Elem())
+	reflectValue, err := value.toReflectValue(reflect.Indirect(o.value).Type().Elem())
 	if err != nil {
 		panic(err)
 	}
@@ -70,87 +70,87 @@ func (self _goArrayObject) setValue(index int64, value Value) bool {
 	return true
 }
 
-func goArrayGetOwnProperty(self *_object, name string) *_property {
+func goArrayGetOwnProperty(obj *object, name string) *property {
 	// length
 	if name == propertyLength {
-		return &_property{
-			value: toValue(reflect.Indirect(self.value.(*_goArrayObject).value).Len()),
+		return &property{
+			value: toValue(reflect.Indirect(obj.value.(*goArrayObject).value).Len()),
 			mode:  0,
 		}
 	}
 
 	// .0, .1, .2, ...
 	if index := stringToArrayIndex(name); index >= 0 {
-		object := self.value.(*_goArrayObject)
+		goObj := obj.value.(*goArrayObject)
 		value := Value{}
-		reflectValue, exists := object.getValueIndex(index)
+		reflectValue, exists := goObj.getValueIndex(index)
 		if exists {
-			value = self.runtime.toValue(reflectValue.Interface())
+			value = obj.runtime.toValue(reflectValue.Interface())
 		}
-		return &_property{
+		return &property{
 			value: value,
-			mode:  object.propertyMode,
+			mode:  goObj.propertyMode,
 		}
 	}
 
-	if method := self.value.(*_goArrayObject).value.MethodByName(name); method != (reflect.Value{}) {
-		return &_property{
-			self.runtime.toValue(method.Interface()),
-			0110,
+	if method := obj.value.(*goArrayObject).value.MethodByName(name); method != (reflect.Value{}) {
+		return &property{
+			obj.runtime.toValue(method.Interface()),
+			0o110,
 		}
 	}
 
-	return objectGetOwnProperty(self, name)
+	return objectGetOwnProperty(obj, name)
 }
 
-func goArrayEnumerate(self *_object, all bool, each func(string) bool) {
-	object := self.value.(*_goArrayObject)
+func goArrayEnumerate(obj *object, all bool, each func(string) bool) {
+	goObj := obj.value.(*goArrayObject)
 	// .0, .1, .2, ...
 
-	for index, length := 0, object.value.Len(); index < length; index++ {
+	for index, length := 0, goObj.value.Len(); index < length; index++ {
 		name := strconv.FormatInt(int64(index), 10)
 		if !each(name) {
 			return
 		}
 	}
 
-	objectEnumerate(self, all, each)
+	objectEnumerate(obj, all, each)
 }
 
-func goArrayDefineOwnProperty(self *_object, name string, descriptor _property, throw bool) bool {
+func goArrayDefineOwnProperty(obj *object, name string, descriptor property, throw bool) bool {
 	if name == propertyLength {
-		return self.runtime.typeErrorResult(throw)
+		return obj.runtime.typeErrorResult(throw)
 	} else if index := stringToArrayIndex(name); index >= 0 {
-		object := self.value.(*_goArrayObject)
-		if object.writable {
-			if self.value.(*_goArrayObject).setValue(index, descriptor.value.(Value)) {
+		goObj := obj.value.(*goArrayObject)
+		if goObj.writable {
+			if obj.value.(*goArrayObject).setValue(index, descriptor.value.(Value)) {
 				return true
 			}
 		}
-		return self.runtime.typeErrorResult(throw)
+		return obj.runtime.typeErrorResult(throw)
 	}
-	return objectDefineOwnProperty(self, name, descriptor, throw)
+	return objectDefineOwnProperty(obj, name, descriptor, throw)
 }
 
-func goArrayDelete(self *_object, name string, throw bool) bool {
+func goArrayDelete(obj *object, name string, throw bool) bool {
 	// length
 	if name == propertyLength {
-		return self.runtime.typeErrorResult(throw)
+		return obj.runtime.typeErrorResult(throw)
 	}
 
 	// .0, .1, .2, ...
 	index := stringToArrayIndex(name)
 	if index >= 0 {
-		object := self.value.(*_goArrayObject)
-		if object.writable {
-			indexValue, exists := object.getValueIndex(index)
+		goObj := obj.value.(*goArrayObject)
+		if goObj.writable {
+			indexValue, exists := goObj.getValueIndex(index)
 			if exists {
-				indexValue.Set(reflect.Zero(reflect.Indirect(object.value).Type().Elem()))
+				indexValue.Set(reflect.Zero(reflect.Indirect(goObj.value).Type().Elem()))
 				return true
 			}
 		}
-		return self.runtime.typeErrorResult(throw)
+		return obj.runtime.typeErrorResult(throw)
 	}
 
-	return self.delete(name, throw)
+	return obj.delete(name, throw)
 }

--- a/type_go_map.go
+++ b/type_go_map.go
@@ -4,69 +4,68 @@ import (
 	"reflect"
 )
 
-func (runtime *_runtime) newGoMapObject(value reflect.Value) *_object {
-	self := runtime.newObject()
-	self.class = classObject // TODO Should this be something else?
-	self.objectClass = _classGoMap
-	self.value = _newGoMapObject(value)
-	return self
+func (rt *runtime) newGoMapObject(value reflect.Value) *object {
+	obj := rt.newObject()
+	obj.class = classObjectName // TODO Should this be something else?
+	obj.objectClass = classGoMap
+	obj.value = newGoMapObject(value)
+	return obj
 }
 
-type _goMapObject struct {
+type goMapObject struct {
 	value     reflect.Value
 	keyType   reflect.Type
 	valueType reflect.Type
 }
 
-func _newGoMapObject(value reflect.Value) *_goMapObject {
+func newGoMapObject(value reflect.Value) *goMapObject {
 	if value.Kind() != reflect.Map {
 		dbgf("%/panic//%@: %v != reflect.Map", value.Kind())
 	}
-	self := &_goMapObject{
+	return &goMapObject{
 		value:     value,
 		keyType:   value.Type().Key(),
 		valueType: value.Type().Elem(),
 	}
-	return self
 }
 
-func (self _goMapObject) toKey(name string) reflect.Value {
-	reflectValue, err := stringToReflectValue(name, self.keyType.Kind())
+func (o goMapObject) toKey(name string) reflect.Value {
+	reflectValue, err := stringToReflectValue(name, o.keyType.Kind())
 	if err != nil {
 		panic(err)
 	}
 	return reflectValue
 }
 
-func (self _goMapObject) toValue(value Value) reflect.Value {
-	reflectValue, err := value.toReflectValue(self.valueType)
+func (o goMapObject) toValue(value Value) reflect.Value {
+	reflectValue, err := value.toReflectValue(o.valueType)
 	if err != nil {
 		panic(err)
 	}
 	return reflectValue
 }
 
-func goMapGetOwnProperty(self *_object, name string) *_property {
-	object := self.value.(*_goMapObject)
-	value := object.value.MapIndex(object.toKey(name))
+func goMapGetOwnProperty(obj *object, name string) *property {
+	goObj := obj.value.(*goMapObject)
+	value := goObj.value.MapIndex(goObj.toKey(name))
 	if value.IsValid() {
-		return &_property{self.runtime.toValue(value.Interface()), 0111}
+		return &property{obj.runtime.toValue(value.Interface()), 0o111}
 	}
 
 	// Other methods
-	if method := self.value.(*_goMapObject).value.MethodByName(name); method.IsValid() {
-		return &_property{
-			value: self.runtime.toValue(method.Interface()),
-			mode:  0110,
+	if method := obj.value.(*goMapObject).value.MethodByName(name); method.IsValid() {
+		return &property{
+			value: obj.runtime.toValue(method.Interface()),
+			mode:  0o110,
 		}
 	}
 
 	return nil
 }
 
-func goMapEnumerate(self *_object, all bool, each func(string) bool) {
-	object := self.value.(*_goMapObject)
-	keys := object.value.MapKeys()
+func goMapEnumerate(obj *object, all bool, each func(string) bool) {
+	goObj := obj.value.(*goMapObject)
+	keys := goObj.value.MapKeys()
 	for _, key := range keys {
 		if !each(toValue(key).String()) {
 			return
@@ -74,22 +73,22 @@ func goMapEnumerate(self *_object, all bool, each func(string) bool) {
 	}
 }
 
-func goMapDefineOwnProperty(self *_object, name string, descriptor _property, throw bool) bool {
-	object := self.value.(*_goMapObject)
+func goMapDefineOwnProperty(obj *object, name string, descriptor property, throw bool) bool {
+	goObj := obj.value.(*goMapObject)
 	// TODO ...or 0222
-	if descriptor.mode != 0111 {
-		return self.runtime.typeErrorResult(throw)
+	if descriptor.mode != 0o111 {
+		return obj.runtime.typeErrorResult(throw)
 	}
 	if !descriptor.isDataDescriptor() {
-		return self.runtime.typeErrorResult(throw)
+		return obj.runtime.typeErrorResult(throw)
 	}
-	object.value.SetMapIndex(object.toKey(name), object.toValue(descriptor.value.(Value)))
+	goObj.value.SetMapIndex(goObj.toKey(name), goObj.toValue(descriptor.value.(Value)))
 	return true
 }
 
-func goMapDelete(self *_object, name string, throw bool) bool {
-	object := self.value.(*_goMapObject)
-	object.value.SetMapIndex(object.toKey(name), reflect.Value{})
+func goMapDelete(obj *object, name string, throw bool) bool {
+	goObj := obj.value.(*goMapObject)
+	goObj.value.SetMapIndex(goObj.toKey(name), reflect.Value{})
 	// FIXME
 	return true
 }

--- a/type_go_map_test.go
+++ b/type_go_map_test.go
@@ -17,7 +17,7 @@ func (s GoMapTest) Join() string {
 	// All of this is meant to ensure that the test is predictable.
 	keys := make([]string, len(s))
 	i := 0
-	for key, _ := range s {
+	for key := range s {
 		keys[i] = key
 		i++
 	}

--- a/type_go_struct.go
+++ b/type_go_struct.go
@@ -13,40 +13,39 @@ import (
 // 1. Creating a new struct every time
 // 2. Creating an addressable? struct in the constructor
 
-func (runtime *_runtime) newGoStructObject(value reflect.Value) *_object {
-	self := runtime.newObject()
-	self.class = classObject // TODO Should this be something else?
-	self.objectClass = _classGoStruct
-	self.value = _newGoStructObject(value)
-	return self
+func (rt *runtime) newGoStructObject(value reflect.Value) *object {
+	o := rt.newObject()
+	o.class = classObjectName // TODO Should this be something else?
+	o.objectClass = classGoStruct
+	o.value = newGoStructObject(value)
+	return o
 }
 
-type _goStructObject struct {
+type goStructObject struct {
 	value reflect.Value
 }
 
-func _newGoStructObject(value reflect.Value) *_goStructObject {
+func newGoStructObject(value reflect.Value) *goStructObject {
 	if reflect.Indirect(value).Kind() != reflect.Struct {
 		dbgf("%/panic//%@: %v != reflect.Struct", value.Kind())
 	}
-	self := &_goStructObject{
+	return &goStructObject{
 		value: value,
 	}
-	return self
 }
 
-func (self _goStructObject) getValue(name string) reflect.Value {
-	if idx := fieldIndexByName(reflect.Indirect(self.value).Type(), name); len(idx) > 0 {
-		return reflect.Indirect(self.value).FieldByIndex(idx)
+func (o goStructObject) getValue(name string) reflect.Value {
+	if idx := fieldIndexByName(reflect.Indirect(o.value).Type(), name); len(idx) > 0 {
+		return reflect.Indirect(o.value).FieldByIndex(idx)
 	}
 
 	if validGoStructName(name) {
 		// Do not reveal hidden or unexported fields.
-		if field := reflect.Indirect(self.value).FieldByName(name); field.IsValid() {
+		if field := reflect.Indirect(o.value).FieldByName(name); field.IsValid() {
 			return field
 		}
 
-		if method := self.value.MethodByName(name); method.IsValid() {
+		if method := o.value.MethodByName(name); method.IsValid() {
 			return method
 		}
 	}
@@ -54,20 +53,20 @@ func (self _goStructObject) getValue(name string) reflect.Value {
 	return reflect.Value{}
 }
 
-func (self _goStructObject) fieldIndex(name string) []int {
-	return fieldIndexByName(reflect.Indirect(self.value).Type(), name)
+func (o goStructObject) fieldIndex(name string) []int { //nolint: unused
+	return fieldIndexByName(reflect.Indirect(o.value).Type(), name)
 }
 
-func (self _goStructObject) method(name string) (reflect.Method, bool) {
-	return reflect.Indirect(self.value).Type().MethodByName(name)
+func (o goStructObject) method(name string) (reflect.Method, bool) { //nolint: unused
+	return reflect.Indirect(o.value).Type().MethodByName(name)
 }
 
-func (self _goStructObject) setValue(rt *_runtime, name string, value Value) bool {
-	if idx := fieldIndexByName(reflect.Indirect(self.value).Type(), name); len(idx) == 0 {
+func (o goStructObject) setValue(rt *runtime, name string, value Value) bool {
+	if idx := fieldIndexByName(reflect.Indirect(o.value).Type(), name); len(idx) == 0 {
 		return false
 	}
 
-	fieldValue := self.getValue(name)
+	fieldValue := o.getValue(name)
 	converted, err := rt.convertCallParameter(value, fieldValue.Type())
 	if err != nil {
 		panic(rt.panicTypeError(err.Error()))
@@ -77,14 +76,14 @@ func (self _goStructObject) setValue(rt *_runtime, name string, value Value) boo
 	return true
 }
 
-func goStructGetOwnProperty(self *_object, name string) *_property {
-	object := self.value.(*_goStructObject)
-	value := object.getValue(name)
+func goStructGetOwnProperty(obj *object, name string) *property {
+	goObj := obj.value.(*goStructObject)
+	value := goObj.getValue(name)
 	if value.IsValid() {
-		return &_property{self.runtime.toValue(value), 0110}
+		return &property{obj.runtime.toValue(value), 0o110}
 	}
 
-	return objectGetOwnProperty(self, name)
+	return objectGetOwnProperty(obj, name)
 }
 
 func validGoStructName(name string) bool {
@@ -94,12 +93,12 @@ func validGoStructName(name string) bool {
 	return 'A' <= name[0] && name[0] <= 'Z' // TODO What about Unicode?
 }
 
-func goStructEnumerate(self *_object, all bool, each func(string) bool) {
-	object := self.value.(*_goStructObject)
+func goStructEnumerate(obj *object, all bool, each func(string) bool) {
+	goObj := obj.value.(*goStructObject)
 
 	// Enumerate fields
-	for index := 0; index < reflect.Indirect(object.value).NumField(); index++ {
-		name := reflect.Indirect(object.value).Type().Field(index).Name
+	for index := 0; index < reflect.Indirect(goObj.value).NumField(); index++ {
+		name := reflect.Indirect(goObj.value).Type().Field(index).Name
 		if validGoStructName(name) {
 			if !each(name) {
 				return
@@ -108,8 +107,8 @@ func goStructEnumerate(self *_object, all bool, each func(string) bool) {
 	}
 
 	// Enumerate methods
-	for index := 0; index < object.value.NumMethod(); index++ {
-		name := object.value.Type().Method(index).Name
+	for index := 0; index < goObj.value.NumMethod(); index++ {
+		name := goObj.value.Type().Method(index).Name
 		if validGoStructName(name) {
 			if !each(name) {
 				return
@@ -117,34 +116,31 @@ func goStructEnumerate(self *_object, all bool, each func(string) bool) {
 		}
 	}
 
-	objectEnumerate(self, all, each)
+	objectEnumerate(obj, all, each)
 }
 
-func goStructCanPut(self *_object, name string) bool {
-	object := self.value.(*_goStructObject)
-	value := object.getValue(name)
+func goStructCanPut(obj *object, name string) bool {
+	goObj := obj.value.(*goStructObject)
+	value := goObj.getValue(name)
 	if value.IsValid() {
 		return true
 	}
 
-	return objectCanPut(self, name)
+	return objectCanPut(obj, name)
 }
 
-func goStructPut(self *_object, name string, value Value, throw bool) {
-	object := self.value.(*_goStructObject)
-	if object.setValue(self.runtime, name, value) {
+func goStructPut(obj *object, name string, value Value, throw bool) {
+	goObj := obj.value.(*goStructObject)
+	if goObj.setValue(obj.runtime, name, value) {
 		return
 	}
 
-	objectPut(self, name, value, throw)
+	objectPut(obj, name, value, throw)
 }
 
-func goStructMarshalJSON(self *_object) json.Marshaler {
-	object := self.value.(*_goStructObject)
-	goValue := reflect.Indirect(object.value).Interface()
-	switch marshaler := goValue.(type) {
-	case json.Marshaler:
-		return marshaler
-	}
-	return nil
+func goStructMarshalJSON(obj *object) json.Marshaler {
+	goObj := obj.value.(*goStructObject)
+	goValue := reflect.Indirect(goObj.value).Interface()
+	marshaler, _ := goValue.(json.Marshaler)
+	return marshaler
 }

--- a/type_number.go
+++ b/type_number.go
@@ -1,5 +1,5 @@
 package otto
 
-func (runtime *_runtime) newNumberObject(value Value) *_object {
-	return runtime.newPrimitiveObject(classNumber, value.numberValue())
+func (rt *runtime) newNumberObject(value Value) *object {
+	return rt.newPrimitiveObject(classNumberName, value.numberValue())
 }

--- a/type_regexp.go
+++ b/type_regexp.go
@@ -7,7 +7,7 @@ import (
 	"github.com/robertkrimen/otto/parser"
 )
 
-type _regExpObject struct {
+type regExpObject struct {
 	regularExpression *regexp.Regexp
 	global            bool
 	ignoreCase        bool
@@ -16,9 +16,9 @@ type _regExpObject struct {
 	flags             string
 }
 
-func (runtime *_runtime) newRegExpObject(pattern string, flags string) *_object {
-	self := runtime.newObject()
-	self.class = classRegExp
+func (rt *runtime) newRegExpObject(pattern string, flags string) *object {
+	o := rt.newObject()
+	o.class = classRegExpName
 
 	global := false
 	ignoreCase := false
@@ -31,18 +31,18 @@ func (runtime *_runtime) newRegExpObject(pattern string, flags string) *_object 
 		switch chr {
 		case 'g':
 			if global {
-				panic(runtime.panicSyntaxError("newRegExpObject: %s %s", pattern, flags))
+				panic(rt.panicSyntaxError("newRegExpObject: %s %s", pattern, flags))
 			}
 			global = true
 		case 'm':
 			if multiline {
-				panic(runtime.panicSyntaxError("newRegExpObject: %s %s", pattern, flags))
+				panic(rt.panicSyntaxError("newRegExpObject: %s %s", pattern, flags))
 			}
 			multiline = true
 			re2flags += "m"
 		case 'i':
 			if ignoreCase {
-				panic(runtime.panicSyntaxError("newRegExpObject: %s %s", pattern, flags))
+				panic(rt.panicSyntaxError("newRegExpObject: %s %s", pattern, flags))
 			}
 			ignoreCase = true
 			re2flags += "i"
@@ -51,7 +51,7 @@ func (runtime *_runtime) newRegExpObject(pattern string, flags string) *_object 
 
 	re2pattern, err := parser.TransformRegExp(pattern)
 	if err != nil {
-		panic(runtime.panicTypeError("Invalid regular expression: %s", err.Error()))
+		panic(rt.panicTypeError("Invalid regular expression: %s", err.Error()))
 	}
 	if len(re2flags) > 0 {
 		re2pattern = fmt.Sprintf("(?%s:%s)", re2flags, re2pattern)
@@ -59,10 +59,10 @@ func (runtime *_runtime) newRegExpObject(pattern string, flags string) *_object 
 
 	regularExpression, err := regexp.Compile(re2pattern)
 	if err != nil {
-		panic(runtime.panicSyntaxError("Invalid regular expression: %s", err.Error()[22:]))
+		panic(rt.panicSyntaxError("Invalid regular expression: %s", err.Error()[22:]))
 	}
 
-	self.value = _regExpObject{
+	o.value = regExpObject{
 		regularExpression: regularExpression,
 		global:            global,
 		ignoreCase:        ignoreCase,
@@ -70,21 +70,21 @@ func (runtime *_runtime) newRegExpObject(pattern string, flags string) *_object 
 		source:            pattern,
 		flags:             flags,
 	}
-	self.defineProperty("global", toValue_bool(global), 0, false)
-	self.defineProperty("ignoreCase", toValue_bool(ignoreCase), 0, false)
-	self.defineProperty("multiline", toValue_bool(multiline), 0, false)
-	self.defineProperty("lastIndex", toValue_int(0), 0100, false)
-	self.defineProperty("source", toValue_string(pattern), 0, false)
-	return self
+	o.defineProperty("global", boolValue(global), 0, false)
+	o.defineProperty("ignoreCase", boolValue(ignoreCase), 0, false)
+	o.defineProperty("multiline", boolValue(multiline), 0, false)
+	o.defineProperty("lastIndex", intValue(0), 0o100, false)
+	o.defineProperty("source", stringValue(pattern), 0, false)
+	return o
 }
 
-func (self *_object) regExpValue() _regExpObject {
-	value, _ := self.value.(_regExpObject)
+func (o *object) regExpValue() regExpObject {
+	value, _ := o.value.(regExpObject)
 	return value
 }
 
-func execRegExp(this *_object, target string) (match bool, result []int) {
-	if this.class != classRegExp {
+func execRegExp(this *object, target string) (bool, []int) {
+	if this.class != classRegExpName {
 		panic(this.runtime.panicTypeError("Calling RegExp.exec on a non-RegExp object"))
 	}
 	lastIndex := this.get("lastIndex").number().int64
@@ -93,15 +93,18 @@ func execRegExp(this *_object, target string) (match bool, result []int) {
 	if !global {
 		index = 0
 	}
+
+	var result []int
 	if 0 > index || index > int64(len(target)) {
 	} else {
 		result = this.regExpValue().regularExpression.FindStringSubmatchIndex(target[index:])
 	}
+
 	if result == nil {
-		this.put("lastIndex", toValue_int(0), true)
-		return // !match
+		this.put("lastIndex", intValue(0), true)
+		return false, nil
 	}
-	match = true
+
 	startIndex := index
 	endIndex := int(lastIndex) + result[1]
 	// We do this shift here because the .FindStringSubmatchIndex above
@@ -112,18 +115,19 @@ func execRegExp(this *_object, target string) (match bool, result []int) {
 		}
 	}
 	if global {
-		this.put("lastIndex", toValue_int(endIndex), true)
+		this.put("lastIndex", intValue(endIndex), true)
 	}
-	return // match
+
+	return true, result
 }
 
-func execResultToArray(runtime *_runtime, target string, result []int) *_object {
+func execResultToArray(rt *runtime, target string, result []int) *object {
 	captureCount := len(result) / 2
 	valueArray := make([]Value, captureCount)
 	for index := 0; index < captureCount; index++ {
 		offset := 2 * index
 		if result[offset] != -1 {
-			valueArray[index] = toValue_string(target[result[offset]:result[offset+1]])
+			valueArray[index] = stringValue(target[result[offset]:result[offset+1]])
 		} else {
 			valueArray[index] = Value{}
 		}
@@ -133,8 +137,8 @@ func execResultToArray(runtime *_runtime, target string, result []int) *_object 
 		// Find the utf16 index in the string, not the byte index.
 		matchIndex = utf16Length(target[:matchIndex])
 	}
-	match := runtime.newArrayOf(valueArray)
-	match.defineProperty("input", toValue_string(target), 0111, false)
-	match.defineProperty("index", toValue_int(matchIndex), 0111, false)
+	match := rt.newArrayOf(valueArray)
+	match.defineProperty("input", stringValue(target), 0o111, false)
+	match.defineProperty("index", intValue(matchIndex), 0o111, false)
 	return match
 }

--- a/type_string.go
+++ b/type_string.go
@@ -6,90 +6,90 @@ import (
 	"unicode/utf8"
 )
 
-type _stringObject interface {
+type stringObjecter interface {
 	Length() int
 	At(int) rune
 	String() string
 }
 
-type _stringASCII string
+type stringASCII string
 
-func (str _stringASCII) Length() int {
+func (str stringASCII) Length() int {
 	return len(str)
 }
 
-func (str _stringASCII) At(at int) rune {
+func (str stringASCII) At(at int) rune {
 	return rune(str[at])
 }
 
-func (str _stringASCII) String() string {
+func (str stringASCII) String() string {
 	return string(str)
 }
 
-type _stringWide struct {
+type stringWide struct {
 	string  string
 	value16 []uint16
 }
 
-func (str _stringWide) Length() int {
+func (str stringWide) Length() int {
 	if str.value16 == nil {
 		str.value16 = utf16.Encode([]rune(str.string))
 	}
 	return len(str.value16)
 }
 
-func (str _stringWide) At(at int) rune {
+func (str stringWide) At(at int) rune {
 	if str.value16 == nil {
 		str.value16 = utf16.Encode([]rune(str.string))
 	}
 	return rune(str.value16[at])
 }
 
-func (str _stringWide) String() string {
+func (str stringWide) String() string {
 	return str.string
 }
 
-func _newStringObject(str string) _stringObject {
+func newStringObject(str string) stringObjecter {
 	for i := 0; i < len(str); i++ {
 		if str[i] >= utf8.RuneSelf {
 			goto wide
 		}
 	}
 
-	return _stringASCII(str)
+	return stringASCII(str)
 
 wide:
-	return &_stringWide{
+	return &stringWide{
 		string: str,
 	}
 }
 
-func stringAt(str _stringObject, index int) rune {
+func stringAt(str stringObjecter, index int) rune {
 	if 0 <= index && index < str.Length() {
 		return str.At(index)
 	}
 	return utf8.RuneError
 }
 
-func (runtime *_runtime) newStringObject(value Value) *_object {
-	str := _newStringObject(value.string())
+func (rt *runtime) newStringObject(value Value) *object {
+	str := newStringObject(value.string())
 
-	self := runtime.newClassObject(classString)
-	self.defineProperty(propertyLength, toValue_int(str.Length()), 0, false)
-	self.objectClass = _classString
-	self.value = str
-	return self
+	obj := rt.newClassObject(classStringName)
+	obj.defineProperty(propertyLength, intValue(str.Length()), 0, false)
+	obj.objectClass = classString
+	obj.value = str
+	return obj
 }
 
-func (self *_object) stringValue() _stringObject {
-	if str, ok := self.value.(_stringObject); ok {
+func (o *object) stringValue() stringObjecter {
+	if str, ok := o.value.(stringObjecter); ok {
 		return str
 	}
 	return nil
 }
 
-func stringEnumerate(self *_object, all bool, each func(string) bool) {
-	if str := self.stringValue(); str != nil {
+func stringEnumerate(obj *object, all bool, each func(string) bool) {
+	if str := obj.stringValue(); str != nil {
 		length := str.Length()
 		for index := 0; index < length; index++ {
 			if !each(strconv.FormatInt(int64(index), 10)) {
@@ -97,17 +97,17 @@ func stringEnumerate(self *_object, all bool, each func(string) bool) {
 			}
 		}
 	}
-	objectEnumerate(self, all, each)
+	objectEnumerate(obj, all, each)
 }
 
-func stringGetOwnProperty(self *_object, name string) *_property {
-	if property := objectGetOwnProperty(self, name); property != nil {
-		return property
+func stringGetOwnProperty(obj *object, name string) *property {
+	if prop := objectGetOwnProperty(obj, name); prop != nil {
+		return prop
 	}
 	// TODO Test a string of length >= +int32 + 1?
 	if index := stringToArrayIndex(name); index >= 0 {
-		if chr := stringAt(self.stringValue(), int(index)); chr != utf8.RuneError {
-			return &_property{toValue_string(string(chr)), 0}
+		if chr := stringAt(obj.stringValue(), int(index)); chr != utf8.RuneError {
+			return &property{stringValue(string(chr)), 0}
 		}
 	}
 	return nil

--- a/underscore/underscore.go
+++ b/underscore/underscore.go
@@ -23,7 +23,7 @@
 package underscore
 
 import (
-	_ "embed"
+	_ "embed" // Embed underscore.
 
 	"github.com/robertkrimen/otto/registry"
 )

--- a/underscore_arrays_test.go
+++ b/underscore_arrays_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 )
 
-// first
+// first.
 func Test_underscore_arrays_0(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("first", function() {
@@ -29,10 +29,10 @@ func Test_underscore_arrays_0(t *testing.T) {
 	})
 }
 
-// rest
+// rest.
 func Test_underscore_arrays_1(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("rest", function() {
@@ -51,10 +51,10 @@ func Test_underscore_arrays_1(t *testing.T) {
 	})
 }
 
-// initial
+// initial.
 func Test_underscore_arrays_2(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("initial", function() {
@@ -69,10 +69,10 @@ func Test_underscore_arrays_2(t *testing.T) {
 	})
 }
 
-// last
+// last.
 func Test_underscore_arrays_3(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("last", function() {
@@ -91,10 +91,10 @@ func Test_underscore_arrays_3(t *testing.T) {
 	})
 }
 
-// compact
+// compact.
 func Test_underscore_arrays_4(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("compact", function() {
@@ -106,10 +106,10 @@ func Test_underscore_arrays_4(t *testing.T) {
 	})
 }
 
-// flatten
+// flatten.
 func Test_underscore_arrays_5(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("flatten", function() {
@@ -123,10 +123,10 @@ func Test_underscore_arrays_5(t *testing.T) {
 	})
 }
 
-// without
+// without.
 func Test_underscore_arrays_6(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("without", function() {
@@ -143,10 +143,10 @@ func Test_underscore_arrays_6(t *testing.T) {
 	})
 }
 
-// uniq
+// uniq.
 func Test_underscore_arrays_7(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("uniq", function() {
@@ -173,10 +173,10 @@ func Test_underscore_arrays_7(t *testing.T) {
 	})
 }
 
-// intersection
+// intersection.
 func Test_underscore_arrays_8(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("intersection", function() {
@@ -190,10 +190,10 @@ func Test_underscore_arrays_8(t *testing.T) {
 	})
 }
 
-// union
+// union.
 func Test_underscore_arrays_9(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("union", function() {
@@ -207,10 +207,10 @@ func Test_underscore_arrays_9(t *testing.T) {
 	})
 }
 
-// difference
+// difference.
 func Test_underscore_arrays_10(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("difference", function() {
@@ -224,10 +224,10 @@ func Test_underscore_arrays_10(t *testing.T) {
 	})
 }
 
-// zip
+// zip.
 func Test_underscore_arrays_11(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('zip', function() {
@@ -239,10 +239,10 @@ func Test_underscore_arrays_11(t *testing.T) {
 	})
 }
 
-// object
+// object.
 func Test_underscore_arrays_12(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('object', function() {
@@ -263,10 +263,10 @@ func Test_underscore_arrays_12(t *testing.T) {
 	})
 }
 
-// indexOf
+// indexOf.
 func Test_underscore_arrays_13(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("indexOf", function() {
@@ -297,10 +297,10 @@ func Test_underscore_arrays_13(t *testing.T) {
 	})
 }
 
-// lastIndexOf
+// lastIndexOf.
 func Test_underscore_arrays_14(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("lastIndexOf", function() {
@@ -323,10 +323,10 @@ func Test_underscore_arrays_14(t *testing.T) {
 	})
 }
 
-// range
+// range.
 func Test_underscore_arrays_15(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("range", function() {

--- a/underscore_chaining_test.go
+++ b/underscore_chaining_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 )
 
-// map/flatten/reduce
+// map/flatten/reduce.
 func Test_underscore_chaining_0(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("map/flatten/reduce", function() {
@@ -31,10 +31,10 @@ func Test_underscore_chaining_0(t *testing.T) {
 	})
 }
 
-// select/reject/sortBy
+// select/reject/sortBy.
 func Test_underscore_chaining_1(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("select/reject/sortBy", function() {
@@ -52,10 +52,10 @@ func Test_underscore_chaining_1(t *testing.T) {
 	})
 }
 
-// select/reject/sortBy in functional style
+// select/reject/sortBy in functional style.
 func Test_underscore_chaining_2(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("select/reject/sortBy in functional style", function() {
@@ -73,10 +73,10 @@ func Test_underscore_chaining_2(t *testing.T) {
 	})
 }
 
-// reverse/concat/unshift/pop/map
+// reverse/concat/unshift/pop/map.
 func Test_underscore_chaining_3(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("reverse/concat/unshift/pop/map", function() {

--- a/underscore_collections_test.go
+++ b/underscore_collections_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 )
 
-// each
+// each.
 func Test_underscore_collections_0(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("each", function() {
@@ -42,10 +42,10 @@ func Test_underscore_collections_0(t *testing.T) {
 	})
 }
 
-// map
+// map.
 func Test_underscore_collections_1(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('map', function() {
@@ -82,10 +82,10 @@ func Test_underscore_collections_1(t *testing.T) {
 	})
 }
 
-// reduce
+// reduce.
 func Test_underscore_collections_2(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('reduce', function() {
@@ -111,7 +111,7 @@ func Test_underscore_collections_2(t *testing.T) {
     } catch (ex) {
       ifnull = ex;
     }
-    ok(ifnull instanceof TypeError, 'handles a null (without inital value) properly');
+    ok(ifnull instanceof TypeError, 'handles a null (without initial value) properly');
 
     ok(_.reduce(null, function(){}, 138) === 138, 'handles a null (with initial value) properly');
     equal(_.reduce([], function(){}, undefined), undefined, 'undefined can be passed as a special case');
@@ -121,10 +121,10 @@ func Test_underscore_collections_2(t *testing.T) {
 	})
 }
 
-// reduceRight
+// reduceRight.
 func Test_underscore_collections_3(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('reduceRight', function() {
@@ -143,7 +143,7 @@ func Test_underscore_collections_3(t *testing.T) {
     } catch (ex) {
       ifnull = ex;
     }
-    ok(ifnull instanceof TypeError, 'handles a null (without inital value) properly');
+    ok(ifnull instanceof TypeError, 'handles a null (without initial value) properly');
 
     var sum = _.reduceRight({a: 1, b: 2, c: 3}, function(sum, num){ return sum + num; });
     equal(sum, 6, 'default initial value on object');
@@ -190,10 +190,10 @@ func Test_underscore_collections_3(t *testing.T) {
 	})
 }
 
-// find
+// find.
 func Test_underscore_collections_4(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('find', function() {
@@ -205,10 +205,10 @@ func Test_underscore_collections_4(t *testing.T) {
 	})
 }
 
-// detect
+// detect.
 func Test_underscore_collections_5(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('detect', function() {
@@ -219,10 +219,10 @@ func Test_underscore_collections_5(t *testing.T) {
 	})
 }
 
-// select
+// select.
 func Test_underscore_collections_6(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('select', function() {
@@ -236,10 +236,10 @@ func Test_underscore_collections_6(t *testing.T) {
 	})
 }
 
-// reject
+// reject.
 func Test_underscore_collections_7(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('reject', function() {
@@ -258,10 +258,10 @@ func Test_underscore_collections_7(t *testing.T) {
 	})
 }
 
-// all
+// all.
 func Test_underscore_collections_8(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('all', function() {
@@ -279,10 +279,10 @@ func Test_underscore_collections_8(t *testing.T) {
 	})
 }
 
-// any
+// any.
 func Test_underscore_collections_9(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('any', function() {
@@ -304,10 +304,10 @@ func Test_underscore_collections_9(t *testing.T) {
 	})
 }
 
-// include
+// include.
 func Test_underscore_collections_10(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('include', function() {
@@ -320,10 +320,10 @@ func Test_underscore_collections_10(t *testing.T) {
 	})
 }
 
-// invoke
+// invoke.
 func Test_underscore_collections_11(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('invoke', function() {
@@ -336,10 +336,10 @@ func Test_underscore_collections_11(t *testing.T) {
 	})
 }
 
-// invoke w/ function reference
+// invoke w/ function reference.
 func Test_underscore_collections_12(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('invoke w/ function reference', function() {
@@ -352,10 +352,10 @@ func Test_underscore_collections_12(t *testing.T) {
 	})
 }
 
-// invoke when strings have a call method
+// invoke when strings have a call method.
 func Test_underscore_collections_13(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('invoke when strings have a call method', function() {
@@ -375,10 +375,10 @@ func Test_underscore_collections_13(t *testing.T) {
 	})
 }
 
-// pluck
+// pluck.
 func Test_underscore_collections_14(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('pluck', function() {
@@ -389,10 +389,10 @@ func Test_underscore_collections_14(t *testing.T) {
 	})
 }
 
-// where
+// where.
 func Test_underscore_collections_15(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('where', function() {
@@ -408,10 +408,10 @@ func Test_underscore_collections_15(t *testing.T) {
 	})
 }
 
-// findWhere
+// findWhere.
 func Test_underscore_collections_16(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('findWhere', function() {
@@ -425,10 +425,10 @@ func Test_underscore_collections_16(t *testing.T) {
 	})
 }
 
-// max
+// max.
 func Test_underscore_collections_17(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('max', function() {
@@ -450,10 +450,10 @@ func Test_underscore_collections_17(t *testing.T) {
 	})
 }
 
-// min
+// min.
 func Test_underscore_collections_18(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('min', function() {
@@ -479,10 +479,10 @@ func Test_underscore_collections_18(t *testing.T) {
 	})
 }
 
-// sortBy
+// sortBy.
 func Test_underscore_collections_19(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('sortBy', function() {
@@ -524,10 +524,10 @@ func Test_underscore_collections_19(t *testing.T) {
 	})
 }
 
-// groupBy
+// groupBy.
 func Test_underscore_collections_20(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('groupBy', function() {
@@ -562,10 +562,10 @@ func Test_underscore_collections_20(t *testing.T) {
 	})
 }
 
-// countBy
+// countBy.
 func Test_underscore_collections_21(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('countBy', function() {
@@ -600,10 +600,10 @@ func Test_underscore_collections_21(t *testing.T) {
 	})
 }
 
-// sortedIndex
+// sortedIndex.
 func Test_underscore_collections_22(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('sortedIndex', function() {
@@ -627,10 +627,10 @@ func Test_underscore_collections_22(t *testing.T) {
 	})
 }
 
-// shuffle
+// shuffle.
 func Test_underscore_collections_23(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('shuffle', function() {
@@ -643,10 +643,10 @@ func Test_underscore_collections_23(t *testing.T) {
 	})
 }
 
-// toArray
+// toArray.
 func Test_underscore_collections_24(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('toArray', function() {
@@ -673,10 +673,10 @@ func Test_underscore_collections_24(t *testing.T) {
 	})
 }
 
-// size
+// size.
 func Test_underscore_collections_25(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('size', function() {

--- a/underscore_functions_test.go
+++ b/underscore_functions_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 )
 
-// bind
+// bind.
 func Test_underscore_functions_0(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("bind", function() {
@@ -48,10 +48,10 @@ func Test_underscore_functions_0(t *testing.T) {
 	})
 }
 
-// partial
+// partial.
 func Test_underscore_functions_1(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("partial", function() {
@@ -65,10 +65,10 @@ func Test_underscore_functions_1(t *testing.T) {
 	})
 }
 
-// bindAll
+// bindAll.
 func Test_underscore_functions_2(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("bindAll", function() {
@@ -87,10 +87,10 @@ func Test_underscore_functions_2(t *testing.T) {
 	})
 }
 
-// memoize
+// memoize.
 func Test_underscore_functions_3(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("memoize", function() {
@@ -112,10 +112,10 @@ func Test_underscore_functions_3(t *testing.T) {
 	})
 }
 
-// once
+// once.
 func Test_underscore_functions_4(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("once", function() {
@@ -129,10 +129,10 @@ func Test_underscore_functions_4(t *testing.T) {
 	})
 }
 
-// wrap
+// wrap.
 func Test_underscore_functions_5(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("wrap", function() {
@@ -154,10 +154,10 @@ func Test_underscore_functions_5(t *testing.T) {
 	})
 }
 
-// compose
+// compose.
 func Test_underscore_functions_6(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("compose", function() {
@@ -173,10 +173,10 @@ func Test_underscore_functions_6(t *testing.T) {
 	})
 }
 
-// after
+// after.
 func Test_underscore_functions_7(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("after", function() {

--- a/underscore_objects_test.go
+++ b/underscore_objects_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 )
 
-// keys
+// keys.
 func Test_underscore_objects_0(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("keys", function() {
@@ -25,10 +25,10 @@ func Test_underscore_objects_0(t *testing.T) {
 	})
 }
 
-// values
+// values.
 func Test_underscore_objects_1(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("values", function() {
@@ -39,10 +39,10 @@ func Test_underscore_objects_1(t *testing.T) {
 	})
 }
 
-// pairs
+// pairs.
 func Test_underscore_objects_2(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("pairs", function() {
@@ -53,10 +53,10 @@ func Test_underscore_objects_2(t *testing.T) {
 	})
 }
 
-// invert
+// invert.
 func Test_underscore_objects_3(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("invert", function() {
@@ -71,10 +71,10 @@ func Test_underscore_objects_3(t *testing.T) {
 	})
 }
 
-// functions
+// functions.
 func Test_underscore_objects_4(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("functions", function() {
@@ -89,10 +89,10 @@ func Test_underscore_objects_4(t *testing.T) {
 	})
 }
 
-// extend
+// extend.
 func Test_underscore_objects_5(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("extend", function() {
@@ -118,10 +118,10 @@ func Test_underscore_objects_5(t *testing.T) {
 	})
 }
 
-// pick
+// pick.
 func Test_underscore_objects_6(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("pick", function() {
@@ -141,10 +141,10 @@ func Test_underscore_objects_6(t *testing.T) {
 	})
 }
 
-// omit
+// omit.
 func Test_underscore_objects_7(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("omit", function() {
@@ -164,10 +164,10 @@ func Test_underscore_objects_7(t *testing.T) {
 	})
 }
 
-// defaults
+// defaults.
 func Test_underscore_objects_8(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("defaults", function() {
@@ -195,10 +195,10 @@ func Test_underscore_objects_8(t *testing.T) {
 	})
 }
 
-// clone
+// clone.
 func Test_underscore_objects_9(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("clone", function() {
@@ -220,10 +220,10 @@ func Test_underscore_objects_9(t *testing.T) {
 	})
 }
 
-// isEqual
+// isEqual.
 func Test_underscore_objects_10(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("isEqual", function() {
@@ -464,10 +464,10 @@ func Test_underscore_objects_10(t *testing.T) {
 	})
 }
 
-// isEmpty
+// isEmpty.
 func Test_underscore_objects_11(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("isEmpty", function() {
@@ -489,7 +489,7 @@ func Test_underscore_objects_11(t *testing.T) {
 	})
 }
 
-// isElement
+// isElement.
 func Test_underscore_objects_12(t *testing.T) {
 	// TEST: ReferenceError: $ is not defined
 	if true {
@@ -497,7 +497,7 @@ func Test_underscore_objects_12(t *testing.T) {
 	}
 
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("isElement", function() {
@@ -509,10 +509,10 @@ func Test_underscore_objects_12(t *testing.T) {
 	})
 }
 
-// isArguments
+// isArguments.
 func Test_underscore_objects_13(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("isArguments", function() {
@@ -531,10 +531,10 @@ func Test_underscore_objects_13(t *testing.T) {
 	})
 }
 
-// isObject
+// isObject.
 func Test_underscore_objects_14(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("isObject", function() {
@@ -557,10 +557,10 @@ func Test_underscore_objects_14(t *testing.T) {
 	})
 }
 
-// isArray
+// isArray.
 func Test_underscore_objects_15(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("isArray", function() {
@@ -574,7 +574,7 @@ func Test_underscore_objects_15(t *testing.T) {
 	})
 }
 
-// isString
+// isString.
 func Test_underscore_objects_16(t *testing.T) {
 	// TEST: ReferenceError: document is not defined
 	if true {
@@ -582,7 +582,7 @@ func Test_underscore_objects_16(t *testing.T) {
 	}
 
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("isString", function() {
@@ -596,10 +596,10 @@ func Test_underscore_objects_16(t *testing.T) {
 	})
 }
 
-// isNumber
+// isNumber.
 func Test_underscore_objects_17(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("isNumber", function() {
@@ -618,10 +618,10 @@ func Test_underscore_objects_17(t *testing.T) {
 	})
 }
 
-// isBoolean
+// isBoolean.
 func Test_underscore_objects_18(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("isBoolean", function() {
@@ -643,10 +643,10 @@ func Test_underscore_objects_18(t *testing.T) {
 	})
 }
 
-// isFunction
+// isFunction.
 func Test_underscore_objects_19(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("isFunction", function() {
@@ -661,10 +661,10 @@ func Test_underscore_objects_19(t *testing.T) {
 	})
 }
 
-// isDate
+// isDate.
 func Test_underscore_objects_20(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("isDate", function() {
@@ -679,10 +679,10 @@ func Test_underscore_objects_20(t *testing.T) {
 	})
 }
 
-// isRegExp
+// isRegExp.
 func Test_underscore_objects_21(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("isRegExp", function() {
@@ -696,10 +696,10 @@ func Test_underscore_objects_21(t *testing.T) {
 	})
 }
 
-// isFinite
+// isFinite.
 func Test_underscore_objects_22(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("isFinite", function() {
@@ -721,10 +721,10 @@ func Test_underscore_objects_22(t *testing.T) {
 	})
 }
 
-// isNaN
+// isNaN.
 func Test_underscore_objects_23(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("isNaN", function() {
@@ -741,10 +741,10 @@ func Test_underscore_objects_23(t *testing.T) {
 	})
 }
 
-// isNull
+// isNull.
 func Test_underscore_objects_24(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("isNull", function() {
@@ -759,10 +759,10 @@ func Test_underscore_objects_24(t *testing.T) {
 	})
 }
 
-// isUndefined
+// isUndefined.
 func Test_underscore_objects_25(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("isUndefined", function() {
@@ -780,10 +780,10 @@ func Test_underscore_objects_25(t *testing.T) {
 	})
 }
 
-// tap
+// tap.
 func Test_underscore_objects_26(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("tap", function() {
@@ -804,10 +804,10 @@ func Test_underscore_objects_26(t *testing.T) {
 	})
 }
 
-// has
+// has.
 func Test_underscore_objects_27(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("has", function () {

--- a/underscore_utility_test.go
+++ b/underscore_utility_test.go
@@ -7,7 +7,7 @@ import (
 // #750 - Return _ instance.
 func Test_underscore_utility_0(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("#750 - Return _ instance.", 2, function() {
@@ -19,10 +19,10 @@ func Test_underscore_utility_0(t *testing.T) {
 	})
 }
 
-// identity
+// identity.
 func Test_underscore_utility_1(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("identity", function() {
@@ -33,10 +33,10 @@ func Test_underscore_utility_1(t *testing.T) {
 	})
 }
 
-// random
+// random.
 func Test_underscore_utility_2(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("random", function() {
@@ -56,10 +56,10 @@ func Test_underscore_utility_2(t *testing.T) {
 	})
 }
 
-// uniqueId
+// uniqueId.
 func Test_underscore_utility_3(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("uniqueId", function() {
@@ -71,10 +71,10 @@ func Test_underscore_utility_3(t *testing.T) {
 	})
 }
 
-// times
+// times.
 func Test_underscore_utility_4(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("times", function() {
@@ -92,10 +92,10 @@ func Test_underscore_utility_4(t *testing.T) {
 	})
 }
 
-// mixin
+// mixin.
 func Test_underscore_utility_5(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("mixin", function() {
@@ -111,10 +111,10 @@ func Test_underscore_utility_5(t *testing.T) {
 	})
 }
 
-// _.escape
+// _.escape.
 func Test_underscore_utility_6(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("_.escape", function() {
@@ -126,10 +126,10 @@ func Test_underscore_utility_6(t *testing.T) {
 	})
 }
 
-// _.unescape
+// _.unescape.
 func Test_underscore_utility_7(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("_.unescape", function() {
@@ -143,10 +143,10 @@ func Test_underscore_utility_7(t *testing.T) {
 	})
 }
 
-// template
+// template.
 func Test_underscore_utility_8(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test("template", function() {
@@ -261,10 +261,10 @@ func Test_underscore_utility_8(t *testing.T) {
 	})
 }
 
-// _.template provides the generated function source, when a SyntaxError occurs
+// _.template provides the generated function source, when a SyntaxError occurs.
 func Test_underscore_utility_9(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('_.template provides the generated function source, when a SyntaxError occurs', function() {
@@ -279,10 +279,10 @@ func Test_underscore_utility_9(t *testing.T) {
 	})
 }
 
-// _.template handles \\u2028 & \\u2029
+// _.template handles \\u2028 & \\u2029.
 func Test_underscore_utility_10(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('_.template handles \\u2028 & \\u2029', function() {
@@ -293,10 +293,10 @@ func Test_underscore_utility_10(t *testing.T) {
 	})
 }
 
-// result calls functions and returns primitives
+// result calls functions and returns primitives.
 func Test_underscore_utility_11(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('result calls functions and returns primitives', function() {
@@ -311,10 +311,10 @@ func Test_underscore_utility_11(t *testing.T) {
 	})
 }
 
-// _.templateSettings.variable
+// _.templateSettings.variable.
 func Test_underscore_utility_12(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('_.templateSettings.variable', function() {
@@ -331,7 +331,7 @@ func Test_underscore_utility_12(t *testing.T) {
 // #547 - _.templateSettings is unchanged by custom settings.
 func Test_underscore_utility_13(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('#547 - _.templateSettings is unchanged by custom settings.', function() {
@@ -346,7 +346,7 @@ func Test_underscore_utility_13(t *testing.T) {
 // #556 - undefined template variables.
 func Test_underscore_utility_14(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('#556 - undefined template variables.', function() {
@@ -373,7 +373,7 @@ func Test_underscore_utility_14(t *testing.T) {
 // interpolate evaluates code only once.
 func Test_underscore_utility_15(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('interpolate evaluates code only once.', 2, function() {
@@ -392,7 +392,7 @@ func Test_underscore_utility_15(t *testing.T) {
 // #746 - _.template settings are not modified.
 func Test_underscore_utility_16(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('#746 - _.template settings are not modified.', 1, function() {
@@ -407,7 +407,7 @@ func Test_underscore_utility_16(t *testing.T) {
 // #779 - delimeters are applied to unescaped text.
 func Test_underscore_utility_17(t *testing.T) {
 	tt(t, func() {
-		test, _ := test_()
+		test := underscoreTest()
 
 		test(`
   test('#779 - delimeters are applied to unescaped text.', 1, function() {

--- a/value.go
+++ b/value.go
@@ -9,17 +9,17 @@ import (
 	"unicode/utf16"
 )
 
-type _valueKind int
+type valueKind int
 
 const (
-	valueUndefined _valueKind = iota
+	valueUndefined valueKind = iota
 	valueNull
 	valueNumber
 	valueString
 	valueBoolean
 	valueObject
 
-	// These are invalid outside of the runtime
+	// These are invalid outside of the runtime.
 	valueEmpty
 	valueResult
 	valueReference
@@ -27,12 +27,12 @@ const (
 
 // Value is the representation of a JavaScript value.
 type Value struct {
-	kind  _valueKind
+	kind  valueKind
 	value interface{}
 }
 
-func (value Value) safe() bool {
-	return value.kind < valueEmpty
+func (v Value) safe() bool {
+	return v.kind < valueEmpty
 }
 
 var (
@@ -54,8 +54,8 @@ func ToValue(value interface{}) (Value, error) {
 	return result, err
 }
 
-func (value Value) isEmpty() bool {
-	return value.kind == valueEmpty
+func (v Value) isEmpty() bool {
+	return v.kind == valueEmpty
 }
 
 // Undefined
@@ -66,13 +66,13 @@ func UndefinedValue() Value {
 }
 
 // IsDefined will return false if the value is undefined, and true otherwise.
-func (value Value) IsDefined() bool {
-	return value.kind != valueUndefined
+func (v Value) IsDefined() bool {
+	return v.kind != valueUndefined
 }
 
 // IsUndefined will return true if the value is undefined, and false otherwise.
-func (value Value) IsUndefined() bool {
-	return value.kind == valueUndefined
+func (v Value) IsUndefined() bool {
+	return v.kind == valueUndefined
 }
 
 // NullValue will return a Value representing null.
@@ -81,15 +81,15 @@ func NullValue() Value {
 }
 
 // IsNull will return true if the value is null, and false otherwise.
-func (value Value) IsNull() bool {
-	return value.kind == valueNull
+func (v Value) IsNull() bool {
+	return v.kind == valueNull
 }
 
 // ---
 
-func (value Value) isCallable() bool {
-	v, ok := value.value.(*_object)
-	return ok && v.isCall()
+func (v Value) isCallable() bool {
+	o, ok := v.value.(*object)
+	return ok && o.isCall()
 }
 
 // Call the value as a function with the given this value and argument list and
@@ -102,20 +102,20 @@ func (value Value) isCallable() bool {
 //  1. There is an error during conversion of the argument list
 //  2. The value is not actually a function
 //  3. An (uncaught) exception is thrown
-func (value Value) Call(this Value, argumentList ...interface{}) (Value, error) {
+func (v Value) Call(this Value, argumentList ...interface{}) (Value, error) {
 	result := Value{}
 	err := catchPanic(func() {
 		// FIXME
-		result = value.call(nil, this, argumentList...)
+		result = v.call(nil, this, argumentList...)
 	})
-	if !value.safe() {
-		value = Value{}
+	if !v.safe() {
+		v = Value{}
 	}
 	return result, err
 }
 
-func (value Value) call(rt *_runtime, this Value, argumentList ...interface{}) Value {
-	if function, ok := value.value.(*_object); ok {
+func (v Value) call(rt *runtime, this Value, argumentList ...interface{}) Value {
+	if function, ok := v.value.(*object); ok {
 		return function.call(this, function.runtime.toValueArray(argumentList...), false, nativeFrame)
 	}
 	if rt == nil {
@@ -124,16 +124,16 @@ func (value Value) call(rt *_runtime, this Value, argumentList ...interface{}) V
 	panic(rt.panicTypeError())
 }
 
-func (value Value) constructSafe(rt *_runtime, this Value, argumentList ...interface{}) (Value, error) {
+func (v Value) constructSafe(rt *runtime, this Value, argumentList ...interface{}) (Value, error) {
 	result := Value{}
 	err := catchPanic(func() {
-		result = value.construct(rt, this, argumentList...)
+		result = v.construct(rt, this, argumentList...)
 	})
 	return result, err
 }
 
-func (value Value) construct(rt *_runtime, this Value, argumentList ...interface{}) Value {
-	if fn, ok := value.value.(*_object); ok {
+func (v Value) construct(rt *runtime, this Value, argumentList ...interface{}) Value { //nolint: unparam
+	if fn, ok := v.value.(*object); ok {
 		return fn.construct(fn.runtime.toValueArray(argumentList...))
 	}
 	if rt == nil {
@@ -143,23 +143,23 @@ func (value Value) construct(rt *_runtime, this Value, argumentList ...interface
 }
 
 // IsPrimitive will return true if value is a primitive (any kind of primitive).
-func (value Value) IsPrimitive() bool {
-	return !value.IsObject()
+func (v Value) IsPrimitive() bool {
+	return !v.IsObject()
 }
 
 // IsBoolean will return true if value is a boolean (primitive).
-func (value Value) IsBoolean() bool {
-	return value.kind == valueBoolean
+func (v Value) IsBoolean() bool {
+	return v.kind == valueBoolean
 }
 
 // IsNumber will return true if value is a number (primitive).
-func (value Value) IsNumber() bool {
-	return value.kind == valueNumber
+func (v Value) IsNumber() bool {
+	return v.kind == valueNumber
 }
 
 // IsNaN will return true if value is NaN (or would convert to NaN).
-func (value Value) IsNaN() bool {
-	switch value := value.value.(type) {
+func (v Value) IsNaN() bool {
+	switch value := v.value.(type) {
 	case float64:
 		return math.IsNaN(value)
 	case float32:
@@ -170,25 +170,25 @@ func (value Value) IsNaN() bool {
 		return false
 	}
 
-	return math.IsNaN(value.float64())
+	return math.IsNaN(v.float64())
 }
 
 // IsString will return true if value is a string (primitive).
-func (value Value) IsString() bool {
-	return value.kind == valueString
+func (v Value) IsString() bool {
+	return v.kind == valueString
 }
 
 // IsObject will return true if value is an object.
-func (value Value) IsObject() bool {
-	return value.kind == valueObject
+func (v Value) IsObject() bool {
+	return v.kind == valueObject
 }
 
 // IsFunction will return true if value is a function.
-func (value Value) IsFunction() bool {
-	if value.kind != valueObject {
+func (v Value) IsFunction() bool {
+	if v.kind != valueObject {
 		return false
 	}
-	return value.value.(*_object).class == classFunction
+	return v.value.(*object).class == classFunctionName
 }
 
 // Class will return the class string of the value or the empty string if value is not an object.
@@ -203,65 +203,65 @@ func (value Value) IsFunction() bool {
 //	Boolean
 //	Date
 //	RegExp
-func (value Value) Class() string {
-	if value.kind != valueObject {
+func (v Value) Class() string {
+	if v.kind != valueObject {
 		return ""
 	}
-	return value.value.(*_object).class
+	return v.value.(*object).class
 }
 
-func (value Value) isArray() bool {
-	if value.kind != valueObject {
+func (v Value) isArray() bool { //nolint: unused
+	if v.kind != valueObject {
 		return false
 	}
-	return isArray(value.value.(*_object))
+	return isArray(v.value.(*object))
 }
 
-func (value Value) isStringObject() bool {
-	if value.kind != valueObject {
+func (v Value) isStringObject() bool { //nolint: unused
+	if v.kind != valueObject {
 		return false
 	}
-	return value.value.(*_object).class == classString
+	return v.value.(*object).class == classStringName
 }
 
-func (value Value) isBooleanObject() bool {
-	if value.kind != valueObject {
+func (v Value) isBooleanObject() bool { //nolint: unused
+	if v.kind != valueObject {
 		return false
 	}
-	return value.value.(*_object).class == classBoolean
+	return v.value.(*object).class == classBooleanName
 }
 
-func (value Value) isNumberObject() bool {
-	if value.kind != valueObject {
+func (v Value) isNumberObject() bool { //nolint: unused
+	if v.kind != valueObject {
 		return false
 	}
-	return value.value.(*_object).class == classNumber
+	return v.value.(*object).class == classNumberName
 }
 
-func (value Value) isDate() bool {
-	if value.kind != valueObject {
+func (v Value) isDate() bool { //nolint: unused
+	if v.kind != valueObject {
 		return false
 	}
-	return value.value.(*_object).class == classDate
+	return v.value.(*object).class == classDateName
 }
 
-func (value Value) isRegExp() bool {
-	if value.kind != valueObject {
+func (v Value) isRegExp() bool {
+	if v.kind != valueObject {
 		return false
 	}
-	return value.value.(*_object).class == classRegExp
+	return v.value.(*object).class == classRegExpName
 }
 
-func (value Value) isError() bool {
-	if value.kind != valueObject {
+func (v Value) isError() bool { //nolint: unused
+	if v.kind != valueObject {
 		return false
 	}
-	return value.value.(*_object).class == classError
+	return v.value.(*object).class == classErrorName
 }
 
 // ---
 
-func toValue_reflectValuePanic(value interface{}, kind reflect.Kind) {
+func reflectValuePanic(value interface{}, kind reflect.Kind) {
 	// FIXME?
 	switch kind {
 	case reflect.Struct:
@@ -308,15 +308,15 @@ func toValue(value interface{}) Value {
 	case string:
 		return Value{valueString, value}
 	// A rune is actually an int32, which is handled above
-	case *_object:
+	case *object:
 		return Value{valueObject, value}
 	case *Object:
 		return Value{valueObject, value.object}
 	case Object:
 		return Value{valueObject, value.object}
-	case _reference: // reference is an interface (already a pointer)
+	case referencer: // reference is an interface (already a pointer)
 		return Value{valueReference, value}
-	case _result:
+	case result:
 		return Value{valueResult, value}
 	case nil:
 		// TODO Ugh.
@@ -335,7 +335,7 @@ func toValue(value interface{}) Value {
 		}
 		switch value.Kind() {
 		case reflect.Bool:
-			return Value{valueBoolean, bool(value.Bool())}
+			return Value{valueBoolean, value.Bool()}
 		case reflect.Int:
 			return Value{valueNumber, int(value.Int())}
 		case reflect.Int8:
@@ -345,7 +345,7 @@ func toValue(value interface{}) Value {
 		case reflect.Int32:
 			return Value{valueNumber, int32(value.Int())}
 		case reflect.Int64:
-			return Value{valueNumber, int64(value.Int())}
+			return Value{valueNumber, value.Int()}
 		case reflect.Uint:
 			return Value{valueNumber, uint(value.Uint())}
 		case reflect.Uint8:
@@ -355,15 +355,15 @@ func toValue(value interface{}) Value {
 		case reflect.Uint32:
 			return Value{valueNumber, uint32(value.Uint())}
 		case reflect.Uint64:
-			return Value{valueNumber, uint64(value.Uint())}
+			return Value{valueNumber, value.Uint()}
 		case reflect.Float32:
 			return Value{valueNumber, float32(value.Float())}
 		case reflect.Float64:
-			return Value{valueNumber, float64(value.Float())}
+			return Value{valueNumber, value.Float()}
 		case reflect.String:
-			return Value{valueString, string(value.String())}
+			return Value{valueString, value.String()}
 		default:
-			toValue_reflectValuePanic(value.Interface(), value.Kind())
+			reflectValuePanic(value.Interface(), value.Kind())
 		}
 	default:
 		return toValue(reflect.ValueOf(value))
@@ -375,10 +375,10 @@ func toValue(value interface{}) Value {
 // String will return the value as a string.
 //
 // This method will make return the empty string if there is an error.
-func (value Value) String() string {
-	result := ""
-	catchPanic(func() {
-		result = value.string()
+func (v Value) String() string {
+	var result string
+	catchPanic(func() { //nolint: errcheck, gosec
+		result = v.string()
 	})
 	return result
 }
@@ -392,19 +392,19 @@ func (value Value) String() string {
 //	ToValue("Nothing happens").ToBoolean() => true
 //
 // If there is an error during the conversion process (like an uncaught exception), then the result will be false and an error.
-func (value Value) ToBoolean() (bool, error) {
+func (v Value) ToBoolean() (bool, error) {
 	result := false
 	err := catchPanic(func() {
-		result = value.bool()
+		result = v.bool()
 	})
 	return result, err
 }
 
-func (value Value) numberValue() Value {
-	if value.kind == valueNumber {
-		return value
+func (v Value) numberValue() Value {
+	if v.kind == valueNumber {
+		return v
 	}
-	return Value{valueNumber, value.float64()}
+	return Value{valueNumber, v.float64()}
 }
 
 // ToFloat will convert the value to a number (float64).
@@ -414,10 +414,10 @@ func (value Value) numberValue() Value {
 //	ToValue("11").ToFloat() => 11.
 //
 // If there is an error during the conversion process (like an uncaught exception), then the result will be 0 and an error.
-func (value Value) ToFloat() (float64, error) {
+func (v Value) ToFloat() (float64, error) {
 	result := float64(0)
 	err := catchPanic(func() {
-		result = value.float64()
+		result = v.float64()
 	})
 	return result, err
 }
@@ -429,10 +429,10 @@ func (value Value) ToFloat() (float64, error) {
 //	ToValue("11").ToInteger() => 11
 //
 // If there is an error during the conversion process (like an uncaught exception), then the result will be 0 and an error.
-func (value Value) ToInteger() (int64, error) {
+func (v Value) ToInteger() (int64, error) {
 	result := int64(0)
 	err := catchPanic(func() {
-		result = value.number().int64
+		result = v.number().int64
 	})
 	return result, err
 }
@@ -446,16 +446,16 @@ func (value Value) ToInteger() (int64, error) {
 //	ToValue('Nothing happens.').ToString() => "Nothing happens."
 //
 // If there is an error during the conversion process (like an uncaught exception), then the result will be the empty string ("") and an error.
-func (value Value) ToString() (string, error) {
+func (v Value) ToString() (string, error) {
 	result := ""
 	err := catchPanic(func() {
-		result = value.string()
+		result = v.string()
 	})
 	return result, err
 }
 
-func (value Value) _object() *_object {
-	if v, ok := value.value.(*_object); ok {
+func (v Value) object() *object {
+	if v, ok := v.value.(*object); ok {
 		return v
 	}
 	return nil
@@ -464,42 +464,35 @@ func (value Value) _object() *_object {
 // Object will return the object of the value, or nil if value is not an object.
 //
 // This method will not do any implicit conversion. For example, calling this method on a string primitive value will not return a String object.
-func (value Value) Object() *Object {
-	if object, ok := value.value.(*_object); ok {
-		return _newObject(object, value)
+func (v Value) Object() *Object {
+	if obj, ok := v.value.(*object); ok {
+		return &Object{
+			object: obj,
+			value:  v,
+		}
 	}
 	return nil
 }
 
-func (value Value) reference() _reference {
-	if value, ok := value.value.(_reference); ok {
-		return value
-	}
-	return nil
-}
-
-func (value Value) resolve() Value {
-	if value, ok := value.value.(_reference); ok {
-		return value.getValue()
-	}
+func (v Value) reference() referencer {
+	value, _ := v.value.(referencer)
 	return value
 }
 
+func (v Value) resolve() Value {
+	if value, ok := v.value.(referencer); ok {
+		return value.getValue()
+	}
+	return v
+}
+
 var (
-	__NaN__              float64 = math.NaN()
-	__PositiveInfinity__ float64 = math.Inf(+1)
-	__NegativeInfinity__ float64 = math.Inf(-1)
-	__PositiveZero__     float64 = 0
-	__NegativeZero__     float64 = math.Float64frombits(0 | (1 << 63))
+	nan              float64 = math.NaN()
+	positiveInfinity float64 = math.Inf(+1)
+	negativeInfinity float64 = math.Inf(-1)
+	positiveZero     float64 = 0
+	negativeZero     float64 = math.Float64frombits(0 | (1 << 63))
 )
-
-func positiveZero() float64 {
-	return __PositiveZero__
-}
-
-func negativeZero() float64 {
-	return __NegativeZero__
-}
 
 // NaNValue will return a value representing NaN.
 //
@@ -507,23 +500,23 @@ func negativeZero() float64 {
 //
 //	ToValue(math.NaN())
 func NaNValue() Value {
-	return Value{valueNumber, __NaN__}
+	return Value{valueNumber, nan}
 }
 
 func positiveInfinityValue() Value {
-	return Value{valueNumber, __PositiveInfinity__}
+	return Value{valueNumber, positiveInfinity}
 }
 
 func negativeInfinityValue() Value {
-	return Value{valueNumber, __NegativeInfinity__}
+	return Value{valueNumber, negativeInfinity}
 }
 
 func positiveZeroValue() Value {
-	return Value{valueNumber, __PositiveZero__}
+	return Value{valueNumber, positiveZero}
 }
 
 func negativeZeroValue() Value {
-	return Value{valueNumber, __NegativeZero__}
+	return Value{valueNumber, negativeZero}
 }
 
 // TrueValue will return a value representing true.
@@ -572,7 +565,7 @@ func sameValue(x Value, y Value) bool {
 	case valueBoolean:
 		return x.bool() == y.bool()
 	case valueObject:
-		return x._object() == y._object()
+		return x.object() == y.object()
 	default:
 		panic(hereBeDragons())
 	}
@@ -598,7 +591,7 @@ func strictEqualityComparison(x Value, y Value) bool {
 	case valueBoolean:
 		return x.bool() == y.bool()
 	case valueObject:
-		return x._object() == y._object()
+		return x.object() == y.object()
 	default:
 		panic(hereBeDragons())
 	}
@@ -620,52 +613,52 @@ func strictEqualityComparison(x Value, y Value) bool {
 //	string      -> string
 //	Array       -> []interface{}
 //	Object      -> map[string]interface{}
-func (self Value) Export() (interface{}, error) {
-	return self.export(), nil
+func (v Value) Export() (interface{}, error) {
+	return v.export(), nil
 }
 
-func (self Value) export() interface{} {
-	switch self.kind {
+func (v Value) export() interface{} {
+	switch v.kind {
 	case valueUndefined:
 		return nil
 	case valueNull:
 		return nil
 	case valueNumber, valueBoolean:
-		return self.value
+		return v.value
 	case valueString:
-		switch value := self.value.(type) {
+		switch value := v.value.(type) {
 		case string:
 			return value
 		case []uint16:
 			return string(utf16.Decode(value))
 		}
 	case valueObject:
-		object := self._object()
-		switch value := object.value.(type) {
-		case *_goStructObject:
+		obj := v.object()
+		switch value := obj.value.(type) {
+		case *goStructObject:
 			return value.value.Interface()
-		case *_goMapObject:
+		case *goMapObject:
 			return value.value.Interface()
-		case *_goArrayObject:
+		case *goArrayObject:
 			return value.value.Interface()
-		case *_goSliceObject:
+		case *goSliceObject:
 			return value.value.Interface()
 		}
-		if object.class == classArray {
+		if obj.class == classArrayName {
 			result := make([]interface{}, 0)
-			lengthValue := object.get(propertyLength)
+			lengthValue := obj.get(propertyLength)
 			length := lengthValue.value.(uint32)
 			kind := reflect.Invalid
 			keyKind := reflect.Invalid
 			elemKind := reflect.Invalid
 			state := 0
 			var t reflect.Type
-			for index := uint32(0); index < length; index += 1 {
+			for index := uint32(0); index < length; index++ {
 				name := strconv.FormatInt(int64(index), 10)
-				if !object.hasProperty(name) {
+				if !obj.hasProperty(name) {
 					continue
 				}
-				value := object.get(name).export()
+				value := obj.get(name).export()
 
 				t = reflect.TypeOf(value)
 
@@ -704,29 +697,29 @@ func (self Value) export() interface{} {
 				val.Index(i).Set(reflect.ValueOf(v))
 			}
 			return val.Interface()
-		} else {
-			result := make(map[string]interface{})
-			// TODO Should we export everything? Or just what is enumerable?
-			object.enumerate(false, func(name string) bool {
-				value := object.get(name)
-				if value.IsDefined() {
-					result[name] = value.export()
-				}
-				return true
-			})
-			return result
 		}
+
+		result := make(map[string]interface{})
+		// TODO Should we export everything? Or just what is enumerable?
+		obj.enumerate(false, func(name string) bool {
+			value := obj.get(name)
+			if value.IsDefined() {
+				result[name] = value.export()
+			}
+			return true
+		})
+		return result
 	}
 
-	if self.safe() {
-		return self
+	if v.safe() {
+		return v
 	}
 
 	return Value{}
 }
 
-func (self Value) evaluateBreakContinue(labels []string) _resultKind {
-	result := self.value.(_result)
+func (v Value) evaluateBreakContinue(labels []string) resultKind {
+	result := v.value.(result)
 	if result.kind == resultBreak || result.kind == resultContinue {
 		for _, label := range labels {
 			if label == result.target {
@@ -737,8 +730,8 @@ func (self Value) evaluateBreakContinue(labels []string) _resultKind {
 	return resultReturn
 }
 
-func (self Value) evaluateBreak(labels []string) _resultKind {
-	result := self.value.(_result)
+func (v Value) evaluateBreak(labels []string) resultKind {
+	result := v.value.(result)
 	if result.kind == resultBreak {
 		for _, label := range labels {
 			if label == result.target {
@@ -751,12 +744,12 @@ func (self Value) evaluateBreak(labels []string) _resultKind {
 
 // Make a best effort to return a reflect.Value corresponding to reflect.Kind, but
 // fallback to just returning the Go value we have handy.
-func (value Value) toReflectValue(typ reflect.Type) (reflect.Value, error) {
+func (v Value) toReflectValue(typ reflect.Type) (reflect.Value, error) {
 	kind := typ.Kind()
 	switch kind {
 	case reflect.Float32, reflect.Float64, reflect.Interface:
 	default:
-		switch value := value.value.(type) {
+		switch value := v.value.(type) {
 		case float32:
 			_, frac := math.Modf(float64(value))
 			if frac > 0 {
@@ -772,101 +765,90 @@ func (value Value) toReflectValue(typ reflect.Type) (reflect.Value, error) {
 
 	switch kind {
 	case reflect.Bool: // Bool
-		return reflect.ValueOf(value.bool()).Convert(typ), nil
+		return reflect.ValueOf(v.bool()).Convert(typ), nil
 	case reflect.Int: // Int
 		// We convert to float64 here because converting to int64 will not tell us
 		// if a value is outside the range of int64
-		tmp := toIntegerFloat(value)
-		if tmp < float_minInt || tmp > float_maxInt {
-			return reflect.Value{}, fmt.Errorf("RangeError: %f (%v) to int", tmp, value)
-		} else {
-			return reflect.ValueOf(int(tmp)).Convert(typ), nil
+		tmp := toIntegerFloat(v)
+		if tmp < floatMinInt || tmp > floatMaxInt {
+			return reflect.Value{}, fmt.Errorf("RangeError: %f (%v) to int", tmp, v)
 		}
+		return reflect.ValueOf(int(tmp)).Convert(typ), nil
 	case reflect.Int8: // Int8
-		tmp := value.number().int64
-		if tmp < int64_minInt8 || tmp > int64_maxInt8 {
-			return reflect.Value{}, fmt.Errorf("RangeError: %d (%v) to int8", tmp, value)
-		} else {
-			return reflect.ValueOf(int8(tmp)).Convert(typ), nil
+		tmp := v.number().int64
+		if tmp < int64MinInt8 || tmp > int64MaxInt8 {
+			return reflect.Value{}, fmt.Errorf("RangeError: %d (%v) to int8", tmp, v)
 		}
+		return reflect.ValueOf(int8(tmp)).Convert(typ), nil
 	case reflect.Int16: // Int16
-		tmp := value.number().int64
-		if tmp < int64_minInt16 || tmp > int64_maxInt16 {
-			return reflect.Value{}, fmt.Errorf("RangeError: %d (%v) to int16", tmp, value)
-		} else {
-			return reflect.ValueOf(int16(tmp)).Convert(typ), nil
+		tmp := v.number().int64
+		if tmp < int64MinInt16 || tmp > int64MaxInt16 {
+			return reflect.Value{}, fmt.Errorf("RangeError: %d (%v) to int16", tmp, v)
 		}
+		return reflect.ValueOf(int16(tmp)).Convert(typ), nil
 	case reflect.Int32: // Int32
-		tmp := value.number().int64
-		if tmp < int64_minInt32 || tmp > int64_maxInt32 {
-			return reflect.Value{}, fmt.Errorf("RangeError: %d (%v) to int32", tmp, value)
-		} else {
-			return reflect.ValueOf(int32(tmp)).Convert(typ), nil
+		tmp := v.number().int64
+		if tmp < int64MinInt32 || tmp > int64MaxInt32 {
+			return reflect.Value{}, fmt.Errorf("RangeError: %d (%v) to int32", tmp, v)
 		}
+		return reflect.ValueOf(int32(tmp)).Convert(typ), nil
 	case reflect.Int64: // Int64
 		// We convert to float64 here because converting to int64 will not tell us
 		// if a value is outside the range of int64
-		tmp := toIntegerFloat(value)
-		if tmp < float_minInt64 || tmp > float_maxInt64 {
-			return reflect.Value{}, fmt.Errorf("RangeError: %f (%v) to int", tmp, value)
-		} else {
-			return reflect.ValueOf(int64(tmp)).Convert(typ), nil
+		tmp := toIntegerFloat(v)
+		if tmp < floatMinInt64 || tmp > floatMaxInt64 {
+			return reflect.Value{}, fmt.Errorf("RangeError: %f (%v) to int", tmp, v)
 		}
+		return reflect.ValueOf(int64(tmp)).Convert(typ), nil
 	case reflect.Uint: // Uint
 		// We convert to float64 here because converting to int64 will not tell us
 		// if a value is outside the range of uint
-		tmp := toIntegerFloat(value)
-		if tmp < 0 || tmp > float_maxUint {
-			return reflect.Value{}, fmt.Errorf("RangeError: %f (%v) to uint", tmp, value)
-		} else {
-			return reflect.ValueOf(uint(tmp)).Convert(typ), nil
+		tmp := toIntegerFloat(v)
+		if tmp < 0 || tmp > floatMaxUint {
+			return reflect.Value{}, fmt.Errorf("RangeError: %f (%v) to uint", tmp, v)
 		}
+		return reflect.ValueOf(uint(tmp)).Convert(typ), nil
 	case reflect.Uint8: // Uint8
-		tmp := value.number().int64
-		if tmp < 0 || tmp > int64_maxUint8 {
-			return reflect.Value{}, fmt.Errorf("RangeError: %d (%v) to uint8", tmp, value)
-		} else {
-			return reflect.ValueOf(uint8(tmp)).Convert(typ), nil
+		tmp := v.number().int64
+		if tmp < 0 || tmp > int64MaxUint8 {
+			return reflect.Value{}, fmt.Errorf("RangeError: %d (%v) to uint8", tmp, v)
 		}
+		return reflect.ValueOf(uint8(tmp)).Convert(typ), nil
 	case reflect.Uint16: // Uint16
-		tmp := value.number().int64
-		if tmp < 0 || tmp > int64_maxUint16 {
-			return reflect.Value{}, fmt.Errorf("RangeError: %d (%v) to uint16", tmp, value)
-		} else {
-			return reflect.ValueOf(uint16(tmp)).Convert(typ), nil
+		tmp := v.number().int64
+		if tmp < 0 || tmp > int64MaxUint16 {
+			return reflect.Value{}, fmt.Errorf("RangeError: %d (%v) to uint16", tmp, v)
 		}
+		return reflect.ValueOf(uint16(tmp)).Convert(typ), nil
 	case reflect.Uint32: // Uint32
-		tmp := value.number().int64
-		if tmp < 0 || tmp > int64_maxUint32 {
-			return reflect.Value{}, fmt.Errorf("RangeError: %d (%v) to uint32", tmp, value)
-		} else {
-			return reflect.ValueOf(uint32(tmp)).Convert(typ), nil
+		tmp := v.number().int64
+		if tmp < 0 || tmp > int64MaxUint32 {
+			return reflect.Value{}, fmt.Errorf("RangeError: %d (%v) to uint32", tmp, v)
 		}
+		return reflect.ValueOf(uint32(tmp)).Convert(typ), nil
 	case reflect.Uint64: // Uint64
 		// We convert to float64 here because converting to int64 will not tell us
 		// if a value is outside the range of uint64
-		tmp := toIntegerFloat(value)
-		if tmp < 0 || tmp > float_maxUint64 {
-			return reflect.Value{}, fmt.Errorf("RangeError: %f (%v) to uint64", tmp, value)
-		} else {
-			return reflect.ValueOf(uint64(tmp)).Convert(typ), nil
+		tmp := toIntegerFloat(v)
+		if tmp < 0 || tmp > floatMaxUint64 {
+			return reflect.Value{}, fmt.Errorf("RangeError: %f (%v) to uint64", tmp, v)
 		}
+		return reflect.ValueOf(uint64(tmp)).Convert(typ), nil
 	case reflect.Float32: // Float32
-		tmp := value.float64()
+		tmp := v.float64()
 		tmp1 := tmp
 		if 0 > tmp1 {
 			tmp1 = -tmp1
 		}
 		if tmp1 > 0 && (tmp1 < math.SmallestNonzeroFloat32 || tmp1 > math.MaxFloat32) {
-			return reflect.Value{}, fmt.Errorf("RangeError: %f (%v) to float32", tmp, value)
-		} else {
-			return reflect.ValueOf(float32(tmp)).Convert(typ), nil
+			return reflect.Value{}, fmt.Errorf("RangeError: %f (%v) to float32", tmp, v)
 		}
+		return reflect.ValueOf(float32(tmp)).Convert(typ), nil
 	case reflect.Float64: // Float64
-		value := value.float64()
-		return reflect.ValueOf(float64(value)).Convert(typ), nil
+		value := v.float64()
+		return reflect.ValueOf(value).Convert(typ), nil
 	case reflect.String: // String
-		return reflect.ValueOf(value.string()).Convert(typ), nil
+		return reflect.ValueOf(v.string()).Convert(typ), nil
 	case reflect.Invalid: // Invalid
 	case reflect.Complex64: // FIXME? Complex64
 	case reflect.Complex128: // FIXME? Complex128
@@ -875,20 +857,20 @@ func (value Value) toReflectValue(typ reflect.Type) (reflect.Value, error) {
 	case reflect.Ptr: // FIXME? Ptr
 	case reflect.UnsafePointer: // FIXME? UnsafePointer
 	default:
-		switch value.kind {
+		switch v.kind {
 		case valueObject:
-			object := value._object()
-			switch vl := object.value.(type) {
-			case *_goStructObject: // Struct
+			obj := v.object()
+			switch vl := obj.value.(type) {
+			case *goStructObject: // Struct
 				return reflect.ValueOf(vl.value.Interface()), nil
-			case *_goMapObject: // Map
+			case *goMapObject: // Map
 				return reflect.ValueOf(vl.value.Interface()), nil
-			case *_goArrayObject: // Array
+			case *goArrayObject: // Array
 				return reflect.ValueOf(vl.value.Interface()), nil
-			case *_goSliceObject: // Slice
+			case *goSliceObject: // Slice
 				return reflect.ValueOf(vl.value.Interface()), nil
 			}
-			exported := reflect.ValueOf(value.export())
+			exported := reflect.ValueOf(v.export())
 			if exported.Type().ConvertibleTo(typ) {
 				return exported.Convert(typ), nil
 			}
@@ -896,12 +878,12 @@ func (value Value) toReflectValue(typ reflect.Type) (reflect.Value, error) {
 		case valueEmpty, valueResult, valueReference:
 			// These are invalid, and should panic
 		default:
-			return reflect.ValueOf(value.value), nil
+			return reflect.ValueOf(v.value), nil
 		}
 	}
 
 	// FIXME Should this end up as a TypeError?
-	panic(fmt.Errorf("invalid conversion of %v (%v) to reflect.Type: %v", value.kind, value, typ))
+	panic(fmt.Errorf("invalid conversion of %v (%v) to reflect.Type: %v", v.kind, v, typ))
 }
 
 func stringToReflectValue(value string, kind reflect.Kind) (reflect.Value, error) {
@@ -941,7 +923,7 @@ func stringToReflectValue(value string, kind reflect.Kind) (reflect.Value, error
 		if err != nil {
 			return reflect.Value{}, err
 		}
-		return reflect.ValueOf(int64(value)), nil
+		return reflect.ValueOf(value), nil
 	case reflect.Uint:
 		value, err := strconv.ParseUint(value, 0, 0)
 		if err != nil {
@@ -971,7 +953,7 @@ func stringToReflectValue(value string, kind reflect.Kind) (reflect.Value, error
 		if err != nil {
 			return reflect.Value{}, err
 		}
-		return reflect.ValueOf(uint64(value)), nil
+		return reflect.ValueOf(value), nil
 	case reflect.Float32:
 		value, err := strconv.ParseFloat(value, 32)
 		if err != nil {
@@ -983,7 +965,7 @@ func stringToReflectValue(value string, kind reflect.Kind) (reflect.Value, error
 		if err != nil {
 			return reflect.Value{}, err
 		}
-		return reflect.ValueOf(float64(value)), nil
+		return reflect.ValueOf(value), nil
 	case reflect.String:
 		return reflect.ValueOf(value), nil
 	}
@@ -992,16 +974,17 @@ func stringToReflectValue(value string, kind reflect.Kind) (reflect.Value, error
 	panic(fmt.Errorf("invalid conversion of %q to reflect.Kind: %v", value, kind))
 }
 
-func (self Value) MarshalJSON() ([]byte, error) {
-	switch self.kind {
+// MarshalJSON implements json.Marshaller.
+func (v Value) MarshalJSON() ([]byte, error) {
+	switch v.kind {
 	case valueUndefined, valueNull:
 		return []byte("null"), nil
 	case valueBoolean, valueNumber:
-		return json.Marshal(self.value)
+		return json.Marshal(v.value)
 	case valueString:
-		return json.Marshal(self.string())
+		return json.Marshal(v.string())
 	case valueObject:
-		return self.Object().MarshalJSON()
+		return v.Object().MarshalJSON()
 	}
-	return nil, fmt.Errorf("invalid type %v", self.kind)
+	return nil, fmt.Errorf("invalid type %v", v.kind)
 }

--- a/value_boolean.go
+++ b/value_boolean.go
@@ -7,37 +7,34 @@ import (
 	"unicode/utf16"
 )
 
-func (value Value) bool() bool {
-	if value.kind == valueBoolean {
-		return value.value.(bool)
+func (v Value) bool() bool {
+	if v.kind == valueBoolean {
+		return v.value.(bool)
 	}
-	if value.IsUndefined() {
+	if v.IsUndefined() || v.IsNull() {
 		return false
 	}
-	if value.IsNull() {
-		return false
-	}
-	switch value := value.value.(type) {
+	switch value := v.value.(type) {
 	case bool:
 		return value
 	case int, int8, int16, int32, int64:
-		return 0 != reflect.ValueOf(value).Int()
+		return reflect.ValueOf(value).Int() != 0
 	case uint, uint8, uint16, uint32, uint64:
-		return 0 != reflect.ValueOf(value).Uint()
+		return reflect.ValueOf(value).Uint() != 0
 	case float32:
-		return 0 != value
+		return value != 0
 	case float64:
 		if math.IsNaN(value) || value == 0 {
 			return false
 		}
 		return true
 	case string:
-		return 0 != len(value)
+		return len(value) != 0
 	case []uint16:
-		return 0 != len(utf16.Decode(value))
+		return len(utf16.Decode(value)) != 0
 	}
-	if value.IsObject() {
+	if v.IsObject() {
 		return true
 	}
-	panic(fmt.Errorf("toBoolean(%T)", value.value))
+	panic(fmt.Sprintf("unexpected boolean type %T", v.value))
 }

--- a/value_number.go
+++ b/value_number.go
@@ -1,6 +1,7 @@
 package otto
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"regexp"
@@ -11,24 +12,25 @@ import (
 var stringToNumberParseInteger = regexp.MustCompile(`^(?:0[xX])`)
 
 func parseNumber(value string) float64 {
-	value = strings.Trim(value, builtinString_trim_whitespace)
+	value = strings.Trim(value, builtinStringTrimWhitespace)
 
 	if value == "" {
 		return 0
 	}
 
 	parseFloat := false
-	if strings.IndexRune(value, '.') != -1 {
+	switch {
+	case strings.IndexRune(value, '.') != -1: //nolint: gosimple
 		parseFloat = true
-	} else if stringToNumberParseInteger.MatchString(value) {
+	case stringToNumberParseInteger.MatchString(value):
 		parseFloat = false
-	} else {
+	default:
 		parseFloat = true
 	}
 
 	if parseFloat {
 		number, err := strconv.ParseFloat(value, 64)
-		if err != nil && err.(*strconv.NumError).Err != strconv.ErrRange {
+		if err != nil && !errors.Is(err, strconv.ErrRange) {
 			return math.NaN()
 		}
 		return number
@@ -41,14 +43,14 @@ func parseNumber(value string) float64 {
 	return float64(number)
 }
 
-func (value Value) float64() float64 {
-	switch value.kind {
+func (v Value) float64() float64 {
+	switch v.kind {
 	case valueUndefined:
 		return math.NaN()
 	case valueNull:
 		return 0
 	}
-	switch value := value.value.(type) {
+	switch value := v.value.(type) {
 	case bool:
 		if value {
 			return 1
@@ -78,67 +80,65 @@ func (value Value) float64() float64 {
 		return value
 	case string:
 		return parseNumber(value)
-	case *_object:
+	case *object:
 		return value.DefaultValue(defaultValueHintNumber).float64()
 	}
-	panic(fmt.Errorf("toFloat(%T)", value.value))
+	panic(fmt.Errorf("toFloat(%T)", v.value))
 }
 
 const (
-	float_2_32 float64 = 4294967296.0
-	float_2_31 float64 = 2147483648.0
-	float_2_16 float64 = 65536.0
-	sqrt1_2    float64 = math.Sqrt2 / 2
+	sqrt1_2 float64 = math.Sqrt2 / 2
 )
 
 const (
 	maxUint32 = math.MaxUint32
 	maxInt    = int(^uint(0) >> 1)
 
-	// int64
-	int64_maxInt8   int64 = math.MaxInt8
-	int64_minInt8   int64 = math.MinInt8
-	int64_maxInt16  int64 = math.MaxInt16
-	int64_minInt16  int64 = math.MinInt16
-	int64_maxInt32  int64 = math.MaxInt32
-	int64_minInt32  int64 = math.MinInt32
-	int64_maxUint8  int64 = math.MaxUint8
-	int64_maxUint16 int64 = math.MaxUint16
-	int64_maxUint32 int64 = math.MaxUint32
+	// int64.
+	int64MaxInt8   int64 = math.MaxInt8
+	int64MinInt8   int64 = math.MinInt8
+	int64MaxInt16  int64 = math.MaxInt16
+	int64MinInt16  int64 = math.MinInt16
+	int64MaxInt32  int64 = math.MaxInt32
+	int64MinInt32  int64 = math.MinInt32
+	int64MaxUint8  int64 = math.MaxUint8
+	int64MaxUint16 int64 = math.MaxUint16
+	int64MaxUint32 int64 = math.MaxUint32
 
-	// float64
-	float_maxInt    float64 = float64(int(^uint(0) >> 1))
-	float_minInt    float64 = float64(int(-maxInt - 1))
-	float_maxUint   float64 = float64(uint(^uint(0)))
-	float_maxUint64 float64 = math.MaxUint64
-	float_maxInt64  float64 = math.MaxInt64
-	float_minInt64  float64 = math.MinInt64
+	// float64.
+	floatMaxInt    float64 = float64(int(^uint(0) >> 1))
+	floatMinInt    float64 = float64(-maxInt - 1)
+	floatMaxUint   float64 = float64(^uint(0))
+	floatMaxUint64 float64 = math.MaxUint64
+	floatMaxInt64  float64 = math.MaxInt64
+	floatMinInt64  float64 = math.MinInt64
 )
 
 func toIntegerFloat(value Value) float64 {
 	float := value.float64()
-	if math.IsInf(float, 0) {
-	} else if math.IsNaN(float) {
-		float = 0
-	} else if float > 0 {
-		float = math.Floor(float)
-	} else {
-		float = math.Ceil(float)
+	switch {
+	case math.IsInf(float, 0):
+		return float
+	case math.IsNaN(float):
+		return 0
+	case float > 0:
+		return math.Floor(float)
+	default:
+		return math.Ceil(float)
 	}
-	return float
 }
 
-type _numberKind int
+type numberKind int
 
 const (
-	numberInteger  _numberKind = iota // 3.0 => 3.0
-	numberFloat                       // 3.14159 => 3.0, 1+2**63 > 2**63-1
-	numberInfinity                    // Infinity => 2**63-1
-	numberNaN                         // NaN => 0
+	numberInteger  numberKind = iota // 3.0 => 3.0
+	numberFloat                      // 3.14159 => 3.0, 1+2**63 > 2**63-1
+	numberInfinity                   // Infinity => 2**63-1
+	numberNaN                        // NaN => 0
 )
 
 type _number struct {
-	kind    _numberKind
+	kind    numberKind
 	int64   int64
 	float64 float64
 }
@@ -146,56 +146,57 @@ type _number struct {
 // FIXME
 // http://www.goinggo.net/2013/08/gustavos-ieee-754-brain-teaser.html
 // http://bazaar.launchpad.net/~niemeyer/strepr/trunk/view/6/strepr.go#L160
-func (value Value) number() (number _number) {
-	switch value := value.value.(type) {
+func (v Value) number() _number {
+	var num _number
+	switch value := v.value.(type) {
 	case int8:
-		number.int64 = int64(value)
-		return
+		num.int64 = int64(value)
+		return num
 	case int16:
-		number.int64 = int64(value)
-		return
+		num.int64 = int64(value)
+		return num
 	case uint8:
-		number.int64 = int64(value)
-		return
+		num.int64 = int64(value)
+		return num
 	case uint16:
-		number.int64 = int64(value)
-		return
+		num.int64 = int64(value)
+		return num
 	case uint32:
-		number.int64 = int64(value)
-		return
+		num.int64 = int64(value)
+		return num
 	case int:
-		number.int64 = int64(value)
-		return
+		num.int64 = int64(value)
+		return num
 	case int64:
-		number.int64 = value
-		return
+		num.int64 = value
+		return num
 	}
 
-	float := value.float64()
+	float := v.float64()
 	if float == 0 {
-		return
+		return num
 	}
 
-	number.kind = numberFloat
-	number.float64 = float
+	num.kind = numberFloat
+	num.float64 = float
 
 	if math.IsNaN(float) {
-		number.kind = numberNaN
-		return
+		num.kind = numberNaN
+		return num
 	}
 
 	if math.IsInf(float, 0) {
-		number.kind = numberInfinity
+		num.kind = numberInfinity
 	}
 
-	if float >= float_maxInt64 {
-		number.int64 = math.MaxInt64
-		return
+	if float >= floatMaxInt64 {
+		num.int64 = math.MaxInt64
+		return num
 	}
 
-	if float <= float_minInt64 {
-		number.int64 = math.MinInt64
-		return
+	if float <= floatMinInt64 {
+		num.int64 = math.MinInt64
+		return num
 	}
 
 	var integer float64
@@ -206,13 +207,13 @@ func (value Value) number() (number _number) {
 	}
 
 	if float == integer {
-		number.kind = numberInteger
+		num.kind = numberInteger
 	}
-	number.int64 = int64(float)
-	return
+	num.int64 = int64(float)
+	return num
 }
 
-// ECMA 262: 9.5
+// ECMA 262: 9.5.
 func toInt32(value Value) int32 {
 	switch value := value.value.(type) {
 	case int8:
@@ -275,47 +276,47 @@ func toUint16(value Value) uint16 {
 	return uint16(int64(floatValue))
 }
 
-// toIntSign returns sign of a number converted to -1, 0 ,1
+// toIntSign returns sign of a number converted to -1, 0 ,1.
 func toIntSign(value Value) int {
 	switch value := value.value.(type) {
 	case int8:
-		if int8(value) > 0 {
+		if value > 0 {
 			return 1
-		} else if int8(value) < 0 {
+		} else if value < 0 {
 			return -1
 		}
 
 		return 0
 	case int16:
-		if int16(value) > 0 {
+		if value > 0 {
 			return 1
-		} else if int16(value) < 0 {
+		} else if value < 0 {
 			return -1
 		}
 
 		return 0
 	case int32:
-		if int32(value) > 0 {
+		if value > 0 {
 			return 1
-		} else if int32(value) < 0 {
+		} else if value < 0 {
 			return -1
 		}
 
 		return 0
 	case uint8:
-		if uint8(value) > 0 {
+		if value > 0 {
 			return 1
 		}
 
 		return 0
 	case uint16:
-		if uint16(value) > 0 {
+		if value > 0 {
 			return 1
 		}
 
 		return 0
 	case uint32:
-		if uint32(value) > 0 {
+		if value > 0 {
 			return 1
 		}
 

--- a/value_primitive.go
+++ b/value_primitive.go
@@ -1,19 +1,20 @@
 package otto
 
 func toNumberPrimitive(value Value) Value {
-	return _toPrimitive(value, defaultValueHintNumber)
+	return toPrimitive(value, defaultValueHintNumber)
 }
 
-func toPrimitive(value Value) Value {
-	return _toPrimitive(value, defaultValueNoHint)
+func toPrimitiveValue(value Value) Value {
+	return toPrimitive(value, defaultValueNoHint)
 }
 
-func _toPrimitive(value Value, hint _defaultValueHint) Value {
+func toPrimitive(value Value, hint defaultValueHint) Value {
 	switch value.kind {
 	case valueNull, valueUndefined, valueNumber, valueString, valueBoolean:
 		return value
 	case valueObject:
-		return value._object().DefaultValue(hint)
+		return value.object().DefaultValue(hint)
+	default:
+		panic(hereBeDragons(value.kind, value))
 	}
-	panic(hereBeDragons(value.kind, value))
 }

--- a/value_string.go
+++ b/value_string.go
@@ -31,12 +31,15 @@ func floatToString(value float64, bitsize int) string {
 
 func numberToStringRadix(value Value, radix int) string {
 	float := value.float64()
-	if math.IsNaN(float) {
+	switch {
+	case math.IsNaN(float):
 		return "NaN"
-	} else if math.IsInf(float, 1) {
+	case math.IsInf(float, 1):
 		return "Infinity"
-	} else if math.IsInf(float, -1) {
+	case math.IsInf(float, -1):
 		return "-Infinity"
+	case float == 0:
+		return "0"
 	}
 	// FIXME This is very broken
 	// Need to do proper radix conversion for floats, ...
@@ -44,22 +47,22 @@ func numberToStringRadix(value Value, radix int) string {
 	return strconv.FormatInt(int64(float), radix)
 }
 
-func (value Value) string() string {
-	if value.kind == valueString {
-		switch value := value.value.(type) {
+func (v Value) string() string {
+	if v.kind == valueString {
+		switch value := v.value.(type) {
 		case string:
 			return value
 		case []uint16:
 			return string(utf16.Decode(value))
 		}
 	}
-	if value.IsUndefined() {
+	if v.IsUndefined() {
 		return "undefined"
 	}
-	if value.IsNull() {
+	if v.IsNull() {
 		return "null"
 	}
-	switch value := value.value.(type) {
+	switch value := v.value.(type) {
 	case bool:
 		return strconv.FormatBool(value)
 	case int:
@@ -96,8 +99,8 @@ func (value Value) string() string {
 		return string(utf16.Decode(value))
 	case string:
 		return value
-	case *_object:
+	case *object:
 		return value.DefaultValue(defaultValueHintString).string()
 	}
-	panic(fmt.Errorf("%v.string( %T)", value.value, value.value))
+	panic(fmt.Errorf("%v.string( %T)", v.value, v.value))
 }

--- a/value_test.go
+++ b/value_test.go
@@ -23,11 +23,6 @@ func TestValue(t *testing.T) {
 func TestObject(t *testing.T) {
 	tt(t, func() {
 		is(emptyValue.isEmpty(), true)
-		//is(newObject().Value(), "[object]")
-		//is(newBooleanObject(false).Value(), "false")
-		//is(newFunctionObject(nil).Value(), "[function]")
-		//is(newNumberObject(1).Value(), "1")
-		//is(newStringObject("Hello, World.").Value(), "Hello, World.")
 	})
 }
 
@@ -95,7 +90,7 @@ func TestToBoolean(t *testing.T) {
 		is("xyzzy", true)
 		is(1, true)
 		is(0, false)
-		//is(toValue(newObject()), true)
+
 		is(UndefinedValue(), false)
 		is(NullValue(), false)
 		is([]uint16{}, false)
@@ -115,7 +110,6 @@ func TestToFloat(t *testing.T) {
 			is(1, 1)
 			is(0, 0)
 			is(NullValue(), 0)
-			//is(newObjectValue(), math.NaN())
 		}
 		is(math.IsNaN(UndefinedValue().float64()), true)
 	})
@@ -268,14 +262,14 @@ func TestExport(t *testing.T) {
 			3.1459,
 			[]interface{}{true, false, 0, 3.1459, "abc"},
 			map[string]interface{}{
-				classBoolean: true,
-				classNumber:  3.1459,
-				classString:  "abc",
-				classArray:   []interface{}{false, 0, "", nil},
-				classObject: map[string]interface{}{
-					classBoolean: false,
-					classNumber:  0,
-					classString:  "def",
+				classBooleanName: true,
+				classNumberName:  3.1459,
+				classStringName:  "abc",
+				classArrayName:   []interface{}{false, 0, "", nil},
+				classObjectName: map[string]interface{}{
+					classBooleanName: false,
+					classNumberName:  0,
+					classStringName:  "def",
 				},
 			},
 		}


### PR DESCRIPTION
Enable more linters, address the issues and do a major naming refactor to use golang lower camelCase identifiers for types, functions, methods and variable names.