### PR TITLE
Fix Idx1 of ObjectLiteral and ArrayLiteral

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -36,7 +36,7 @@ func (al *ArrayLiteral) Idx0() file.Idx {
 
 // Idx1 implements Node.
 func (al *ArrayLiteral) Idx1() file.Idx {
-	return al.RightBracket
+	return al.RightBracket + 1
 }
 
 // expression implements Expression.

--- a/ast/node.go
+++ b/ast/node.go
@@ -343,7 +343,7 @@ func (ol *ObjectLiteral) Idx0() file.Idx {
 
 // Idx1 implements Node.
 func (ol *ObjectLiteral) Idx1() file.Idx {
-	return ol.RightBrace
+	return ol.RightBrace + 1
 }
 
 // expression implements Expression.

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1049,6 +1049,13 @@ func TestPosition(t *testing.T) {
 		node = program.Body[0].(*ast.ExpressionStatement).Expression.(*ast.AssignExpression).Right.(*ast.ObjectLiteral)
 		is(node.Idx0(), 5)
 		is(parser.slice(node.Idx0(), node.Idx1()), "{x: 1}")
+
+		parser = newParser("", "x = [1, 2]", 1, nil)
+		program, err = parser.parse()
+		is(err, nil)
+		node = program.Body[0].(*ast.ExpressionStatement).Expression.(*ast.AssignExpression).Right.(*ast.ArrayLiteral)
+		is(node.Idx0(), 5)
+		is(parser.slice(node.Idx0(), node.Idx1()), "[1, 2]")
 	})
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1042,6 +1042,13 @@ func TestPosition(t *testing.T) {
 		node = block.List[0].(*ast.ForInStatement)
 		is(node.Idx0(), 14)
 		is(parser.slice(node.Idx0(), node.Idx1()), "for (p in o) { console.log(p); }")
+
+		parser = newParser("", "x = {x: 1}", 1, nil)
+		program, err = parser.parse()
+		is(err, nil)
+		node = program.Body[0].(*ast.ExpressionStatement).Expression.(*ast.AssignExpression).Right.(*ast.ObjectLiteral)
+		is(node.Idx0(), 5)
+		is(parser.slice(node.Idx0(), node.Idx1()), "{x: 1}")
 	})
 }
 


### PR DESCRIPTION
Idx1 should point to the first character immediately after the node, rather than the last character of the node.