### PR TITLE
Add BadStatement case to walk.go to avoid panic

### DIFF
--- a/ast/walk.go
+++ b/ast/walk.go
@@ -38,6 +38,7 @@ func Walk(v Visitor, n Node) {
 			Walk(v, n.Right)
 		}
 	case *BadExpression:
+	case *BadStatement:
 	case *BinaryExpression:
 		if n != nil {
 			Walk(v, n.Left)

--- a/ast/walk_test.go
+++ b/ast/walk_test.go
@@ -136,3 +136,22 @@ func Test_issue261(t *testing.T) {
 		})
 	}
 }
+
+func TestBadStatement(t *testing.T) {
+	source := `
+	var abc;
+	break; do {
+	} while(true);
+`
+	program, err := parser.ParseFile(nil, "", source, 0)
+	require.ErrorContains(t, err, "Illegal break statement")
+
+	w := &walker{
+		source: source,
+		seen:   make(map[ast.Node]struct{}),
+	}
+
+	require.NotPanics(t, func() {
+		ast.Walk(w, program)
+	})
+}


### PR DESCRIPTION
This PR is to address what I think might have been an oversight in the ast package walk.go file.

When the switch runs across a BadStatement node, this causes it to default (and panic).

I have added an empty case for this node type similar to BadExpression to get around this as well as a unit test.