### PR TITLE
ci: fix golangci-lint errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,7 +48,16 @@ linters:
     - exhaustruct
     - nosnakecase
     - dupword
+    - structcheck
+    - deadcode
+    - golint
+    - varcheck
+    - ifshort
+    - interfacer
+    - maligned
 
 issues:
   exclude-use-default: false
   max-same-issues: 0
+  exclude:
+  - Deferring unsafe method "Close" on type "io\.ReadCloser"

--- a/tools/gen-jscore/main.go
+++ b/tools/gen-jscore/main.go
@@ -29,7 +29,7 @@ type jsType struct {
 	Class           string     `yaml:"class"`
 	Value           string     `yaml:"value"`
 	Properties      []property `yaml:"properties"`
-	Prototype       *prototype
+	Prototype       *prototype `yaml:"prototype"`
 }
 
 // BlankConstructor is a default fallback returning false for templates.

--- a/value_number.go
+++ b/value_number.go
@@ -18,9 +18,9 @@ func parseNumber(value string) float64 {
 		return 0
 	}
 
-	parseFloat := false
+	var parseFloat bool
 	switch {
-	case strings.IndexRune(value, '.') != -1: //nolint: gosimple
+	case strings.ContainsRune(value, '.'):
 		parseFloat = true
 	case stringToNumberParseInteger.MatchString(value):
 		parseFloat = false


### PR DESCRIPTION
Fix golangci-lint errors triggered by new version.

Disable deprecated linters.