### PR TITLE
Add Console type

### DIFF
--- a/console.go
+++ b/console.go
@@ -14,6 +14,11 @@ type Console interface {
 	Info(call FunctionCall) Value
 	Warn(call FunctionCall) Value
 	Error(call FunctionCall) Value
+
+	Dir(call FunctionCall) Value
+	Time(call FunctionCall) Value
+	TimeEnd(call FunctionCall) Value
+	Assert(call FunctionCall) Value
 }
 
 func formatForConsole(argumentList []Value) string {

--- a/console.go
+++ b/console.go
@@ -6,6 +6,16 @@ import (
 	"strings"
 )
 
+// Console is implemented by type which can be used to process console output.
+type Console interface {
+	Log(v ...interface{})
+	Trace(v ...interface{})
+	Debug(v ...interface{})
+	Info(v ...interface{})
+	Warn(v ...interface{})
+	Error(v ...interface{})
+}
+
 func formatForConsole(argumentList []Value) string {
 	output := []string{}
 	for _, argument := range argumentList {

--- a/console.go
+++ b/console.go
@@ -81,6 +81,29 @@ func builtinConsoleError(call FunctionCall) Value {
 	return Value{}
 }
 
+type noopConsole struct {
+}
+
+func (n *noopConsole) Log(_ FunctionCall) Value { return Value{} }
+
+func (n *noopConsole) Trace(_ FunctionCall) Value { return Value{} }
+
+func (n *noopConsole) Debug(_ FunctionCall) Value { return Value{} }
+
+func (n *noopConsole) Info(_ FunctionCall) Value { return Value{} }
+
+func (n *noopConsole) Warn(_ FunctionCall) Value { return Value{} }
+
+func (n *noopConsole) Error(_ FunctionCall) Value { return Value{} }
+
+func (n *noopConsole) Dir(_ FunctionCall) Value { return Value{} }
+
+func (n *noopConsole) Time(_ FunctionCall) Value { return Value{} }
+
+func (n *noopConsole) TimeEnd(_ FunctionCall) Value { return Value{} }
+
+func (n *noopConsole) Assert(_ FunctionCall) Value { return Value{} }
+
 // Nothing happens.
 func builtinConsoleDir(call FunctionCall) Value {
 	return Value{}

--- a/console.go
+++ b/console.go
@@ -6,14 +6,14 @@ import (
 	"strings"
 )
 
-// Console is implemented by type which can be used to process console output.
+// Console describes the well known console object present in browsers and other runtimes.
 type Console interface {
-	Log(v ...interface{})
-	Trace(v ...interface{})
-	Debug(v ...interface{})
-	Info(v ...interface{})
-	Warn(v ...interface{})
-	Error(v ...interface{})
+	Log(call FunctionCall) Value
+	Trace(call FunctionCall) Value
+	Debug(call FunctionCall) Value
+	Info(call FunctionCall) Value
+	Warn(call FunctionCall) Value
+	Error(call FunctionCall) Value
 }
 
 func formatForConsole(argumentList []Value) string {

--- a/console.go
+++ b/console.go
@@ -29,6 +29,48 @@ func formatForConsole(argumentList []Value) string {
 	return strings.Join(output, " ")
 }
 
+type builtinConsole struct{}
+
+func (b *builtinConsole) Log(call FunctionCall) Value {
+	return builtinConsoleLog(call)
+}
+
+func (b *builtinConsole) Trace(call FunctionCall) Value {
+	return builtinConsoleLog(call)
+}
+
+func (b *builtinConsole) Debug(call FunctionCall) Value {
+	return builtinConsoleLog(call)
+}
+
+func (b *builtinConsole) Info(call FunctionCall) Value {
+	return builtinConsoleLog(call)
+}
+
+func (b *builtinConsole) Warn(call FunctionCall) Value {
+	return builtinConsoleLog(call)
+}
+
+func (b *builtinConsole) Error(call FunctionCall) Value {
+	return builtinConsoleLog(call)
+}
+
+func (b *builtinConsole) Dir(call FunctionCall) Value {
+	return builtinConsoleDir(call)
+}
+
+func (b *builtinConsole) Time(call FunctionCall) Value {
+	return builtinConsoleTime(call)
+}
+
+func (b *builtinConsole) TimeEnd(call FunctionCall) Value {
+	return builtinConsoleTimeEnd(call)
+}
+
+func (b *builtinConsole) Assert(call FunctionCall) Value {
+	return builtinConsoleAssert(call)
+}
+
 func builtinConsoleLog(call FunctionCall) Value {
 	fmt.Fprintln(os.Stdout, formatForConsole(call.ArgumentList))
 	return Value{}

--- a/console_test.go
+++ b/console_test.go
@@ -1,0 +1,27 @@
+package otto
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test(t *testing.T) {
+
+}
+
+// ExampleWithNoopConsole shows how to use WithNoopConsole while ensuring that the used no-op console
+// does not actually print anything to stdout.
+func ExampleWithNoopConsole() { //nolint: govet
+	vm := New(WithNoopConsole())
+
+	src := `console.log("Hello, World.");
+console.dir(42);
+console.trace(1, "abc", [1, 2, 3]);`
+	value, err := vm.Run(src)
+	fmt.Println(value)
+	fmt.Println(err)
+
+	// Output:
+	// undefined
+	// <nil>
+}

--- a/inline_console.go
+++ b/inline_console.go
@@ -1,0 +1,396 @@
+package otto
+
+// newConsoleManual is a manually implemented "fork" of newConsole which is generated code.
+func (rt *runtime) newConsoleManual() *object {
+	return &object{
+		runtime:     rt,
+		class:       classObjectName,
+		objectClass: classObject,
+		prototype:   rt.global.ObjectPrototype,
+		extensible:  true,
+		property: map[string]property{
+			"log": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "log",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "log",
+							call: builtinConsoleLog,
+						},
+					},
+				},
+			},
+			"debug": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "debug",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "debug",
+							call: builtinConsoleLog,
+						},
+					},
+				},
+			},
+			"info": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "info",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "info",
+							call: builtinConsoleLog,
+						},
+					},
+				},
+			},
+			"error": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "error",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "error",
+							call: builtinConsoleError,
+						},
+					},
+				},
+			},
+			"warn": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "warn",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "warn",
+							call: builtinConsoleError,
+						},
+					},
+				},
+			},
+			"dir": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "dir",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "dir",
+							call: builtinConsoleDir,
+						},
+					},
+				},
+			},
+			"time": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "time",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "time",
+							call: builtinConsoleTime,
+						},
+					},
+				},
+			},
+			"timeEnd": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "timeEnd",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "timeEnd",
+							call: builtinConsoleTimeEnd,
+						},
+					},
+				},
+			},
+			"trace": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "trace",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "trace",
+							call: builtinConsoleTrace,
+						},
+					},
+				},
+			},
+			"assert": {
+				mode: 0o101,
+				value: Value{
+					kind: valueObject,
+					value: &object{
+						runtime:     rt,
+						class:       classFunctionName,
+						objectClass: classObject,
+						prototype:   rt.global.FunctionPrototype,
+						extensible:  true,
+						property: map[string]property{
+							propertyLength: {
+								mode: 0,
+								value: Value{
+									kind:  valueNumber,
+									value: 0,
+								},
+							},
+							propertyName: {
+								mode: 0,
+								value: Value{
+									kind:  valueString,
+									value: "assert",
+								},
+							},
+						},
+						propertyOrder: []string{
+							propertyLength,
+							propertyName,
+						},
+						value: nativeFunctionObject{
+							name: "assert",
+							call: builtinConsoleAssert,
+						},
+					},
+				},
+			},
+		},
+		propertyOrder: []string{
+			"log",
+			"debug",
+			"info",
+			"error",
+			"warn",
+			"dir",
+			"time",
+			"timeEnd",
+			"trace",
+			"assert",
+		},
+	}
+}

