### PR TITLE
chore: update go and tools

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -11,16 +11,16 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.23
           cache: true
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v6
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -8,8 +8,8 @@ jobs:
   go-test-lint:
     strategy:
       matrix:
-        go: [1.21, 1.22]
-        golangcli: [v1.57.2]
+        go: [1.22, 1.23]
+        golangcli: [v1.61.0]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,9 @@ linters-settings:
     rules:
     - name: var-naming
       disabled: true
+  gosec:
+    excludes:
+      - G115 # Too many false positives.
 
 linters:
   enable-all: true
@@ -23,14 +26,13 @@ linters:
     - lll
     - gochecknoglobals
     - gochecknoinits
-    - scopelint
     - funlen
     - godox
-    - exhaustivestruct
-    - goerr113
+    - err113
     - wsl
     - nlreturn
     - gomnd
+    - mnd
     - paralleltest
     - wrapcheck
     - testpackage
@@ -44,20 +46,13 @@ linters:
     - maintidx
     - ireturn
     - exhaustruct
-    - nosnakecase
     - dupword
-    - structcheck
-    - deadcode
-    - golint
-    - varcheck
-    - ifshort
-    - interfacer
-    - maligned
     # Just causes noise
     - depguard
-    # Go 1.22+ only
-    - copyloopvar
-    - intrange
+    # Deprecated
+    - execinquery
+    # Not needed in go 1.22+
+    - exportloopref
 
 issues:
   exclude-use-default: false
@@ -73,4 +68,6 @@ issues:
     # Field alignment in tests isn't a performance issue.
     - text: fieldalignment
       path: _test\.go
+    - text: Error return value of `fmt\.Fprint.*` is not checked
+      path: tools/tester/main.go
 

--- a/builtin_array.go
+++ b/builtin_array.go
@@ -43,7 +43,7 @@ func builtinArrayToLocaleString(call FunctionCall) Value {
 		return stringValue("")
 	}
 	stringList := make([]string, 0, length)
