### PR TITLE
fix: string slice and replace

### DIFF
--- a/string_test.go
+++ b/string_test.go
@@ -331,6 +331,7 @@ func TestString_slice_unicode(t *testing.T) {
 		test(`"uñiçode".slice(0,11)`, "uñiçode")
 		test(`"uñiçode".slice(0,-1)`, "uñiçod")
 		test(`"uñiçode".slice(-1,11)`, "e")
+		test(`"发送 213123".slice(0,2)`, "发送")
 	})
 }
 


### PR DESCRIPTION
Fix string slice and replace so they work correctly with utf8 characters.

Fixes #534