### PR TITLE
Support trailing comma after the last argument.

### DIFF
--- a/parser/expression.go
+++ b/parser/expression.go
@@ -384,21 +384,19 @@ func (p *parser) parseArgumentList() (argumentList []ast.Expression, idx0, idx1 
 		p.comments.Unset()
 	}
 	idx0 = p.expect(token.LEFT_PARENTHESIS)
-	if p.token != token.RIGHT_PARENTHESIS {
-		for {
-			exp := p.parseAssignmentExpression()
-			if p.mode&StoreComments != 0 {
-				p.comments.SetExpression(exp)
-			}
-			argumentList = append(argumentList, exp)
-			if p.token != token.COMMA {
-				break
-			}
-			if p.mode&StoreComments != 0 {
-				p.comments.Unset()
-			}
-			p.next()
+	for p.token != token.RIGHT_PARENTHESIS {
+		exp := p.parseAssignmentExpression()
+		if p.mode&StoreComments != 0 {
+			p.comments.SetExpression(exp)
 		}
+		argumentList = append(argumentList, exp)
+		if p.token != token.COMMA {
+			break
+		}
+		if p.mode&StoreComments != 0 {
+			p.comments.Unset()
+		}
+		p.next()
 	}
 	if p.mode&StoreComments != 0 {
 		p.comments.Unset()

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -879,6 +879,15 @@ func TestParser(t *testing.T) {
                 2
             debugger
         `, nil)
+
+		test(`
+            function mergeObjects(x, y) { /* dummy body */}
+
+            mergeObjects(
+                { "duck": "quack" },
+                { "dog": "bark" }, // Allow trailing comma after the last argument.
+            );
+        `, nil)
 	})
 }
 


### PR DESCRIPTION
Example:

```js
function mergeObjects(x, y) { /* dummy body */}

mergeObjects(
    { "duck": "quack" },
    { "dog": "bark" }, // Allow trailing comma after the last argument.
);
```