--- a/inline_console.go
+++ b/inline_console.go
@@ -1,7 +1,7 @@
 package otto
 
 // newConsoleManual is a manually implemented "fork" of newConsole which is generated code.
-func (rt *runtime) newConsoleManual() *object {
+func (rt *runtime) newConsoleManual(console Console) *object {
 	return &object{
 		runtime:     rt,
 		class:       classObjectName,
@@ -41,7 +41,7 @@ func (rt *runtime) newConsoleManual() *object {
 						},
 						value: nativeFunctionObject{
 							name: "log",
-							call: builtinConsoleLog,
+							call: console.Log,
 						},
 					},
 				},
@@ -78,7 +78,7 @@ func (rt *runtime) newConsoleManual() *object {
 						},
 						value: nativeFunctionObject{
 							name: "debug",
-							call: builtinConsoleLog,
+							call: console.Debug,
 						},
 					},
 				},
@@ -115,7 +115,7 @@ func (rt *runtime) newConsoleManual() *object {
 						},
 						value: nativeFunctionObject{
 							name: "info",
-							call: builtinConsoleLog,
+							call: console.Info,
 						},
 					},
 				},
@@ -152,7 +152,7 @@ func (rt *runtime) newConsoleManual() *object {
 						},
 						value: nativeFunctionObject{
 							name: "error",
-							call: builtinConsoleError,
+							call: console.Error,
 						},
 					},
 				},