-	for index := int64(0); index < length; index++ {
+	for index := range length {
 		value := thisObject.get(arrayIndexToString(index))
 		stringValue := ""
 		switch value.kind {
@@ -71,7 +71,7 @@ func builtinArrayConcat(call FunctionCall) Value {
 			obj := item.object()
 			if isArray(obj) {
 				length := obj.get(propertyLength).number().int64
-				for index := int64(0); index < length; index++ {
+				for index := range length {
 					name := strconv.FormatInt(index, 10)
 					if obj.hasProperty(name) {
 						valueArray = append(valueArray, obj.get(name))
@@ -151,7 +151,7 @@ func builtinArrayJoin(call FunctionCall) Value {
 		return stringValue("")
 	}
 	stringList := make([]string, 0, length)
-	for index := int64(0); index < length; index++ {
+	for index := range length {
 		value := thisObject.get(arrayIndexToString(index))
 		stringValue := ""
 		switch value.kind {
@@ -175,7 +175,7 @@ func builtinArraySplice(call FunctionCall) Value {
 	}
 	valueArray := make([]Value, deleteCount)
 
-	for index := int64(0); index < deleteCount; index++ {
+	for index := range deleteCount {
 		indexString := arrayIndexToString(start + index)
 		if thisObject.hasProperty(indexString) {
 			valueArray[index] = thisObject.get(indexString)
@@ -236,7 +236,7 @@ func builtinArraySplice(call FunctionCall) Value {
 		}
 	}
 
-	for index := int64(0); index < itemCount; index++ {
+	for index := range itemCount {
 		thisObject.put(arrayIndexToString(index+start), itemList[index], true)
 	}
 	thisObject.put(propertyLength, int64Value(length+itemCount-deleteCount), true)
@@ -257,7 +257,7 @@ func builtinArraySlice(call FunctionCall) Value {
 	sliceLength := end - start
 	sliceValueArray := make([]Value, sliceLength)
 
-	for index := int64(0); index < sliceLength; index++ {
+	for index := range sliceLength {
 		from := arrayIndexToString(index + start)
 		if thisObject.hasProperty(from) {
 			sliceValueArray[index] = thisObject.get(from)
@@ -283,7 +283,7 @@ func builtinArrayUnshift(call FunctionCall) Value {
 		}
 	}
 
-	for index := int64(0); index < itemCount; index++ {
+	for index := range itemCount {
 		thisObject.put(arrayIndexToString(index), itemList[index], true)
 	}
 
@@ -531,7 +531,7 @@ func builtinArrayEvery(call FunctionCall) Value {
 	if iterator := call.Argument(0); iterator.isCallable() {
 		length := int64(toUint32(thisObject.get(propertyLength)))
 		callThis := call.Argument(1)
-		for index := int64(0); index < length; index++ {
+		for index := range length {
 			if key := arrayIndexToString(index); thisObject.hasProperty(key) {
 				if value := thisObject.get(key); iterator.call(call.runtime, callThis, value, int64Value(index), this).bool() {
 					continue
@@ -550,7 +550,7 @@ func builtinArraySome(call FunctionCall) Value {
 	if iterator := call.Argument(0); iterator.isCallable() {
 		length := int64(toUint32(thisObject.get(propertyLength)))
 		callThis := call.Argument(1)
-		for index := int64(0); index < length; index++ {
+		for index := range length {
 			if key := arrayIndexToString(index); thisObject.hasProperty(key) {
 				if value := thisObject.get(key); iterator.call(call.runtime, callThis, value, int64Value(index), this).bool() {
 					return trueValue
@@ -568,7 +568,7 @@ func builtinArrayForEach(call FunctionCall) Value {
 	if iterator := call.Argument(0); iterator.isCallable() {
 		length := int64(toUint32(thisObject.get(propertyLength)))
 		callThis := call.Argument(1)
-		for index := int64(0); index < length; index++ {
+		for index := range length {
 			if key := arrayIndexToString(index); thisObject.hasProperty(key) {
 				iterator.call(call.runtime, callThis, thisObject.get(key), int64Value(index), this)
 			}
@@ -585,7 +585,7 @@ func builtinArrayMap(call FunctionCall) Value {
 		length := int64(toUint32(thisObject.get(propertyLength)))
 		callThis := call.Argument(1)
 		values := make([]Value, length)
-		for index := int64(0); index < length; index++ {
+		for index := range length {
 			if key := arrayIndexToString(index); thisObject.hasProperty(key) {
 				values[index] = iterator.call(call.runtime, callThis, thisObject.get(key), index, this)
 			} else {
@@ -604,7 +604,7 @@ func builtinArrayFilter(call FunctionCall) Value {
 		length := int64(toUint32(thisObject.get(propertyLength)))
 		callThis := call.Argument(1)
 		values := make([]Value, 0)
-		for index := int64(0); index < length; index++ {
+		for index := range length {
 			if key := arrayIndexToString(index); thisObject.hasProperty(key) {
 				value := thisObject.get(key)
 				if iterator.call(call.runtime, callThis, value, index, this).bool() {

--- a/builtin_date.go
+++ b/builtin_date.go
@@ -129,7 +129,7 @@ func builtinDateBeforeSet(call FunctionCall, argumentLimit int, timeLocal bool) 
 	}
 
 	valueList := make([]int, argumentLimit)
-	for index := 0; index < argumentLimit; index++ {
+	for index := range argumentLimit {
 		value := call.ArgumentList[index]
 		nm := value.number()
 		switch nm.kind {

--- a/builtin_function.go
+++ b/builtin_function.go
@@ -85,7 +85,7 @@ func builtinFunctionApply(call FunctionCall) Value {
 	thisObject := call.thisObject()
 	length := int64(toUint32(arrayObject.get(propertyLength)))
 	valueArray := make([]Value, length)
-	for index := int64(0); index < length; index++ {
+	for index := range length {
 		valueArray[index] = arrayObject.get(arrayIndexToString(index))
 	}
 	return thisObject.call(this, valueArray, false, nativeFrame)

--- a/builtin_json.go
+++ b/builtin_json.go
@@ -44,7 +44,7 @@ func builtinJSONReviveWalk(ctx builtinJSONParseContext, holder *object, name str
 	if obj := value.object(); obj != nil {
 		if isArray(obj) {
 			length := int64(objectLength(obj))
-			for index := int64(0); index < length; index++ {
+			for index := range length {
 				idxName := arrayIndexToString(index)
 				idxValue := builtinJSONReviveWalk(ctx, obj, idxName)
 				if idxValue.IsUndefined() {

--- a/builtin_string.go
+++ b/builtin_string.go
@@ -163,7 +163,7 @@ func builtinStringMatch(call FunctionCall) Value {
 	}
 	matchCount := len(result)
 	valueArray := make([]Value, matchCount)
-	for index := 0; index < matchCount; index++ {
+	for index := range matchCount {
 		valueArray[index] = stringValue(target[result[index][0]:result[index][1]])
 	}
 	matcher.put("lastIndex", intValue(result[matchCount-1][1]), true)
@@ -246,7 +246,7 @@ func builtinStringReplace(call FunctionCall) Value {
 			}
 			matchCount := len(match) / 2
 			argumentList := make([]Value, matchCount+2)
-			for index := 0; index < matchCount; index++ {
+			for index := range matchCount {
 				offset := 2 * index
 				if match[offset] != -1 {
 					argumentList[index] = stringValue(target[match[offset]:match[offset+1]])

--- a/console.go
+++ b/console.go
@@ -15,12 +15,12 @@ func formatForConsole(argumentList []Value) string {
 }
 
 func builtinConsoleLog(call FunctionCall) Value {
-	fmt.Fprintln(os.Stdout, formatForConsole(call.ArgumentList))
+	fmt.Fprintln(os.Stdout, formatForConsole(call.ArgumentList)) //nolint:errcheck // Nothing we can do if this fails.
 	return Value{}
 }
 
 func builtinConsoleError(call FunctionCall) Value {
-	fmt.Fprintln(os.Stdout, formatForConsole(call.ArgumentList))
+	fmt.Fprintln(os.Stdout, formatForConsole(call.ArgumentList)) //nolint:errcheck // Nothing we can do if this fails.
 	return Value{}
 }
 

--- a/error.go
+++ b/error.go
@@ -148,7 +148,7 @@ func newError(rt *runtime, name string, stackFramesToPop int, in ...interface{})
 	if rt != nil && rt.scope != nil {
 		curScope := rt.scope
 
-		for i := 0; i < stackFramesToPop; i++ {
+		for range stackFramesToPop {
 			if curScope.outer != nil {
 				curScope = curScope.outer
 			}

--- a/functional_benchmark_test.go
+++ b/functional_benchmark_test.go
@@ -123,7 +123,7 @@ func benchmarkGoSliceSort(b *testing.B, size int, sortFuncCall string, sortCode 
 	b.Helper()
 	// generate arbitrary slice of 'size'
 	testSlice := make([]int, size)
-	for i := 0; i < size; i++ {
+	for i := range size {
 		testSlice[i] = rand.Int() //nolint:gosec
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/robertkrimen/otto
 
-go 1.18
+go 1.22
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -114,7 +114,7 @@ func (p *parser) scanIdentifier() (string, error) {
 			}
 			parse = true
 			var value rune
-			for j := 0; j < 4; j++ {
+			for range 4 {
 				p.read()
 				decimal, ok := hex2decimal(byte(p.chr))
 				if !ok {
@@ -764,7 +764,7 @@ func parseStringLiteral(literal string) (string, error) {
 				if len(str) < size {
 					return "", fmt.Errorf("invalid escape: \\%s: len(%q) != %d", string(chr), str, size)
 				}
-				for j := 0; j < size; j++ {
+				for j := range size {
 					decimal, ok := hex2decimal(str[j])
 					if !ok {
 						return "", fmt.Errorf("invalid escape: \\%s: %q", string(chr), str[:size])

--- a/parser/marshal_test.go
+++ b/parser/marshal_test.go
@@ -24,7 +24,7 @@ func marshal(name string, children ...interface{}) interface{} {
 	}
 	ret := map[string]interface{}{}
 	length := len(children) / 2
-	for i := 0; i < length; i++ {
+	for i := range length {
 		name := children[i*2].(string)
 		value := children[i*2+1]
 		ret[name] = value
@@ -168,7 +168,7 @@ func testMarshalNode(node interface{}) interface{} {
 		value := reflect.ValueOf(node)
 		if value.Kind() == reflect.Slice {
 			tmp0 := []interface{}{}
-			for index := 0; index < value.Len(); index++ {
+			for index := range value.Len() {
 				tmp0 = append(tmp0, testMarshalNode(value.Index(index).Interface()))
 			}
 			return tmp0

--- a/runtime.go
+++ b/runtime.go
@@ -293,7 +293,7 @@ func fieldIndexByName(t reflect.Type, name string) []int {
 		t = t.Elem()
 	}
 
-	for i := 0; i < t.NumField(); i++ {
+	for i := range t.NumField() {
 		f := t.Field(i)
 
 		if !validGoStructName(f.Name) {
@@ -430,7 +430,7 @@ func (rt *runtime) convertCallParameter(v Value, t reflect.Type) (reflect.Value,
 
 				switch o.class {
 				case classArrayName:
-					for i := int64(0); i < l; i++ {
+					for i := range l {
 						p, ok := o.property[strconv.FormatInt(i, 10)]
 						if !ok {
 							continue
@@ -457,7 +457,7 @@ func (rt *runtime) convertCallParameter(v Value, t reflect.Type) (reflect.Value,
 						gslice = false
 					}
 
-					for i := int64(0); i < l; i++ {
+					for i := range l {
 						var p *property
 						if gslice {
 							p = goSliceGetOwnProperty(o, strconv.FormatInt(i, 10))
@@ -601,7 +601,7 @@ func (rt *runtime) convertCallParameter(v Value, t reflect.Type) (reflect.Value,
 	if v.kind == valueString {
 		var s encoding.TextUnmarshaler
 
-		if reflect.PtrTo(t).Implements(reflect.TypeOf(&s).Elem()) {
+		if reflect.PointerTo(t).Implements(reflect.TypeOf(&s).Elem()) {
 			r := reflect.New(t)
 
 			if err := r.Interface().(encoding.TextUnmarshaler).UnmarshalText([]byte(v.string())); err != nil {

--- a/tools/tester/main.go
+++ b/tools/tester/main.go
@@ -67,13 +67,6 @@ var broken = map[string]string{
 	"sendbird-calls.js": "runtime: out of memory",
 }
 
-func min(a, b int) int {
-	if a > b {
-		return b
-	}
-	return a
-}
-
 // libraries represents fetch all libraries response.
 type libraries struct {
 	Results []library `json:"results"`
@@ -203,7 +196,7 @@ func fetchAll(src string) error {
 	work := make(chan library, downloadWorkers)
 	errs := make(chan error, len(libs.Results))
 	wg.Add(downloadWorkers)
-	for i := 0; i < downloadWorkers; i++ {
+	for range downloadWorkers {
 		go func() {
 			defer wg.Done()
 			for lib := range work {
@@ -261,7 +254,7 @@ func report(files []string) error {
 	work := make(chan string, workers)
 	results := make(chan result, len(files))
 	wg.Add(workers)
-	for i := 0; i < workers; i++ {
+	for range workers {
 		go func() {
 			defer wg.Done()
 			for f := range work {

--- a/type_go_struct.go
+++ b/type_go_struct.go
@@ -97,7 +97,7 @@ func goStructEnumerate(obj *object, all bool, each func(string) bool) {
 	goObj := obj.value.(*goStructObject)
 
 	// Enumerate fields
-	for index := 0; index < reflect.Indirect(goObj.value).NumField(); index++ {
+	for index := range reflect.Indirect(goObj.value).NumField() {
 		name := reflect.Indirect(goObj.value).Type().Field(index).Name
 		if validGoStructName(name) {
 			if !each(name) {
@@ -107,7 +107,7 @@ func goStructEnumerate(obj *object, all bool, each func(string) bool) {
 	}
 
 	// Enumerate methods
-	for index := 0; index < goObj.value.NumMethod(); index++ {
+	for index := range goObj.value.NumMethod() {
 		name := goObj.value.Type().Method(index).Name
 		if validGoStructName(name) {
 			if !each(name) {

--- a/type_regexp.go
+++ b/type_regexp.go
@@ -124,7 +124,7 @@ func execRegExp(this *object, target string) (bool, []int) {
 func execResultToArray(rt *runtime, target string, result []int) *object {
 	captureCount := len(result) / 2
 	valueArray := make([]Value, captureCount)
-	for index := 0; index < captureCount; index++ {
+	for index := range captureCount {
 		offset := 2 * index
 		if result[offset] != -1 {
 			valueArray[index] = stringValue(target[result[offset]:result[offset+1]])

--- a/type_string.go
+++ b/type_string.go
@@ -50,7 +50,7 @@ func (str stringWide) String() string {
 }
 
 func newStringObject(str string) stringObjecter {
-	for i := 0; i < len(str); i++ {
+	for i := range len(str) {
 		if str[i] >= utf8.RuneSelf {
 			goto wide
 		}
@@ -91,7 +91,7 @@ func (o *object) stringValue() stringObjecter {
 func stringEnumerate(obj *object, all bool, each func(string) bool) {
 	if str := obj.stringValue(); str != nil {
 		length := str.Length()
-		for index := 0; index < length; index++ {
+		for index := range length {
 			if !each(strconv.FormatInt(int64(index), 10)) {
 				return
 			}

--- a/value.go
+++ b/value.go
@@ -647,7 +647,7 @@ func (v Value) export() interface{} {
 			elemKind := reflect.Invalid
 			state := 0
 			var t reflect.Type
-			for index := uint32(0); index < length; index++ {
+			for index := range length {
 				name := strconv.FormatInt(int64(index), 10)
 				if !obj.hasProperty(name) {
 					continue

--- a/value_test.go
+++ b/value_test.go
@@ -177,7 +177,7 @@ func Test_toInt32(t *testing.T) {
 			math.Inf(+1), int32(0),
 			math.Inf(-1), int32(0),
 		}
-		for index := 0; index < len(test)/2; index++ {
+		for index := range len(test) / 2 {
 			// FIXME terst, Make strict again?
 			is(
 				toInt32(toValue(test[index*2])),
@@ -199,7 +199,7 @@ func Test_toUint32(t *testing.T) {
 			math.Inf(+1), uint32(0),
 			math.Inf(-1), uint32(0),
 		}
-		for index := 0; index < len(test)/2; index++ {
+		for index := range len(test) / 2 {
 			// FIXME terst, Make strict again?
 			is(
 				toUint32(toValue(test[index*2])),
@@ -221,7 +221,7 @@ func Test_toUint16(t *testing.T) {
 			math.Inf(+1), uint16(0),
 			math.Inf(-1), uint16(0),
 		}
-		for index := 0; index < len(test)/2; index++ {
+		for index := range len(test) / 2 {
 			// FIXME terst, Make strict again?
 			is(
 				toUint16(toValue(test[index*2])),


### PR DESCRIPTION
Update to the oldest supported release of go v1.22 at this time.

Update golangci-lint to 1.61.0 and address all issues.

Update actions to the latest versions.