### PR TITLE
fix: positions of expressions

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -451,6 +451,9 @@ type UnaryExpression struct {
 
 // Idx0 implements Node.
 func (ue *UnaryExpression) Idx0() file.Idx {
+	if ue.Postfix {
+		return ue.Operand.Idx0()
+	}
 	return ue.Idx
 }
 

--- a/ast/node.go
+++ b/ast/node.go
@@ -483,7 +483,7 @@ func (ve *VariableExpression) Idx0() file.Idx {
 // Idx1 implements Node.
 func (ve *VariableExpression) Idx1() file.Idx {
 	if ve.Initializer == nil {
-		return file.Idx(int(ve.Idx) + len(ve.Name) + 1)
+		return file.Idx(int(ve.Idx) + len(ve.Name))
 	}
 	return ve.Initializer.Idx1()
 }

--- a/ast/node.go
+++ b/ast/node.go
@@ -397,7 +397,7 @@ func (se *SequenceExpression) Idx0() file.Idx {
 
 // Idx1 implements Node.
 func (se *SequenceExpression) Idx1() file.Idx {
-	return se.Sequence[0].Idx1()
+	return se.Sequence[len(se.Sequence)-1].Idx1()
 }
 
 // expression implements Expression.

--- a/ast/node.go
+++ b/ast/node.go
@@ -178,7 +178,7 @@ func (ce *ConditionalExpression) Idx0() file.Idx {
 
 // Idx1 implements Node.
 func (ce *ConditionalExpression) Idx1() file.Idx {
-	return ce.Test.Idx1()
+	return ce.Alternate.Idx1()
 }
 
 // expression implements Expression.

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -884,7 +884,7 @@ func (p *parser) parseLogicalOrExpression() ast.Expression {
 	return left
 }
 
-func (p *parser) parseConditionlExpression() ast.Expression {
+func (p *parser) parseConditionalExpression() ast.Expression {
 	left := p.parseLogicalOrExpression()
 
 	if p.token == token.QUESTION_MARK {
@@ -911,7 +911,7 @@ func (p *parser) parseConditionlExpression() ast.Expression {
 }
 
 func (p *parser) parseAssignmentExpression() ast.Expression {
-	left := p.parseConditionlExpression()
+	left := p.parseConditionalExpression()
 	var operator token.Token
 	switch p.token {
 	case token.ASSIGN:

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1071,6 +1071,21 @@ func TestPosition(t *testing.T) {
 		node = block.List[0].(*ast.ExpressionStatement).Expression.(*ast.SequenceExpression)
 		is(node.Idx0(), 14)
 		is(parser.slice(node.Idx0(), node.Idx1()), "x = 1, y = 2")
+
+		parser = newParser("", "x = ~x", 1, nil)
+		program, err = parser.parse()
+		is(err, nil)
+		node = program.Body[0].(*ast.ExpressionStatement).Expression.(*ast.AssignExpression).Right.(*ast.UnaryExpression)
+		is(node.Idx0(), 5)
+		is(parser.slice(node.Idx0(), node.Idx1()), "~x")
+
+		parser = newParser("", "(function(){ xyz++; })", 1, nil)
+		program, err = parser.parse()
+		is(err, nil)
+		block = program.Body[0].(*ast.ExpressionStatement).Expression.(*ast.FunctionLiteral).Body.(*ast.BlockStatement)
+		node = block.List[0].(*ast.ExpressionStatement).Expression.(*ast.UnaryExpression)
+		is(node.Idx0(), 14)
+		is(parser.slice(node.Idx0(), node.Idx1()), "xyz++")
 	})
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1063,6 +1063,14 @@ func TestPosition(t *testing.T) {
 		node = program.Body[0].(*ast.ExpressionStatement).Expression.(*ast.AssignExpression).Right.(*ast.ConditionalExpression)
 		is(node.Idx0(), 5)
 		is(parser.slice(node.Idx0(), node.Idx1()), "true ? 1 : 2")
+
+		parser = newParser("", "(function(){ x = 1, y = 2; })", 1, nil)
+		program, err = parser.parse()
+		is(err, nil)
+		block = program.Body[0].(*ast.ExpressionStatement).Expression.(*ast.FunctionLiteral).Body.(*ast.BlockStatement)
+		node = block.List[0].(*ast.ExpressionStatement).Expression.(*ast.SequenceExpression)
+		is(node.Idx0(), 14)
+		is(parser.slice(node.Idx0(), node.Idx1()), "x = 1, y = 2")
 	})
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1056,6 +1056,13 @@ func TestPosition(t *testing.T) {
 		node = program.Body[0].(*ast.ExpressionStatement).Expression.(*ast.AssignExpression).Right.(*ast.ArrayLiteral)
 		is(node.Idx0(), 5)
 		is(parser.slice(node.Idx0(), node.Idx1()), "[1, 2]")
+
+		parser = newParser("", "x = true ? 1 : 2", 1, nil)
+		program, err = parser.parse()
+		is(err, nil)
+		node = program.Body[0].(*ast.ExpressionStatement).Expression.(*ast.AssignExpression).Right.(*ast.ConditionalExpression)
+		is(node.Idx0(), 5)
+		is(parser.slice(node.Idx0(), node.Idx1()), "true ? 1 : 2")
 	})
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1086,6 +1086,20 @@ func TestPosition(t *testing.T) {
 		node = block.List[0].(*ast.ExpressionStatement).Expression.(*ast.UnaryExpression)
 		is(node.Idx0(), 14)
 		is(parser.slice(node.Idx0(), node.Idx1()), "xyz++")
+
+		parser = newParser("", "(function(){ var abc, xyz = 1; })", 1, nil)
+		program, err = parser.parse()
+		is(err, nil)
+		block = program.Body[0].(*ast.ExpressionStatement).Expression.(*ast.FunctionLiteral).Body.(*ast.BlockStatement)
+		node = block.List[0].(*ast.VariableStatement)
+		is(node.Idx0(), 14)
+		is(parser.slice(node.Idx0(), node.Idx1()), "var abc, xyz = 1")
+		node = block.List[0].(*ast.VariableStatement).List[0].(*ast.VariableExpression)
+		is(node.Idx0(), 18)
+		is(parser.slice(node.Idx0(), node.Idx1()), "abc")
+		node = block.List[0].(*ast.VariableStatement).List[1].(*ast.VariableExpression)
+		is(node.Idx0(), 23)
+		is(parser.slice(node.Idx0(), node.Idx1()), "xyz = 1")
 	})
 }
 


### PR DESCRIPTION
* Fix typo in `parseConditionlExpression`
* Fix Idx1 of ConditionalExpression to point to Alternate.Idx1()
* Fix Idx1 of SequenceExpression to point to Idx1 of the last Sequence element
* Fix Idx0 of UnaryExpression to point to the beginning of Operand in case of postfix operator
* Fix Idx1 of VariableExpression to point to the character immediately after Name if it does not have Initializer