@@ -189,7 +189,7 @@ func (rt *runtime) newConsoleManual() *object {
 						},
 						value: nativeFunctionObject{
 							name: "warn",
-							call: builtinConsoleError,
+							call: console.Warn,
 						},
 					},
 				},
@@ -226,7 +226,7 @@ func (rt *runtime) newConsoleManual() *object {
 						},
 						value: nativeFunctionObject{
 							name: "dir",
-							call: builtinConsoleDir,
+							call: console.Dir,
 						},
 					},
 				},
@@ -263,7 +263,7 @@ func (rt *runtime) newConsoleManual() *object {
 						},
 						value: nativeFunctionObject{
 							name: "time",
-							call: builtinConsoleTime,
+							call: console.Time,
 						},
 					},
 				},
@@ -300,7 +300,7 @@ func (rt *runtime) newConsoleManual() *object {
 						},
 						value: nativeFunctionObject{
 							name: "timeEnd",
-							call: builtinConsoleTimeEnd,
+							call: console.TimeEnd,
 						},
 					},
 				},
@@ -337,7 +337,7 @@ func (rt *runtime) newConsoleManual() *object {
 						},
 						value: nativeFunctionObject{
 							name: "trace",
-							call: builtinConsoleTrace,
+							call: console.Trace,
 						},
 					},
 				},
@@ -374,7 +374,7 @@ func (rt *runtime) newConsoleManual() *object {
 						},
 						value: nativeFunctionObject{
 							name: "assert",
-							call: builtinConsoleAssert,
+							call: console.Assert,
 						},
 					},
 				},

--- a/options.go
+++ b/options.go
@@ -1,0 +1,11 @@
+package otto
+
+// Option is an Otto option.
+type Option func(*Otto)
+
+// WithConsole replaces the builtin Console used with the given object.
+func WithConsole(console Console) func(o *Otto) {
+	return func(o *Otto) {
+		o.console = console
+	}
+}

--- a/options.go
+++ b/options.go
@@ -9,3 +9,9 @@ func WithConsole(console Console) func(o *Otto) {
 		o.console = console
 	}
 }
+
+// WithNoopConsole replaces the builtin Console with a no-op implementation.
+func WithNoopConsole() func(o *Otto) {
+	noop := &noopConsole{}
+	return WithConsole(noop)
+}

--- a/otto.go
+++ b/otto.go
@@ -235,16 +235,29 @@ type Otto struct {
 	// See "Halting Problem" for more information.
 	Interrupt chan func()
 	runtime   *runtime
+
+	console Console
 }
 
 // New will allocate a new JavaScript runtime.
-func New() *Otto {
+func New(options ...Option) *Otto {
 	o := &Otto{
 		runtime: newContext(),
 	}
 	o.runtime.otto = o
 	o.runtime.traceLimit = 10
-	if err := o.Set("console", o.runtime.newConsole()); err != nil {
+
+	for i := 0; i < len(options); i++ {
+		options[i](o)
+	}
+
+	if o.console == nil {
+		o.console = &builtinConsole{}
+	}
+
+	// o.console = o.runtime.newConsole() // FIXME: We should try to use the generated code
+
+	if err := o.Set("console", o.runtime.newConsoleManual(o.console)); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
This PR is a draft inspired by the existing PR #445. My goal is to contribute allow users of otto to pass in their own implementation of a new `Console` interface for two reasons:

- Redirect logging to any implementation they want.
- Prevent any output to stdout which is what otto currently does

For now this is a draft because I need feedback by more experienced maintainers. I will update the PR description once the option of merging is given. I am happy with merging only some refactorings or submitting them step-wise in smaller PRs if that is of any help.

Closes: https://github.com/FabianTe/otto/issues/1