### PR TITLE
ci: fix lint failures

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         go: [1.19, 1.18]
-        golangcli: [v1.50.1]
+        golangcli: [v1.53.3]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -32,7 +32,7 @@ jobs:
       - name: Go Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: ${{ matrix.golangci }}
+          version: ${{ matrix.golangcli }}
           args: "--out-${NO_FUTURE}format colored-line-number"
           skip-pkg-cache: true
           skip-build-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,6 +55,8 @@ linters:
     - ifshort
     - interfacer
     - maligned
+    # Just causes noise
+    - depguard
 
 issues:
   exclude-use-default: false

--- a/builtin_date.go
+++ b/builtin_date.go
@@ -2,7 +2,7 @@ package otto
 
 import (
 	"math"
-	Time "time"
+	"time"
 )
 
 // Date
@@ -10,7 +10,7 @@ import (
 const (
 	// TODO Be like V8?
 	// builtinDateDateTimeLayout = "Mon Jan 2 2006 15:04:05 GMT-0700 (MST)".
-	builtinDateDateTimeLayout = Time.RFC1123 // "Mon, 02 Jan 2006 15:04:05 MST"
+	builtinDateDateTimeLayout = time.RFC1123 // "Mon, 02 Jan 2006 15:04:05 MST"
 	builtinDateDateLayout     = "Mon, 02 Jan 2006"
 	builtinDateTimeLayout     = "15:04:05 MST"
 )
@@ -18,16 +18,16 @@ const (
 // utcTimeZone is the time zone used for UTC calculations.
 // It is GMT not UTC as that's what Javascript does because toUTCString is
 // actually an alias to toGMTString.
-var utcTimeZone = Time.FixedZone("GMT", 0)
+var utcTimeZone = time.FixedZone("GMT", 0)
 
 func builtinDate(call FunctionCall) Value {
 	date := &dateObject{}
-	date.Set(newDateTime([]Value{}, Time.Local))
+	date.Set(newDateTime([]Value{}, time.Local)) //nolint: gosmopolitan
 	return stringValue(date.Time().Format(builtinDateDateTimeLayout))
 }
 
 func builtinNewDate(obj *object, argumentList []Value) Value {
-	return objectValue(obj.runtime.newDate(newDateTime(argumentList, Time.Local)))
+	return objectValue(obj.runtime.newDate(newDateTime(argumentList, time.Local))) //nolint: gosmopolitan
 }
 
 func builtinDateToString(call FunctionCall) Value {
@@ -35,7 +35,7 @@ func builtinDateToString(call FunctionCall) Value {
 	if date.isNaN {
 		return stringValue("Invalid Date")
 	}
-	return stringValue(date.Time().Local().Format(builtinDateDateTimeLayout))
+	return stringValue(date.Time().Local().Format(builtinDateDateTimeLayout)) //nolint: gosmopolitan
 }
 
 func builtinDateToDateString(call FunctionCall) Value {
@@ -43,7 +43,7 @@ func builtinDateToDateString(call FunctionCall) Value {
 	if date.isNaN {
 		return stringValue("Invalid Date")
 	}
-	return stringValue(date.Time().Local().Format(builtinDateDateLayout))
+	return stringValue(date.Time().Local().Format(builtinDateDateLayout)) //nolint: gosmopolitan
 }
 
 func builtinDateToTimeString(call FunctionCall) Value {
@@ -51,7 +51,7 @@ func builtinDateToTimeString(call FunctionCall) Value {
 	if date.isNaN {
 		return stringValue("Invalid Date")
 	}
-	return stringValue(date.Time().Local().Format(builtinDateTimeLayout))
+	return stringValue(date.Time().Local().Format(builtinDateTimeLayout)) //nolint: gosmopolitan
 }
 
 func builtinDateToUTCString(call FunctionCall) Value {
@@ -142,7 +142,7 @@ func builtinDateBeforeSet(call FunctionCall, argumentLimit int, timeLocal bool) 
 	}
 	baseTime := date.Time()
 	if timeLocal {
-		baseTime = baseTime.Local()
+		baseTime = baseTime.Local() //nolint: gosmopolitan
 	}
 	ecmaTime := newEcmaTime(baseTime)
 	return obj, &date, &ecmaTime, valueList
@@ -154,7 +154,7 @@ func builtinDateParse(call FunctionCall) Value {
 }
 
 func builtinDateUTC(call FunctionCall) Value {
-	return float64Value(newDateTime(call.ArgumentList, Time.UTC))
+	return float64Value(newDateTime(call.ArgumentList, time.UTC))
 }
 
 func builtinDateNow(call FunctionCall) Value {
@@ -168,7 +168,7 @@ func builtinDateToLocaleString(call FunctionCall) Value {
 	if date.isNaN {
 		return stringValue("Invalid Date")
 	}
-	return stringValue(date.Time().Local().Format("2006-01-02 15:04:05"))
+	return stringValue(date.Time().Local().Format("2006-01-02 15:04:05")) //nolint: gosmopolitan
 }
 
 // This is a placeholder.
@@ -177,7 +177,7 @@ func builtinDateToLocaleDateString(call FunctionCall) Value {
 	if date.isNaN {
 		return stringValue("Invalid Date")
 	}
-	return stringValue(date.Time().Local().Format("2006-01-02"))
+	return stringValue(date.Time().Local().Format("2006-01-02")) //nolint: gosmopolitan
 }
 
 // This is a placeholder.
@@ -186,7 +186,7 @@ func builtinDateToLocaleTimeString(call FunctionCall) Value {
 	if date.isNaN {
 		return stringValue("Invalid Date")
 	}
-	return stringValue(date.Time().Local().Format("15:04:05"))
+	return stringValue(date.Time().Local().Format("15:04:05")) //nolint: gosmopolitan
 }
 
 func builtinDateValueOf(call FunctionCall) Value {
@@ -204,7 +204,7 @@ func builtinDateGetYear(call FunctionCall) Value {
 	if date.isNaN {
 		return NaNValue()
 	}
-	return intValue(date.Time().Local().Year() - 1900)
+	return intValue(date.Time().Local().Year() - 1900) //nolint: gosmopolitan
 }
 
 func builtinDateGetFullYear(call FunctionCall) Value {
@@ -214,7 +214,7 @@ func builtinDateGetFullYear(call FunctionCall) Value {
 	if date.isNaN {
 		return NaNValue()
 	}
-	return intValue(date.Time().Local().Year())
+	return intValue(date.Time().Local().Year()) //nolint: gosmopolitan
 }
 
 func builtinDateGetUTCFullYear(call FunctionCall) Value {
@@ -230,7 +230,7 @@ func builtinDateGetMonth(call FunctionCall) Value {
 	if date.isNaN {
 		return NaNValue()
 	}
-	return intValue(dateFromGoMonth(date.Time().Local().Month()))
+	return intValue(dateFromGoMonth(date.Time().Local().Month())) //nolint: gosmopolitan
 }
 
 func builtinDateGetUTCMonth(call FunctionCall) Value {
@@ -246,7 +246,7 @@ func builtinDateGetDate(call FunctionCall) Value {
 	if date.isNaN {
 		return NaNValue()
 	}
-	return intValue(date.Time().Local().Day())
+	return intValue(date.Time().Local().Day()) //nolint: gosmopolitan
 }
 
 func builtinDateGetUTCDate(call FunctionCall) Value {
@@ -263,7 +263,7 @@ func builtinDateGetDay(call FunctionCall) Value {
 	if date.isNaN {
 		return NaNValue()
 	}
-	return intValue(dateFromGoDay(date.Time().Local().Weekday()))
+	return intValue(dateFromGoDay(date.Time().Local().Weekday())) //nolint: gosmopolitan
 }
 
 func builtinDateGetUTCDay(call FunctionCall) Value {
@@ -279,7 +279,7 @@ func builtinDateGetHours(call FunctionCall) Value {
 	if date.isNaN {
 		return NaNValue()
 	}
-	return intValue(date.Time().Local().Hour())
+	return intValue(date.Time().Local().Hour()) //nolint: gosmopolitan
 }
 
 func builtinDateGetUTCHours(call FunctionCall) Value {
@@ -295,7 +295,7 @@ func builtinDateGetMinutes(call FunctionCall) Value {
 	if date.isNaN {
 		return NaNValue()
 	}
-	return intValue(date.Time().Local().Minute())
+	return intValue(date.Time().Local().Minute()) //nolint: gosmopolitan
 }
 
 func builtinDateGetUTCMinutes(call FunctionCall) Value {
@@ -311,7 +311,7 @@ func builtinDateGetSeconds(call FunctionCall) Value {
 	if date.isNaN {
 		return NaNValue()
 	}
-	return intValue(date.Time().Local().Second())
+	return intValue(date.Time().Local().Second()) //nolint: gosmopolitan
 }
 
 func builtinDateGetUTCSeconds(call FunctionCall) Value {
@@ -327,7 +327,7 @@ func builtinDateGetMilliseconds(call FunctionCall) Value {
 	if date.isNaN {
 		return NaNValue()
 	}
-	return intValue(date.Time().Local().Nanosecond() / (100 * 100 * 100))
+	return intValue(date.Time().Local().Nanosecond() / (100 * 100 * 100)) //nolint: gosmopolitan
 }
 
 func builtinDateGetUTCMilliseconds(call FunctionCall) Value {
@@ -343,9 +343,9 @@ func builtinDateGetTimezoneOffset(call FunctionCall) Value {
 	if date.isNaN {
 		return NaNValue()
 	}
-	timeLocal := date.Time().Local()
+	timeLocal := date.Time().Local() //nolint: gosmopolitan
 	// Is this kosher?
-	timeLocalAsUTC := Time.Date(
+	timeLocalAsUTC := time.Date(
 		timeLocal.Year(),
 		timeLocal.Month(),
 		timeLocal.Day(),
@@ -353,7 +353,7 @@ func builtinDateGetTimezoneOffset(call FunctionCall) Value {
 		timeLocal.Minute(),
 		timeLocal.Second(),
 		timeLocal.Nanosecond(),
-		Time.UTC,
+		time.UTC,
 	)
 	return float64Value(date.Time().Sub(timeLocalAsUTC).Seconds() / 60)
 }

--- a/object_class.go
+++ b/object_class.go
@@ -203,12 +203,10 @@ func objectCanPutDetails(obj *object, name string) (canPut bool, prop *property,
 	if prop != nil {
 		switch propertyValue := prop.value.(type) {
 		case Value:
-			canPut = prop.writable()
-			return
+			return prop.writable(), prop, nil
 		case propertyGetSet:
 			setter = propertyValue[1]
-			canPut = setter != nil
-			return
+			return setter != nil, prop, setter
 		default:
 			panic(obj.runtime.panicTypeError("unexpected type %T to Object.CanPutDetails", prop.value))
 		}
@@ -231,8 +229,7 @@ func objectCanPutDetails(obj *object, name string) (canPut bool, prop *property,
 		return prop.writable(), nil, nil
 	case propertyGetSet:
 		setter = propertyValue[1]
-		canPut = setter != nil
-		return
+		return setter != nil, prop, setter
 	default:
 		panic(obj.runtime.panicTypeError("unexpected type %T to Object.CanPutDetails", prop.value))
 	}

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -143,23 +143,20 @@ func (p *parser) scan() (tkn token.Token, literal string, idx file.Idx) { //noli
 
 				switch tkn {
 				case 0: // Not a keyword
-					if literal == "true" || literal == "false" {
+					switch literal {
+					case "true", "false":
 						p.insertSemicolon = true
-						tkn = token.BOOLEAN
-						return
-					} else if literal == "null" {
+						return token.BOOLEAN, literal, idx
+					case "null":
 						p.insertSemicolon = true
-						tkn = token.NULL
-						return
+						return token.NULL, literal, idx
 					}
-
 				case token.KEYWORD:
-					tkn = token.KEYWORD
 					if strict {
 						// TODO If strict and in strict mode, then this is not a break
 						break
 					}
-					return
+					return token.KEYWORD, literal, idx
 
 				case
 					token.THIS,
@@ -169,19 +166,18 @@ func (p *parser) scan() (tkn token.Token, literal string, idx file.Idx) { //noli
 					token.CONTINUE,
 					token.DEBUGGER:
 					p.insertSemicolon = true
-					return
+					return tkn, literal, idx
 
 				default:
-					return
+					return tkn, literal, idx
 				}
 			}
 			p.insertSemicolon = true
-			tkn = token.IDENTIFIER
-			return
+			return token.IDENTIFIER, literal, idx
 		case '0' <= chr && chr <= '9':
 			p.insertSemicolon = true
 			tkn, literal = p.scanNumericLiteral(false)
-			return
+			return tkn, literal, idx
 		default:
 			p.read()
 			switch chr {
@@ -306,7 +302,7 @@ func (p *parser) scan() (tkn token.Token, literal string, idx file.Idx) { //noli
 			}
 		}
 		p.insertSemicolon = insertSemicolon
-		return
+		return tkn, literal, idx
 	}
 }
 

--- a/type_function.go
+++ b/type_function.go
@@ -162,7 +162,7 @@ func (o *object) isCall() bool {
 	}
 }
 
-func (o *object) call(this Value, argumentList []Value, eval bool, frm frame) Value {
+func (o *object) call(this Value, argumentList []Value, eval bool, frm frame) Value { //nolint: unparam // Isn't currently used except in recursive self.
 	switch fn := o.value.(type) {
 	case nativeFunctionObject:
 		// Since eval is a native function, we only have to check for it here


### PR DESCRIPTION
Fix lint failures introduced by new 1.53 linters
* Remove naked returns
* Accept times using local time where intended
* Allow unused parameter for now on call method
* Disable depguard which just seems to be noise

Also:
* Correct typo so we use the specified golangci-lint version in CI.
* Remove alias for time package in builtin_date.go